### PR TITLE
[JF-804] fix validation rules (Iphone Safari)

### DIFF
--- a/view/frontend/web/template/checkout/idinstep.html
+++ b/view/frontend/web/template/checkout/idinstep.html
@@ -10,10 +10,10 @@
          </div>
          <div class="buckaroo_idin_right">
             <form data-bind="submit: verificateIDIN" >
-                <select id="buckaroo_magento2_idin_issuer" class="field" 
+                <select id="buckaroo_magento2_idin_issuer" class="field"
+                        data-validate="{'required-entry':true}"
                         data-bind="value: idinIssuer,
-                                    event: { change: setSelectedBankDropDown },
-                                    attr: { 'data-validate': JSON.stringify({ 'required-entry': true }) }"
+                                    event: { change: setSelectedBankDropDown }"
                                     name="bank">
                     <option data-bind="i18n: 'Select a bank', 'value': ''"></option>
                     <!-- ko foreach: banktypes -->

--- a/view/frontend/web/template/payment/buckaroo_magento2_afterpay.html
+++ b/view/frontend/web/template/payment/buckaroo_magento2_afterpay.html
@@ -26,10 +26,10 @@
                             <ul id="Saluation">
                                 <li>
                                     <input type="radio" id="buckaroo_magento2_afterpay_genderSelectMan"
+                                           data-validate="{required:true}"
                                            data-bind="
                                            value: '1',
                                            click: setSelectedGender.bind($data, '1'),
-                                           attr: { 'data-validate': JSON.stringify({ 'required': true }) },
                                            checked: genderValidate
                                            "
                                            class="field"
@@ -38,10 +38,10 @@
                                 </li>
                                 <li>
                                     <input type="radio" id="buckaroo_magento2_afterpay_genderSelectWoman"
+                                           data-validate="{required:true}"
                                            data-bind="
                                            value: '2',
                                            click: setSelectedGender.bind($data, '2'),
-                                           attr: { 'data-validate': JSON.stringify({ 'required': true }) },
                                            checked: genderValidate
                                             "
                                            class="field"
@@ -76,10 +76,10 @@
                             <input id="buckaroo_magento2_afterpay_Telephone"
                                    type="text"
                                    class="input-text field"
+                                   data-validate="{required:true}"
                                    data-bind="
                                    valueUpdate: 'keyup',
                                    value: telephoneNumber,
-                                   attr: { 'data-validate': JSON.stringify({ 'required': true })}"
                                    name="payment[buckaroo_magento2_afterpay][customer_telephone]">
                         </div>
                     </div>
@@ -93,6 +93,7 @@
                             <input id="buckaroo_magento2_afterpay_DoB"
                                    class="field"
                                    type="text"
+                                   data-validate="{required:true, 'validate-date-au':true}"
                                    data-bind="
                                    datepicker: {
                                         storage: dateValidate,
@@ -105,8 +106,7 @@
                                    },
                                    event: { change: selectPaymentMethod },
                                    valueUpdate: 'change',
-                                   value: dateValidate,
-                                   attr: { 'data-validate': JSON.stringify({ 'required': true, 'validate-date-au': true })}"
+                                   value: dateValidate"
                                    name="payment[buckaroo_magento2_afterpay][customer_DoB]"
                                    aria-required="true" aria-invalid="true" aria-describedby="buckaroo_magento2_afterpay_DoB-error">
                             <div for="buckaroo_magento2_afterpay_DoB" class="mage-error" id="buckaroo_magento2_afterpay_DoB-error" style="display: none;"><span data-bind="i18n: 'You should be at least 18 years old.' "></span></div>
@@ -123,10 +123,10 @@
                             <input id="buckaroo_magento2_afterpay_IBAN"
                                    class="input-text field"
                                    type="text"
+                                   data-validate="{required:true, IBAN:true}"
                                    data-bind="
                                    value: bankaccountnumber,
-                                   valueUpdate: 'keyup',
-                                   attr: {'data-validate': JSON.stringify({ 'required': true, 'IBAN':true })}"
+                                   valueUpdate: 'keyup'"
                                    name="payment[buckaroo_magento2_afterpay][customer_iban]">
                         </div>
                     </div>
@@ -165,15 +165,10 @@
                                    name="payment[buckaroo_magento2_afterpay][COCNumber]"
                                    class="input-text field"
                                    type="text"
+                                   data-validate="{required:true, minlength:8}"
                                    data-bind="
                                        valueUpdate: 'keyup',
-                                       value: CocNumber,
-                                       attr: {
-                                            'data-validate': JSON.stringify({
-                                                'required': true,
-                                                'minlength': 8
-                                            }),
-                                        }">
+                                       value: CocNumber">
                         </div>
                     </div>
 
@@ -184,11 +179,10 @@
                                    name="payment[buckaroo_magento2_afterpay][CompanyName]"
                                    class="input-text field"
                                    type="text"
+                                   data-validate="{required:true, 'min-words':18}"
                                    data-bind="
                                        valueUpdate: 'keyup',
