### PR TITLE
Fixing signature check when names have the "+" character

### DIFF
--- a/Model/Validator/Push.php
+++ b/Model/Validator/Push.php
@@ -207,6 +207,8 @@ class Push implements ValidatorInterface
             case 'cust_customershippingtelephone':
             case 'cust_customershippinghousenumber':
             case 'cust_customershippinghouseadditionalnumber':
+            case 'cust_voornaam':
+            case 'cust_achternaam':
                 $decodedValue = $brq_value;
                 break;
             default:


### PR DESCRIPTION
When a customer has the "+" character in their name or last name on his address Buckaroo fails at sending the webhook to Magento receiving a signature error.