### PR TITLE
Replace deprecated facebook/webdriver with php-webdriver

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     },
     "require-dev": {
         "satooshi/php-coveralls": "^1.0",
-        "facebook/webdriver": "^1.1"
+        "php-webdriver/webdriver": "^1.1"
     },
     "repositories": {
         "magento": {


### PR DESCRIPTION
`facebook/webdriver` has been deprecated and renamed to [php-webdriver/webdriver](https://packagist.org/packages/php-webdriver/webdriver), see https://github.com/php-webdriver/php-webdriver#upgrade-from-version-180

This is just drop-in replacement.