### PR TITLE
Bug: - Interceptor in plugin param, does not work with override

### DIFF
--- a/Model/Plugin/PluginBefore.php
+++ b/Model/Plugin/PluginBefore.php
@@ -38,7 +38,7 @@ class PluginBefore
     }
 
     public function beforePushButtons(
-        \Magento\Backend\Block\Widget\Button\Toolbar\Interceptor $subject,
+        \Magento\Backend\Block\Widget\Button\Toolbar $subject,
         \Magento\Framework\View\Element\AbstractBlock $context,
         \Magento\Backend\Block\Widget\Button\ButtonList $buttonList
     ) {


### PR DESCRIPTION
Will otherwise give error:
PHP Fatal error: Uncaught TypeError: Argument 1 passed to Buckaroo\Magento2\Model\Plugin\PluginBefore::beforePushButtons() must be an instance of Magento\Backend\Block\Widget\Button\Toolbar\Interceptor, instance of Foo\Block\Adminhtml\Order\View\Button\Toolbar\Interceptor given

Foo\Toolbar does extend Magento\Toolbar.
But Foo\Toolbar\Interceptor does not extend Magento\Toolbar\Interceptor