-                                       value: CompanyName,
-                                       attr: { 'data-validate': JSON.stringify({ 'required': true, 'min-words': 1 })
-                                        }">
+                                       value: CompanyName">
                         </div>
                     </div>
                     <!-- /ko -->
@@ -201,9 +195,9 @@
                             <input id="buckaroo_magento2_afterpay_TermsCondition"
                                    class="field"
                                    type="checkbox"
+                                   data-validate="{required:true}"
                                    data-bind="
-                                   checked: termsValidate,
-                                   attr: { 'data-validate': JSON.stringify({ 'required': true})}"
+                                   checked: termsValidate"
                                    name="payment[buckaroo_magento2_afterpay][termsCondition]">
                             <span>
                                 <a target="_blank"

--- a/view/frontend/web/template/payment/buckaroo_magento2_afterpay2.html
+++ b/view/frontend/web/template/payment/buckaroo_magento2_afterpay2.html
@@ -26,10 +26,10 @@
                             <ul id="Saluation">
                                 <li>
                                     <input type="radio" id="buckaroo_magento2_afterpay2_genderSelectMan"
+                                           data-validate="{required:true}"
                                            data-bind="
                                            value: '1',
                                            click: setSelectedGender.bind($data, '1'),
-                                           attr: { 'data-validate': JSON.stringify({ 'required': true }) },
                                            checked: genderValidate
                                            "
                                            class="field"
@@ -38,10 +38,10 @@
                                 </li>
                                 <li>
                                     <input type="radio" id="buckaroo_magento2_afterpay2_genderSelectWoman"
+                                           data-validate="{required:true}"
                                            data-bind="
                                            value: '2',
                                            click: setSelectedGender.bind($data, '2'),
-                                           attr: { 'data-validate': JSON.stringify({ 'required': true }) },
                                            checked: genderValidate
                                             "
                                            class="field"
@@ -76,10 +76,10 @@
                             <input id="buckaroo_magento2_afterpay2_Telephone"
                                    type="text"
                                    class="input-text field"
+                                   data-validate="{required:true}"
                                    data-bind="
                                    valueUpdate: 'keyup',
-                                   value: telephoneNumber,
-                                   attr: { 'data-validate': JSON.stringify({ 'required': true })}"
+                                   value: telephoneNumber"
                                    name="payment[buckaroo_magento2_afterpay2][customer_telephone]">
                         </div>
                     </div>
@@ -92,6 +92,7 @@
                             <input id="buckaroo_magento2_afterpay2_DoB"
                                    class="field"
                                    type="text"
+                                   data-validate="{required:true, 'validate-date-au':true}"
                                    data-bind="
                                    datepicker: {
                                         storage: dateValidate,
@@ -104,8 +105,7 @@
                                    },
                                    event: { change: selectPaymentMethod },
                                    valueUpdate: 'change',
-                                   value: dateValidate,
-                                   attr: { 'data-validate': JSON.stringify({ 'required': true, 'validate-date-au': true })}"
+                                   value: dateValidate"
                                    name="payment[buckaroo_magento2_afterpay2][customer_DoB]">
                             <div for="buckaroo_magento2_afterpay2_DoB" class="mage-error" id="buckaroo_magento2_afterpay2_DoB-error" style="display: none;"><span data-bind="i18n: 'You should be at least 18 years old.' "></span></div>
                         </div>
@@ -120,10 +120,10 @@
                             <input id="buckaroo_magento2_afterpay2_IBAN"
                                    class="input-text field"
                                    type="text"
+                                   data-validate="{required:true, IBAN:true}"
                                    data-bind="
                                    value: bankaccountnumber,
-                                   valueUpdate: 'keyup',
-                                   attr: {'data-validate': JSON.stringify({ 'required': true, 'IBAN':true })}"
+                                   valueUpdate: 'keyup'"
                                    name="payment[buckaroo_magento2_afterpay2][customer_iban]">
                         </div>
                     </div>
@@ -162,15 +162,10 @@
                                    name="payment[buckaroo_magento2_afterpay2][COCNumber]"
                                    class="input-text field"
                                    type="text"
+                                   data-validate="{required:true, minlength:8}"
                                    data-bind="
                                        valueUpdate: 'keyup',
-                                       value: CocNumber,
-                                       attr: {
-                                            'data-validate': JSON.stringify({
-                                                'required': true,
-                                                'minlength': 8
-                                            }),
-                                        }">
+                                       value: CocNumber">
                         </div>
                     </div>
 
@@ -181,11 +176,10 @@
                                    name="payment[buckaroo_magento2_afterpay2][CompanyName]"
                                    class="input-text field"
                                    type="text"
+                                   data-validate="{required:true, 'min-words':1}"
                                    data-bind="
                                        valueUpdate: 'keyup',
-                                       value: CompanyName,
-                                       attr: { 'data-validate': JSON.stringify({ 'required': true, 'min-words': 1 })
-                                        }">
+                                       value: CompanyName">
                         </div>
                     </div>
                     <!-- /ko -->
@@ -198,9 +192,9 @@
                             <input id="buckaroo_magento2_afterpay2_TermsCondition"
                                    class="field"
                                    type="checkbox"
+                                   data-validate="{required:true}"
                                    data-bind="
