### PR TITLE
🐛 Fix substr check in CommandInterface.php

### DIFF
--- a/Model/Plugin/CommandInterface.php
+++ b/Model/Plugin/CommandInterface.php
@@ -48,7 +48,7 @@ class CommandInterface
         /** @var MethodInterface $methodInstance */
         $methodInstance = $payment->getMethodInstance();
         $paymentAction = $methodInstance->getConfigPaymentAction();
-        $paymentCode = substr($methodInstance->getCode(), 0, 13);
+        $paymentCode = substr($methodInstance->getCode(), 0, 18);
 
         if ($paymentCode == 'buckaroo_magento2_' && $paymentAction) {
             $this->updateOrderStateAndStatus($order, $methodInstance);


### PR DESCRIPTION
A college of mine found a bug in your module.

Since the namespace change from 'tig_buckaroo_' to 'buckaroo_magento2_' the substr should check for 18 characters not 13.