### PR TITLE
Fix an error while setting a cookie with SameSite

### DIFF
--- a/Model/Plugin/FixSession.php
+++ b/Model/Plugin/FixSession.php
@@ -54,6 +54,7 @@ class FixSession
             //$this->logger->addDebug(__METHOD__ . '|1|' . var_export([$name, $value, $metadata->getSameSite()], true));
             if ($metadata->getSameSite() != 'None') {
                 $metadata->setSameSite('None');
+                $metadata->setSecure(true);
             }
         }
         return [$name, $value, $metadata];


### PR DESCRIPTION
When setting a samesite cookie behind an SSL offloading loadbalancer the secure flag does not get set automatically.
This raises an exception causing a 502 denial of service.

```
"0":"Cookie must be secure in order to use the SameSite None directive.","1":"#1 BuckarooMagento2ModelPluginFixSession->beforeSetPublicCookie() called at [vendor/magento/framework/Interception/Interceptor.php:121]
#2 MagentoFrameworkStdlibCookiePhpCookieManagerInterceptor->MagentoFrameworkInterception{closure}() called at [vendor/magento/framework/Interception/Interceptor.php:153]
#3 MagentoFrameworkStdlibCookiePhpCookieManagerInterceptor->___callPlugins() called at [generated/code/Magento/Framework/Stdlib/Cookie/PhpCookieManager/Interceptor.php:23]
#4 MagentoFrameworkStdlibCookiePhpCookieManagerInterceptor->setPublicCookie() called at [vendor/magento/framework/Session/SessionManager.php:247]
#5 MagentoFrameworkSessionSessionManager->renewCookie() called at [vendor/magento/framework/Session/SessionManager.php:212]
#6 MagentoFrameworkSessionSessionManager->start() called at [vendor/magento/framework/Interception/Interceptor.php:58]
#7 MagentoFrameworkSessionGenericInterceptor->___callParent() called at [vendor/magento/framework/Interception/Interceptor.php:138]
#8 MagentoFrameworkSessionGenericInterceptor->MagentoFrameworkInterception{closure}() called at [vendor/magento/framework/Interception/Interceptor.php:153]
#9 MagentoFrameworkSessionGenericInterceptor->___callPlugins() called at [generated/code/Magento/Framework/Session/Generic/Interceptor.php:23]
#10 MagentoFrameworkSessionGenericInterceptor->start() called at [vendor/magento/framework/Session/SessionManager.php:141]
#11 MagentoFrameworkSessionSessionManager->__construct() called at [generated/code/Magento/Framework/Session/Generic/Interceptor.php:14]
#12 MagentoFrameworkSessionGenericInterceptor->__construct() called at [vendor/magento/framework/ObjectManager/Factory/AbstractFactory.php:121]
#13 MagentoFrameworkObjectManagerFactoryAbstractFactory->createObject() called at [vendor/magento/framework/ObjectManager/Factory/Compiled.php:108]
#14 MagentoFrameworkObjectManagerFactoryCompiled->create() called at [vendor/magento/framework/ObjectManager/Factory/Compiled.php:150]
#15 MagentoFrameworkObjectManagerFactoryCompiled->get() called at [vendor/magento/framework/ObjectManager/Factory/Compiled.php:79]
#16 MagentoFrameworkObjectManagerFactoryCompiled->create() called at [vendor/magento/framework/ObjectManager/Factory/Compiled.php:150]
#17 MagentoFrameworkObjectManagerFactoryCompiled->get() called at [vendor/magento/framework/ObjectManager/Factory/Compiled.php:79]
#18 MagentoFrameworkObjectManagerFactoryCompiled->create() called at [vendor/magento/framework/ObjectManager/Factory/Compiled.php:150]
#19 MagentoFrameworkObjectManagerFactoryCompiled->get() called at [vendor/magento/framework/ObjectManager/Factory/Compiled.php:79]
#20 MagentoFrameworkObjectManagerFactoryCompiled->create() called at [vendor/magento/framework/ObjectManager/Factory/Compiled.php:150]
#21 MagentoFrameworkObjectManagerFactoryCompiled->get() called at [vendor/magento/framework/ObjectManager/Factory/Compiled.php:125]
#22 MagentoFrameworkObjectManagerFactoryCompiled->parseArray() called at [vendor/magento/framework/ObjectManager/Factory/Compiled.php:86]
#23 MagentoFrameworkObjectManagerFactoryCompiled->create() called at [vendor/magento/framework/ObjectManager/ObjectManager.php:70]
#24 MagentoFrameworkObjectManagerObjectManager->get() called at [vendor/magento/framework/App/FrontController.php:86]
#25 MagentoFrameworkAppFrontController->__construct() called at [generated/code/Magento/Framework/App/FrontController/Interceptor.php:14]
#26 MagentoFrameworkAppFrontControllerInterceptor->__construct() called at [vendor/magento/framework/ObjectManager/Factory/AbstractFactory.php:121]
#27 MagentoFrameworkObjectManagerFactoryAbstractFactory->createObject() called at [vendor/magento/framework/ObjectManager/Factory/Compiled.php:108]
#28 MagentoFrameworkObjectManagerFactoryCompiled->create() called at [vendor/magento/framework/ObjectManager/ObjectManager.php:70]
#29 MagentoFrameworkObjectManagerObjectManager->get() called at [vendor/magento/framework/App/Http.php:115]
#30 MagentoFrameworkAppHttp->launch() called at [vendor/magento/framework/App/Bootstrap.php:263]
#31 MagentoFrameworkAppBootstrap->run() called at [pub/index.php:40]
```