-                                   checked: termsValidate,
-                                   attr: { 'data-validate': JSON.stringify({ 'required': true})}"
+                                   checked: termsValidate"
                                    name="payment[buckaroo_magento2_afterpay2][termsCondition]">
                             <span>
                                 <a target="_blank"

--- a/view/frontend/web/template/payment/buckaroo_magento2_afterpay20.html
+++ b/view/frontend/web/template/payment/buckaroo_magento2_afterpay20.html
@@ -27,11 +27,11 @@
                             <ul id="Saluation">
                                 <li>
                                     <input type="radio" id="buckaroo_magento2_afterpay20_genderSelectMan"
+                                           data-validate="{required:true}"
                                            data-bind="
                                            value: '1',
                                            event: { change: selectPaymentMethod },
                                            click: setSelectedGender.bind($data, '1'),
-                                           attr: { 'data-validate': JSON.stringify({ 'required': true }) },
                                            checked: genderValidate
                                            "
                                            class="field"
@@ -40,10 +40,10 @@
                                 </li>
                                 <li>
                                     <input type="radio" id="buckaroo_magento2_afterpay20_genderSelectWoman"
+                                           data-validate="{required:true}"
                                            data-bind="
                                            value: '2',
                                            click: setSelectedGender.bind($data, '2'),
-                                           attr: { 'data-validate': JSON.stringify({ 'required': true }) },
                                            checked: genderValidate
                                             "
                                            class="field"
@@ -64,8 +64,8 @@
                                    class="input-text field"
                                    type="text"
                                    name="payment[buckaroo_magento2_afterpay20][buckaroo_identification_number]"
+                                   data-validate="{required:true}"
                                    data-bind="
-                                   attr: { 'data-validate': JSON.stringify({ 'required': true }) },
                                    checked: identificationValidate
                                    valueUpdate: 'blur',
                                    value: identificationValidate
@@ -95,8 +95,8 @@
                             <input id="buckaroo_magento2_afterpay20_Telephone"
                                    type="text"
                                    class="input-text field"
+                                   data-validate="{phoneValidation: true, required:true}"
                                    data-bind="
-                                   attr: { 'data-validate': JSON.stringify({ 'phoneValidation': true, 'required': true }) },
                                    checked: phoneValidate,
                                    valueUpdate: 'blur',
                                    value: phoneValidate"
@@ -113,6 +113,7 @@
                             <input id="buckaroo_magento2_afterpay20_DoB"
                                    class="field"
                                    type="text"
+                                   data-validate="{required:true, 'validate-date-au':true}"
                                    data-bind="
                                    datepicker: {
                                         storage: dateValidate,
@@ -125,8 +126,7 @@
                                    },
                                    event: { change: selectPaymentMethod },
                                    valueUpdate: 'change',
-                                   value: dateValidate,
-                                   attr: { 'data-validate': JSON.stringify({ 'required': true, 'validate-date-au': true })}"
+                                   value: dateValidate"
                                    name="payment[buckaroo_magento2_afterpay20][customer_DoB]">
                             <div for="buckaroo_magento2_afterpay20_DoB" generated="true" class="mage-error" id="buckaroo_magento2_afterpay20_DoB-error" style="display: none;"><span data-bind="i18n: 'You should be at least 18 years old.' "></span></div>
                         </div>
@@ -140,10 +140,10 @@
                             <input id="buckaroo_magento2_afterpay20_TermsCondition"
                                    class="field"
                                    type="checkbox"
+                                   data-validate="{required:true}"
                                    data-bind="
                                    checked: termsValidate,
-                                   event: { change: selectPaymentMethod },
-                                   attr: { 'data-validate': JSON.stringify({ 'required': true})}"
+                                   event: { change: selectPaymentMethod }"
                                    name="payment[buckaroo_magento2_afterpay20][termsCondition]">
                             <span>
                                 <a target="_blank"

--- a/view/frontend/web/template/payment/buckaroo_magento2_billink.html
+++ b/view/frontend/web/template/payment/buckaroo_magento2_billink.html
@@ -27,11 +27,11 @@
                             <ul id="Saluation">
                                 <li>
                                     <input type="radio" id="buckaroo_magento2_billink_genderSelectMan"
+                                           data-validate="{required:true}"
                                            data-bind="
                                            value: '1',
                                            event: { change: selectPaymentMethod },
                                            click: setSelectedGender.bind($data, '1'),
-                                           attr: { 'data-validate': JSON.stringify({ 'required': true }) },
                                            checked: genderValidate
                                            "
                                            class="field"
@@ -40,10 +40,10 @@
                                 </li>
                                 <li>
                                     <input type="radio" id="buckaroo_magento2_billink_genderSelectWoman"
+                                           data-validate="{required:true}"
                                            data-bind="
                                            value: '2',
                                            click: setSelectedGender.bind($data, '2'),
-                                           attr: { 'data-validate': JSON.stringify({ 'required': true }) },
                                            checked: genderValidate
                                             "
                                            class="field"
@@ -77,8 +77,8 @@
                             <input id="buckaroo_magento2_billink_Telephone"
                                    type="text"
                                    class="input-text field"
