### PR TITLE
[BP-1223] Buckaroo was sending an empty XML tag when trying to process a null tax percentage

### DIFF
--- a/Model/Method/Afterpay20.php
+++ b/Model/Method/Afterpay20.php
@@ -546,7 +546,7 @@ class Afterpay20 extends AbstractMethod
                 'Group' => 'Article',
             ],
             [
-                '_'       => $articleVat,
+                '_'       => $articleVat ?? 0,
                 'Name'    => 'VatPercentage',
                 'GroupID' => $latestKey,
                 'Group' => 'Article',


### PR DESCRIPTION
When trying to refund an order with zero tax percentage order line, Buckaroo it's building an empty XML tag which is causing an error.

This PR just fixes how Buckaroo treats this value, checking if it's null and placing a zero as value.