### PR TITLE
[BP-749] [BUGFIX] Added ScopeInterface to getting configuration values

### DIFF
--- a/Model/Method/Afterpay20.php
+++ b/Model/Method/Afterpay20.php
@@ -362,7 +362,7 @@ class Afterpay20 extends AbstractMethod
 
         // For the first invoice possible add payment fee
         if (is_array($articles) && $numberOfInvoices == 1) {
-            $includesTax = $this->_scopeConfig->getValue(static::TAX_CALCULATION_INCLUDES_TAX);
+            $includesTax = $this->_scopeConfig->getValue(static::TAX_CALCULATION_INCLUDES_TAX, \Magento\Store\Model\ScopeInterface::SCOPE_STORE);
             $serviceLine = $this->getServiceCostLine((count($articles)/5)+1, $currentInvoice, $includesTax);
             $articles = array_merge($articles, $serviceLine);
         }
@@ -700,7 +700,7 @@ class Afterpay20 extends AbstractMethod
     {
         $this->logger2->addDebug(__METHOD__.'|1|');
 
-        $includesTax = $this->_scopeConfig->getValue(static::TAX_CALCULATION_INCLUDES_TAX);
+        $includesTax = $this->_scopeConfig->getValue(static::TAX_CALCULATION_INCLUDES_TAX, \Magento\Store\Model\ScopeInterface::SCOPE_STORE);
 
         $quoteFactory = $this->objectManager->create('\Magento\Quote\Model\QuoteFactory');
         $quote = $quoteFactory->create()->load($payment->getOrder()->getQuoteId());
@@ -788,7 +788,7 @@ class Afterpay20 extends AbstractMethod
      */
     public function getInvoiceArticleData($invoice)
     {
-        $includesTax = $this->_scopeConfig->getValue(static::TAX_CALCULATION_INCLUDES_TAX);
+        $includesTax = $this->_scopeConfig->getValue(static::TAX_CALCULATION_INCLUDES_TAX, \Magento\Store\Model\ScopeInterface::SCOPE_STORE);
 
         // Set loop variables
         $articles = [];
@@ -856,7 +856,7 @@ class Afterpay20 extends AbstractMethod
     {
         /** @var \Magento\Sales\Model\Order\Creditmemo $creditmemo */
         $creditmemo = $payment->getCreditmemo();
-        $includesTax = $this->_scopeConfig->getValue(static::TAX_CALCULATION_INCLUDES_TAX);
+        $includesTax = $this->_scopeConfig->getValue(static::TAX_CALCULATION_INCLUDES_TAX, \Magento\Store\Model\ScopeInterface::SCOPE_STORE);
 
         $articles = [];
         $count = 1;
@@ -1016,7 +1016,7 @@ class Afterpay20 extends AbstractMethod
         $taxClassId = $this->taxConfig->getShippingTaxClass();
         $percent = $this->taxCalculation->getRate($request->setProductClassId($taxClassId));
 
-        $shippingIncludesTax = $this->_scopeConfig->getValue(static::TAX_CALCULATION_SHIPPING_INCLUDES_TAX);
+        $shippingIncludesTax = $this->_scopeConfig->getValue(static::TAX_CALCULATION_SHIPPING_INCLUDES_TAX, \Magento\Store\Model\ScopeInterface::SCOPE_STORE);
         $shippingAmount = $order->getShippingAmount();
 
         if ($shippingIncludesTax) {
@@ -1151,8 +1151,8 @@ class Afterpay20 extends AbstractMethod
     {
         $this->logger2->addDebug(__METHOD__.'|1|');
 
-        $catalogIncludesTax = $this->_scopeConfig->getValue(static::TAX_CALCULATION_INCLUDES_TAX);
-        $shippingIncludesTax = $this->_scopeConfig->getValue(static::TAX_CALCULATION_SHIPPING_INCLUDES_TAX);
+        $catalogIncludesTax = $this->_scopeConfig->getValue(static::TAX_CALCULATION_INCLUDES_TAX, \Magento\Store\Model\ScopeInterface::SCOPE_STORE);
+        $shippingIncludesTax = $this->_scopeConfig->getValue(static::TAX_CALCULATION_SHIPPING_INCLUDES_TAX, \Magento\Store\Model\ScopeInterface::SCOPE_STORE);
 
         $taxes = 0;
 


### PR DESCRIPTION
Hi Buckaroo,

Issue: when the global value of `tax/calculation/price_includes_tax` (and or `tax/calculation/shipping_includes_tax`) is different than the one on storeview level, Afterpay can give errors if there is a discount involved. This is due to the fact that the configuration value of these two was only retrieved on global value (it was missing ScopeInterface). By adding ScopeInterface::SCOPE_STORE, the value will be retrieved on the level of correct storeview.

How to reproduce:
-> Set Global value of `tax/calculation/price_includes_tax` and `tax/calculation/shipping_includes_tax` to 'Excluding Tax'
-> Set Storeview value of `tax/calculation/price_includes_tax` and `tax/calculation/shipping_includes_tax` to 'Including Tax`
-> Try to place an order with discount