### PR TITLE
Buckaroo (old) : Add check on empty shipping phone number

### DIFF
--- a/Model/Method/Afterpay.php
+++ b/Model/Method/Afterpay.php
@@ -1286,6 +1286,10 @@ class Afterpay extends AbstractMethod
 
         $birthDayStamp = str_replace('/', '-', $payment->getAdditionalInformation('customer_DoB'));
 
+        $shippingPhoneNumber = empty($shippingAddressTelephone) ?
+            $payment->getAdditionalInformation('customer_telephone') :
+            $shippingAddress->getTelephone();
+
         $shippingData = [
             [
                 '_'    => $shippingAddress->getFirstname(),
@@ -1328,7 +1332,7 @@ class Afterpay extends AbstractMethod
                 'Name' => 'ShippingEmail',
             ],
             [
-                '_'    => $shippingAddress->getTelephone(),
+                '_'    => $shippingPhoneNumber,
                 'Name' => 'ShippingPhoneNumber',
             ],
             [

--- a/Model/Method/Afterpay.php
+++ b/Model/Method/Afterpay.php
@@ -1286,9 +1286,11 @@ class Afterpay extends AbstractMethod
 
         $birthDayStamp = str_replace('/', '-', $payment->getAdditionalInformation('customer_DoB'));
 
+        $shippingAddressTelephone = $shippingAddress->getTelephone();
+
         $shippingPhoneNumber = empty($shippingAddressTelephone) ?
             $payment->getAdditionalInformation('customer_telephone') :
-            $shippingAddress->getTelephone();
+            $shippingAddressTelephone;
 
         $shippingData = [
             [


### PR DESCRIPTION
This commit fixes an issue where the extension assumes the shipping phone-number is never empty.
However there are cases, in which an empty shipping phone-number is saved.
In this case Buckaroo just copies the empty value, and adds is to to the SOAP request.
The SOAP request will then fail, because an empty value is sent for the shipping phone number.