### PR TITLE
Refund approval workflow not working for Transfer

### DIFF
--- a/Model/Push.php
+++ b/Model/Push.php
@@ -424,11 +424,14 @@ class Push implements PushInterface
             Giftcards::PAYMENT_METHOD_CODE,
             Transfer::PAYMENT_METHOD_CODE
         ];
+        
+        $isRefund = $this->hasPostData('add_service_action_from_magento', ['refund']);
+
         if ($payment
             && $payment->getMethod()
             && $receivedStatusCode
             && ($this->getTransactionType() == self::BUCK_PUSH_TYPE_TRANSACTION)
-            && (!in_array($payment->getMethod(), $ignoredPaymentMethods))
+            && (!in_array($payment->getMethod(), $ignoredPaymentMethods) || $isRefund)
         ) {
             $this->logging->addDebug(__METHOD__ . '|5|');
 


### PR DESCRIPTION
The isPushNeeded method does a small check for refund approval cases, but the receivePushCheckDuplicates method is not prepared to handle refund approvals for BankTransfer as it's ignoring it.

So I added a piece of code that will fix the validation for refund transactions.