+                                   data-validate="{required:true}"
                                    data-bind="
-                                   attr: { 'data-validate': JSON.stringify({ 'required': true }) },
                                    checked: phoneValidate
                                    valueUpdate: 'blur',
                                    value: phoneValidate"
@@ -98,6 +98,7 @@
                             <input id="buckaroo_magento2_billink_DoB"
                                    class="field"
                                    type="text"
+                                   data-validate="{required:true, 'validate-date-au':true}"
                                    data-bind="
                                    datepicker: {
                                         storage: dateValidate,
@@ -110,8 +111,7 @@
                                    },
                                    event: { change: selectPaymentMethod },
                                    valueUpdate: 'change',
-                                   value: dateValidate,
-                                   attr: { 'data-validate': JSON.stringify({ 'required': true, 'validate-date-au': true })}"
+                                   value: dateValidate"
                                    name="payment[buckaroo_magento2_billink][customer_DoB]">
                             <div for="buckaroo_magento2_billink_DoB" generated="true" class="mage-error" id="buckaroo_magento2_billink_DoB-error" style="display: none;"><span data-bind="i18n: 'You should be at least 18 years old.' "></span></div>
                         </div>
@@ -126,8 +126,8 @@
                                    class="input-text field"
                                    type="text"
                                    name="payment[buckaroo_magento2_billink][buckaroo_chamberOfCommerce]"
-                                   data-bind="
-                                   attr: { 'data-validate': JSON.stringify({ 'required': true }) },
+                                   data-validate="{required:true}"
+                                   data-bind=",
                                    checked: chamberOfCommerceValidate
                                    valueUpdate: 'blur',
                                    value: chamberOfCommerceValidate
@@ -144,8 +144,8 @@
                                    class="input-text field"
                                    type="text"
                                    name="payment[buckaroo_magento2_billink][buckaroo_VATNumber]"
+                                   data-validate="{required:false}"
                                    data-bind="
-                                   attr: { 'data-validate': JSON.stringify({ 'required': false }) },
                                    valueUpdate: 'blur',
                                    value: VATNumberValidate
                                    ">
@@ -160,10 +160,10 @@
                             <input id="buckaroo_magento2_billink_TermsCondition"
                                    class="field"
                                    type="checkbox"
+                                   data-validate="{required:true}"
                                    data-bind="
                                    checked: termsValidate,
-                                   event: { change: selectPaymentMethod },
-                                   attr: { 'data-validate': JSON.stringify({ 'required': true})}"
+                                   event: { change: selectPaymentMethod }"
                                    name="payment[buckaroo_magento2_billink][termsCondition]">
                             <span>
                                 <a target="_blank"

--- a/view/frontend/web/template/payment/buckaroo_magento2_capayablein3.html
+++ b/view/frontend/web/template/payment/buckaroo_magento2_capayablein3.html
@@ -44,10 +44,10 @@
                             <ul id="Saluation">
                                 <li>
                                     <input type="radio" id="buckaroo_magento2_capayablein3_genderSelectMan"
+                                           data-validate="{required:true}"
                                            data-bind="
                                                    value: '1',
                                                    click: setSelectedGender.bind($data, '1'),
-                                                   attr: { 'data-validate': JSON.stringify({ 'required': true }) },
                                                    checked: genderValidate
                                                    "
                                            class="field"
@@ -56,10 +56,10 @@
                                 </li>
                                 <li>
                                     <input type="radio" id="buckaroo_magento2_capayablein3_genderSelectWoman"
+                                           data-validate="{required:true}"
                                            data-bind="
                                                    value: '2',
                                                    click: setSelectedGender.bind($data, '2'),
-                                                   attr: { 'data-validate': JSON.stringify({ 'required': true }) },
                                                    checked: genderValidate
                                                     "
                                            class="field"
@@ -92,6 +92,7 @@
                             <input id="buckaroo_magento2_capayablein3_DoB"
                                    class="field"
                                    type="text"
+                                   data-validate="{required:true}"
                                    data-bind="
                                            datepicker: {
                                                 storage: dateValidate,
@@ -103,8 +104,7 @@
                                                 }
                                            },
                                            valueUpdate: 'blur',
-                                           value: dateValidate,
-                                           attr: { 'data-validate': JSON.stringify({ 'required': true })}"
+                                           value: dateValidate"
                                    name="payment[buckaroo_magento2_capayablein3][customer_DoB]">
                         </div>
                         <div for="buckaroo_magento2_capayablein3_DoB" generated="true" class="mage-error" id="dob-error" style="display: none;"><span data-bind="i18n: 'This is a required field.'"></span> </div>
@@ -131,10 +131,10 @@
                                    name="payment[buckaroo_magento2_capayablein3][COCNumber]"
                                    class="input-text field"
                                    type="text"
+                                   data-validate="{required:true, minlength:8}"
                                    data-bind="
                                        valueUpdate: 'keyup',
-                                       value: CocNumber,
-                                       attr: { 'data-validate': JSON.stringify({'required': true, 'minlength': 8}) }">
+                                       value: CocNumber">
                         </div>
                     </div>
 
