### PR TITLE
Move translation to where variable is defined. You can't translate va…

### DIFF
--- a/Model/ConfigProvider/Method/Creditcard.php
+++ b/Model/ConfigProvider/Method/Creditcard.php
@@ -153,9 +153,12 @@ class Creditcard extends AbstractConfigProvider
             self::XPATH_CREDITCARD_ALLOWED_CREDITCARDS,
             \Magento\Store\Model\ScopeInterface::SCOPE_STORE)
         );
-        
+
+        $cards = [];
         foreach ($allowed as $key => $value) {
-            $cards[] = $allCreditcard[$value];
+            if (isset($allCreditcard[$value])) {
+                $cards[] = $allCreditcard[$value];
+            }
         }
 
         usort($cards, function ($cardA, $cardB){

--- a/view/frontend/web/js/view/summary/totals.js
+++ b/view/frontend/web/js/view/summary/totals.js
@@ -25,8 +25,8 @@ define(
                 },
                 totals              : quote.getTotals(),
                 model               : {},
-                excludingTaxMessage : '(Excluding Tax)',
-                includingTaxMessage : '(Including Tax)',
+                excludingTaxMessage : $t('(Excluding Tax)'),
+                includingTaxMessage : $t('(Including Tax)'),
 
                 /**
                  * @override

--- a/view/frontend/web/template/cart/totals/buckaroo_fee.html
+++ b/view/frontend/web/template/cart/totals/buckaroo_fee.html
@@ -2,15 +2,15 @@
 <!-- ko if: displayBothPrices() -->
 <tr class="totals buckaroo_fee excl">
     <th class="mark">
-        <span data-bind="text: $t(getTitle()) + ' ' + $t(excludingTaxMessage)"></span>
+        <span data-bind="text: $t(getTitle()) + ' ' + excludingTaxMessage"></span>
     </th>
-    <td data-bind="text: getValue(), attr: {'data-th': $t(excludingTaxMessage)}" class="amount"></td>
+    <td data-bind="text: getValue(), attr: {'data-th': excludingTaxMessage}" class="amount"></td>
 </tr>
 <tr class="totals buckaroo_fee incl">
     <th class="mark">
-        <span data-bind="text: $t(getTitle()) + ' ' + $t(includingTaxMessage)"></span>
+        <span data-bind="text: $t(getTitle()) + ' ' + includingTaxMessage"></span>
     </th>
-    <td data-bind="text: getIncludingTaxValue(), attr: {'data-th': $t(includingTaxMessage)}" class="amount"></td>
+    <td data-bind="text: getIncludingTaxValue(), attr: {'data-th': includingTaxMessage}" class="amount"></td>
 </tr>
 <!-- /ko -->
 <!-- ko if: displayPriceInclTax() -->

--- a/view/frontend/web/template/summary/buckaroo_fee.html
+++ b/view/frontend/web/template/summary/buckaroo_fee.html
@@ -2,15 +2,15 @@
 <!-- ko if: displayBothPrices() -->
 <tr class="totals buckaroo_fee excl">
     <th class="mark">
-        <span data-bind="text: $t(getTitle()) + ' ' + $t(excludingTaxMessage)"></span>
+        <span data-bind="text: $t(getTitle()) + ' ' + excludingTaxMessage"></span>
     </th>
-    <td data-bind="text: getValue(), attr: {'data-th': $t(excludingTaxMessage)}" class="amount"></td>
+    <td data-bind="text: getValue(), attr: {'data-th': excludingTaxMessage}" class="amount"></td>
 </tr>
 <tr class="totals buckaroo_fee incl">
     <th class="mark">
-        <span data-bind="text: $t(getTitle()) + ' ' + $t(includingTaxMessage)"></span>
+        <span data-bind="text: $t(getTitle()) + ' ' + includingTaxMessage"></span>
     </th>
-    <td data-bind="text: getIncludingTaxValue(), attr: {'data-th': $t(includingTaxMessage)}" class="amount"></td>
+    <td data-bind="text: getIncludingTaxValue(), attr: {'data-th': includingTaxMessage}" class="amount"></td>
 </tr>
 <!-- /ko -->
 <!-- ko if: displayPriceInclTax() -->


### PR DESCRIPTION
You can't use variables inside `$t(...)`, Magento won't place the translations in the `js-translation.js` file.
See: https://devdocs.magento.com/guides/v2.4/frontend-dev-guide/translations/translate_theory.html
Magento uses a couple of regex to find translations that are used in javascript, see https://magento.stackexchange.com/a/322432. When you use a variable inside a `$t(...)` it can't find the value of the variable to translate.