### PR TITLE
Add Magento_ReleaseNotification as sequence

### DIFF
--- a/etc/module.xml
+++ b/etc/module.xml
@@ -23,6 +23,7 @@
     <module name="Buckaroo_Magento2" setup_version="1.18.0" build_number="1767" stability="stable">
         <sequence>
             <module name="Magento_Payment"/>
+            <module name="Magento_ReleaseNotification"/>
         </sequence>
     </module>
 </config>


### PR DESCRIPTION
Module requires on Magento_ReleaseNotification to show release notes in the backend, without Magento_ReleaseNotification it will cause a js error in the dashboard.