@@ -145,10 +145,10 @@
                                    name="payment[buckaroo_magento2_capayablein3][CompanyName]"
                                    class="input-text field"
                                    type="text"
+                                   data-validate="{required:true, 'min-words':1}"
                                    data-bind="
                                        valueUpdate: 'keyup',
-                                       value: CompanyName,
-                                       attr: { 'data-validate': JSON.stringify({'required': true, 'min-words': 1 })}">
+                                       value: CompanyName">
                         </div>
                     </div>
                     <!-- /ko -->

--- a/view/frontend/web/template/payment/buckaroo_magento2_capayablepostpay.html
+++ b/view/frontend/web/template/payment/buckaroo_magento2_capayablepostpay.html
@@ -44,10 +44,10 @@
                             <ul id="Saluation">
                                 <li>
                                     <input type="radio" id="buckaroo_magento2_capayablepostpay_genderSelectMan"
+                                           data-validate="{required:true}"
                                            data-bind="
                                                    value: '1',
                                                    click: setSelectedGender.bind($data, '1'),
-                                                   attr: { 'data-validate': JSON.stringify({ 'required': true }) },
                                                    checked: genderValidate
                                                    "
                                            class="field"
@@ -56,10 +56,10 @@
                                 </li>
                                 <li>
                                     <input type="radio" id="buckaroo_magento2_capayablepostpay_genderSelectWoman"
+                                           data-validate="{required:true}"
                                            data-bind="
                                                    value: '2',
                                                    click: setSelectedGender.bind($data, '2'),
-                                                   attr: { 'data-validate': JSON.stringify({ 'required': true }) },
                                                    checked: genderValidate
                                                     "
                                            class="field"
@@ -92,6 +92,7 @@
                             <input id="buckaroo_magento2_capayablepostpay_DoB"
                                    class="field"
                                    type="text"
+                                   data-validate="{required:true}"
                                    data-bind="
                                            datepicker: {
                                                 storage: dateValidate,
@@ -103,8 +104,7 @@
                                                 }
                                            },
                                            valueUpdate: 'blur',
-                                           value: dateValidate,
-                                           attr: { 'data-validate': JSON.stringify({ 'required': true })}"
+                                           value: dateValidate"
                                    name="payment[buckaroo_magento2_capayablepostpay][customer_DoB]">
                         </div>
                         <div for="buckaroo_magento2_capayablepostpay_DoB" generated="true" class="mage-error" id="dob-error" style="display: none;"><span data-bind="i18n: 'This is a required field.'"></span> </div>
@@ -131,10 +131,10 @@
                                    name="payment[buckaroo_magento2_capayablepostpay][COCNumber]"
                                    class="input-text field"
                                    type="text"
+                                   data-validate="{required:true, minlength:8}"
                                    data-bind="
                                        valueUpdate: 'keyup',
-                                       value: CocNumber,
-                                       attr: { 'data-validate': JSON.stringify({'required': true, 'minlength': 8}) }">
+                                       value: CocNumber">
                         </div>
                     </div>
 
@@ -145,10 +145,10 @@
                                    name="payment[buckaroo_magento2_capayablepostpay][CompanyName]"
                                    class="input-text field"
                                    type="text"
+                                   data-validate="{required:true, 'min-words':1}"
                                    data-bind="
                                        valueUpdate: 'keyup',
-                                       value: CompanyName,
-                                       attr: { 'data-validate': JSON.stringify({'required': true, 'min-words': 1 })}">
+                                       value: CompanyName">
                         </div>
                     </div>
                     <!-- /ko -->

--- a/view/frontend/web/template/payment/buckaroo_magento2_creditcard.html
+++ b/view/frontend/web/template/payment/buckaroo_magento2_creditcard.html
@@ -39,9 +39,9 @@
 
                         <!-- ko if: selectionType == '2' -->
                             <select id="buckaroo_magento2_creditcard_issuer" class="field"
+                                    data-validate="{'required-entry':true}"
                                     data-bind="value: creditcardIssuer,
-                                    event: { change: setSelectedBankDropDown },
-                                    attr: { 'data-validate': JSON.stringify({ 'required-entry': true }) }"
+                                    event: { change: setSelectedBankDropDown }"
                                     name="card">
                                 <option data-bind="i18n: 'Select a Credit Card or Debit Card', 'value': ''"></option>
                                 <!-- ko foreach: creditcards -->

--- a/view/frontend/web/template/payment/buckaroo_magento2_creditcards.html
+++ b/view/frontend/web/template/payment/buckaroo_magento2_creditcards.html
@@ -31,9 +31,9 @@
                         </div>
 
                         <select id="buckaroo_magento2_creditcards_issuer" class="field" style="display: none;"
+                                data-validate="{'required-entry':true}"
                                 data-bind="value: CardIssuer,
-                                event: { change: validateIssuer },
-                                attr: { 'data-validate': JSON.stringify({ 'required-entry': true }) }"
+                                event: { change: validateIssuer }"
                                 name="payment[buckaroo_magento2_creditcards][issuer]">
                             <option data-bind="i18n: 'Select a card', 'value': ''"></option>
                             <!-- ko foreach: creditcards -->
@@ -50,11 +50,11 @@
                                        type="text"
                                        class="input-text field"
                                        name="payment[buckaroo_magento2_creditcards][cardholdername]"
+                                       data-validate="{required:true, validateCardHolderName:true}"
                                        data-bind="
                             valueUpdate: 'blur',
                             value: CardHolderName,
                             textInput: CardHolderName(),
-                            attr: { 'data-validate': JSON.stringify({ 'required': true, 'validateCardHolderName': true }) },
                             event: { blur: encryptCardDetails }">
                             </div>
                         </div>
@@ -66,11 +66,11 @@
                                        type="text"
                                        class="input-text field"
                                        name="payment[buckaroo_magento2_creditcards][cardnumber]"
+                                       data-validate="{required:true, validateCardNumber:true}"
                                        data-bind="
                             valueUpdate: 'blur',
                             value: CardNumber,
                             textInput: CardNumber(),
-                            attr: { 'data-validate': JSON.stringify({ 'required': true, 'validateCardNumber': true }) },
                             event: { blur: encryptCardDetails, change: processCard }">
                             </div>
                         </div>
@@ -79,8 +79,8 @@
                             <label class="label" for="buckaroo_magento2_creditcards_expirationmonth"><span data-bind="i18n: 'Month:'"></span></label>
                             <div class="control">
                                 <select id="buckaroo_magento2_creditcards_expirationmonth" class="field"
+                                        data-validate="{'required-entry':true}"
                                         data-bind="value: ExpirationMonth,
-                                        attr: { 'data-validate': JSON.stringify({ 'required-entry': true }) },
                                         event: { change: validateMonth }"
                                         name="payment[buckaroo_magento2_creditcards][expirationmonth]">
                                     <!-- ko foreach: months -->
@@ -94,8 +94,8 @@
                             <label class="label" for="buckaroo_magento2_creditcards_expirationyear"><span data-bind="i18n: 'Year:'"></span></label>
                             <div class="control">
                                 <select id="buckaroo_magento2_creditcards_expirationyear" class="field"
+                                        data-validate="{'required-entry':true}"
                                         data-bind="value: ExpirationYear,
-                                                   attr: { 'data-validate': JSON.stringify({ 'required-entry': true }) },
                                                    event: { change: validateYear },
                                                    foreach: getYears()"
                                         name="payment[buckaroo_magento2_creditcards][expirationyear]">
@@ -116,11 +116,11 @@
                                        type="text"
                                        class="input-text field"
                                        name="payment[buckaroo_magento2_creditcards][cvc]"
+                                       data-validate="{required:true, validateCvc:true}"
                                        data-bind="
                             valueUpdate: 'blur',
                             value: Cvc,
                             textInput: Cvc(),
-                            attr: { 'data-validate': JSON.stringify({ 'required': true, 'validateCvc': true }) },
                             event: { blur: encryptCardDetails }">
                             </div>
                             <div class="card_info width-10">

--- a/view/frontend/web/template/payment/buckaroo_magento2_giropay.html
+++ b/view/frontend/web/template/payment/buckaroo_magento2_giropay.html
@@ -30,12 +30,10 @@
                         </label>
                         <div class="control">
                             <input id="bicnumber" class="input-text field _error" type="text"
+                                   data-validate="{required:true, BIC:true}"
                                    data-bind="
                                     value: bicnumber,
-                                    valueUpdate: 'keyup',
-                                    attr: {
-                                        'data-validate': JSON.stringify({ 'required': true,  'BIC':true  })
-                                    }
+                                    valueUpdate: 'keyup'
                                    "
                                    name="payment[buckaroo_magento2_giropay][customer_bic]">
                         </div>

--- a/view/frontend/web/template/payment/buckaroo_magento2_ideal.html
+++ b/view/frontend/web/template/payment/buckaroo_magento2_ideal.html
@@ -39,9 +39,9 @@
 
                         <!-- ko if: selectionType == '2' -->
                             <select id="buckaroo_magento2_ideal_issuer" class="field"
+                                    data-validate="{'required-entry':true}"
                                     data-bind="value: idealIssuer,
-                                    event: { change: setSelectedBankDropDown },
-                                    attr: { 'data-validate': JSON.stringify({ 'required-entry': true }) }"
+                                    event: { change: setSelectedBankDropDown }"
                                     name="bank">
                                 <option data-bind="i18n: 'Select a bank', 'value': ''"></option>
                                 <!-- ko foreach: banktypes -->

--- a/view/frontend/web/template/payment/buckaroo_magento2_idealprocessing.html
+++ b/view/frontend/web/template/payment/buckaroo_magento2_idealprocessing.html
@@ -39,9 +39,9 @@
 
                         <!-- ko if: selectionType == '2' -->
                             <select id="buckaroo_magento2_idealp_issuer" class="field"
+                                    data-validate="{'required-entry':true}"
                                     data-bind="value: idealIssuer,
-                                    event: { change: setSelectedBankDropDown },
-                                    attr: { 'data-validate': JSON.stringify({ 'required-entry': true }) }"
+                                    event: { change: setSelectedBankDropDown }"
                                     name="bank">
                                 <option data-bind="i18n: 'Select a bank', 'value': ''"></option>
                                 <!-- ko foreach: banktypes -->

--- a/view/frontend/web/template/payment/buckaroo_magento2_mrcash.html
+++ b/view/frontend/web/template/payment/buckaroo_magento2_mrcash.html
@@ -37,11 +37,11 @@
                                        type="text"
                                        class="input-text field"
                                        name="payment[buckaroo_magento2_mrcash][cardholdername]"
+                                       data-validate="{required:true, validateCardHolderName:true}"
                                        data-bind="
                             valueUpdate: 'blur',
                             value: CardHolderName,
                             textInput: CardHolderName(),
-                            attr: { 'data-validate': JSON.stringify({ 'required': true, 'validateCardHolderName': true }) },
                             event: { blur: encryptCardDetails }">
                             </div>
                         </div>
@@ -53,11 +53,11 @@
                                        type="text"
                                        class="input-text field"
                                        name="payment[buckaroo_magento2_mrcash][cardnumber]"
+                                       data-validate="{required:true, validateCardNumber:true}"
                                        data-bind="
                             valueUpdate: 'blur',
                             value: CardNumber,
                             textInput: CardNumber(),
-                            attr: { 'data-validate': JSON.stringify({ 'required': true, 'validateCardNumber': true }) },
                             event: { blur: encryptCardDetails }">
                             </div>
                         </div>
@@ -66,8 +66,8 @@
                             <label class="label" for="buckaroo_magento2_mrcash_expirationmonth"><span data-bind="i18n: 'Month:'"></span></label>
                             <div class="control">
                                 <select id="buckaroo_magento2_mrcash_expirationmonth" class="field"
+                                        data-validate="{'required-entry':true}"
                                         data-bind="value: ExpirationMonth,
-                                        attr: { 'data-validate': JSON.stringify({ 'required-entry': true }) },
                                         event: { change: validateMonth }"
                                         name="payment[buckaroo_magento2_mrcash][expirationmonth]">
                                     <!-- ko foreach: months -->
@@ -81,8 +81,8 @@
                             <label class="label" for="buckaroo_magento2_mrcash_expirationyear"><span data-bind="i18n: 'Year:'"></span></label>
                             <div class="control">
                                 <select id="buckaroo_magento2_mrcash_expirationyear" class="field"
+                                        data-validate="{'required-entry':true}"
                                         data-bind="value: ExpirationYear,
-                                                   attr: { 'data-validate': JSON.stringify({ 'required-entry': true }) },
                                                    event: { change: validateYear, blur: validateYear },
                                                    foreach: getYears()"
                                         name="payment[buckaroo_magento2_mrcash][expirationyear]">

--- a/view/frontend/web/template/payment/buckaroo_magento2_payperemail.html
+++ b/view/frontend/web/template/payment/buckaroo_magento2_payperemail.html
@@ -29,10 +29,10 @@
                             <ul id="Saluation">
                                 <li>
                                     <input type="radio" id="buckaroo_magento2_payperemail_genderSelectMan"
+                                           data-validate="{required:true}"
                                            data-bind="
                                                value: '1',
                                                click: setSelectedGender.bind($data, '1'),
-                                               attr: { 'data-validate': JSON.stringify({ 'required': true }) },
                                                checked: genderValidate
                                                "
                                            class="field"
@@ -41,10 +41,10 @@
                                 </li>
                                 <li>
                                     <input type="radio" id="buckaroo_magento2_payperemail_genderSelectWoman"
+                                           data-validate="{required:true}"
                                            data-bind="
                                                value: '2',
                                                click: setSelectedGender.bind($data, '2'),
-                                               attr: { 'data-validate': JSON.stringify({ 'required': true }) },
                                                checked: genderValidate
                                             "
                                            class="field"
@@ -62,9 +62,9 @@
                             <input id="buckaroo_magento2_payperemail_BillingFirstName"
                                    class="input-text field"
                                    type="text"
+                                   data-validate="{required:true}"
                                    data-bind="
                                        valueUpdate: 'keyup',
-                                       attr: { 'data-validate': JSON.stringify({ 'required': true }) },
                                        value: BillingFirstName,
                                        textInput: CustomerFirstName()"
                                    name="payment[buckaroo_magento2_payperemail][customer_billingFirstName]"
@@ -78,9 +78,9 @@
                             <input id="buckaroo_magento2_payperemail_BillingLastName"
                                    class="input-text field"
                                    type="text"
+                                   data-validate="{required:true}"
                                    data-bind="
                                        valueUpdate: 'keyup',
-                                       attr: { 'data-validate': JSON.stringify({ 'required': true }) },
                                        value: BillingLastName,
                                        textInput: CustomerLastName()"
                                    name="payment[buckaroo_magento2_payperemail][customer_billingLastName]"
@@ -94,9 +94,9 @@
                             <input id="buckaroo_magento2_payperemail_Email"
                                    type="text"
                                    class="input-text field"
+                                   data-validate="{required:true, 'validate-email':true}"
                                    data-bind="
                                        valueUpdate: 'keyup',
-                                       attr: { 'data-validate': JSON.stringify({ 'required': true, 'validate-email': true })},
                                        value: BillingEmail,
                                        textInput: CustomerEmail()"
                                    name="payment[buckaroo_magento2_payperemail][customer_email]">

--- a/view/frontend/web/template/payment/buckaroo_magento2_sepadirectdebit.html
+++ b/view/frontend/web/template/payment/buckaroo_magento2_sepadirectdebit.html
@@ -46,12 +46,10 @@
                         </label>
                         <div class="control">
                             <input id="bankaccountnumber" class="input-text field" type="text"
+                                   data-validate="{required:true, IBAN: true}"
                                    data-bind="
                                     value: bankaccountnumber,
-                                    valueUpdate: 'keyup',
-                                    attr: {
-                                        'data-validate': JSON.stringify({ 'required': true, 'IBAN':true })
-                                    }
+                                    valueUpdate: 'keyup'
                                    "
                                    name="payment[buckaroo_magento2_sepadirectdebit][customer_iban]">
                         </div>
@@ -64,12 +62,10 @@
                         </label>
                         <div class="control">
                             <input id="bicnumber" class="input-text field" type="text"
+                                   data-validate="{required:true, BIC: true}"
                                    data-bind="
                                     value: bicnumber,
-                                    valueUpdate: 'keyup',
-                                    attr: {
-                                        'data-validate': JSON.stringify({ 'required': true, 'BIC':true })
-                                    }
+                                    valueUpdate: 'keyup'
                                    "
                                    name="payment[buckaroo_magento2_sepadirectdebit][customer_bic]">
                         </div>

--- a/view/frontend/web/template/payment/buckaroo_magento2_tinka.html
+++ b/view/frontend/web/template/payment/buckaroo_magento2_tinka.html
@@ -27,10 +27,10 @@
                             <ul id="Saluation">
                                 <li>
                                     <input type="radio" id="buckaroo_magento2_tinka_genderSelectMan"
+                                           data-validate="{required:true}"
                                            data-bind="
                                            value: '1',
                                            click: setSelectedGender.bind($data, '1'),
-                                           attr: { 'data-validate': JSON.stringify({ 'required': true }) },
                                            checked: genderValidate
                                            "
                                            class="field"
@@ -39,10 +39,10 @@
                                 </li>
                                 <li>
                                     <input type="radio" id="buckaroo_magento2_tinka_genderSelectWoman"
+                                           data-validate="{required:true}"
                                            data-bind="
                                            value: '2',
                                            click: setSelectedGender.bind($data, '2'),
-                                           attr: { 'data-validate': JSON.stringify({ 'required': true }) },
                                            checked: genderValidate
                                             "
                                            class="field"
@@ -63,8 +63,8 @@
                                    class="input-text field"
                                    type="text"
                                    name="payment[buckaroo_magento2_tinka][buckaroo_identification_number]"
+                                   data-validate="{required:true}"
                                    data-bind="
-                                   attr: { 'data-validate': JSON.stringify({ 'required': true }) },
                                    checked: identificationValidate
                                    valueUpdate: 'blur',
                                    value: identificationValidate
@@ -95,6 +95,7 @@
                             <input id="buckaroo_magento2_tinka_DoB"
                                    class="field"
                                    type="text"
+                                   data-validate="{required:true, 'validate-date-au': true}"
                                    data-bind="
                                    datepicker: {
                                         storage: dateValidate,
@@ -106,8 +107,7 @@
                                         }
                                    },
                                    valueUpdate: 'change',
-                                   value: dateValidate,
-                                   attr: { 'data-validate': JSON.stringify({ 'required': true, 'validate-date-au': true })}"
+                                   value: dateValidate"
                                    name="payment[buckaroo_magento2_tinka][customer_DoB]">
                             <div for="buckaroo_magento2_tinka_DoB" generated="true" class="mage-error" id="buckaroo_magento2_tinka_DoB-error" style="display: none;"><span data-bind="i18n: 'You should be at least 18 years old.' "></span></div>
                         </div>


### PR DESCRIPTION
Problem with validation on iPhones (tested on iPhone 13 ios 15) in browser Safari.
Example:
<input type="radio" id="buckaroo_magento2_afterpay20_genderSelectMan" data-bind="
                                           value: '1',
                                           event: { change: selectPaymentMethod },
                                           click: setSelectedGender.bind($data, '1'),
                                           attr: { 'data-validate': JSON.stringify({ 'required': true }) },
                                           checked: genderValidate
                                           " class="field" name="payment[buckaroo_magento2_afterpay20][customer_gender]" value="1" data-validate="{&quot;required&quot;:true}" aria-required="true" data-dashlane-rid="0a07315bd3051d63" data-form-type="payment,type">
                                           
  Problem with "&quot;" in attribute data-validate="{&quot;required&quot;:true}".
  How to reproduce:
  - go to checkout;
  - select payment method for example in3;
  - do not choose gender;
  - press "place order";
  - error with validation in console "undefined is not an object (evaluating '$.validator.methods[method].call')';
  