### PR TITLE
2+ partial refunds of the same order doesn't generate credit memo for all refunds when approved at the same time

### DIFF
--- a/Model/Push.php
+++ b/Model/Push.php
@@ -907,29 +907,27 @@ class Push implements PushInterface
         }
     }
 
-    protected function setReceivedTransactionStatuses()
+    /**
+     * It updates the BUCKAROO_RECEIVED_TRANSACTIONS_STATUSES payment additional information
+     * with the current received tx status.
+     *
+     * @return void
+     */
+    protected function setReceivedTransactionStatuses(): void
     {
-        if (empty($this->postData['brq_transactions']) || empty($this->postData['brq_statuscode'])) {
+        $txId = $this->postData['brq_transactions'];
+        $statusCode = $this->postData['brq_statuscode'];
+
+        if (empty($txId) || empty($statusCode)) {
             return;
         }
 
         $payment = $this->order->getPayment();
 
-        if (!$payment->getAdditionalInformation(self::BUCKAROO_RECEIVED_TRANSACTIONS_STATUSES)) {
-            $payment->setAdditionalInformation(
-                self::BUCKAROO_RECEIVED_TRANSACTIONS_STATUSES,
-                [$this->postData['brq_transactions'] => $this->postData['brq_statuscode']]
-            );
-        } else {
-            $buckarooTransactionKeysArray = $payment->getAdditionalInformation(
-                self::BUCKAROO_RECEIVED_TRANSACTIONS_STATUSES
-            );
-            $buckarooTransactionKeysArray[$this->postData['brq_transactions']] = $this->postData['brq_statuscode'];
-            $payment->setAdditionalInformation(
-                self::BUCKAROO_RECEIVED_TRANSACTIONS_STATUSES,
-                $buckarooTransactionKeysArray
-            );
-        }
+        $receivedTxStatuses = $payment->getAdditionalInformation(self::BUCKAROO_RECEIVED_TRANSACTIONS_STATUSES) ?? [];
+        $receivedTxStatuses[$txId] = $statusCode;
+
+        $payment->setAdditionalInformation(self::BUCKAROO_RECEIVED_TRANSACTIONS_STATUSES, $receivedTxStatuses);
     }
 
     /**

--- a/Model/Push.php
+++ b/Model/Push.php
@@ -921,7 +921,9 @@ class Push implements PushInterface
                 [$this->postData['brq_transactions'] => $this->postData['brq_statuscode']]
             );
         } else {
-            $buckarooTransactionKeysArray = $payment->getAdditionalInformation(self::BUCKAROO_RECEIVED_TRANSACTIONS);
+            $buckarooTransactionKeysArray = $payment->getAdditionalInformation(
+                self::BUCKAROO_RECEIVED_TRANSACTIONS_STATUSES
+            );
             $buckarooTransactionKeysArray[$this->postData['brq_transactions']] = $this->postData['brq_statuscode'];
             $payment->setAdditionalInformation(
                 self::BUCKAROO_RECEIVED_TRANSACTIONS_STATUSES,


### PR DESCRIPTION
This pull request fixes the issue described on https://github.com/buckaroo-it/Magento2/issues/576.

### Problem

Two or more partial refunds of the same order that needs approval don't create all necessary creditmemos when approved at the same time (batch approval).

### Why the problem happens?

The problem starts at the `handleAwaitingApprovalRefunds` method, which handles the status **BUCKAROO_MAGENTO2_STATUSCODE_PENDING_APPROVAL** from a refund when the customer attempts to create a creditmemo and receives the awaiting approval message.

Inside this method, if conditions are met, it calls **setReceivedTransactionStatuses** which inside has the following validation:

```
if (!$payment->getAdditionalInformation(self::BUCKAROO_RECEIVED_TRANSACTIONS_STATUSES)) {
    $payment->setAdditionalInformation(
        self::BUCKAROO_RECEIVED_TRANSACTIONS_STATUSES,
        [$this->postData['brq_transactions'] => $this->postData['brq_statuscode']]
    );
} else {
    $buckarooTransactionKeysArray = $payment->getAdditionalInformation(self::BUCKAROO_RECEIVED_TRANSACTIONS);
    $buckarooTransactionKeysArray[$this->postData['brq_transactions']] = $this->postData['brq_statuscode'];
    $payment->setAdditionalInformation(
        self::BUCKAROO_RECEIVED_TRANSACTIONS_STATUSES,
        $buckarooTransactionKeysArray
    );
}
```

To be more specific, the line `$buckarooTransactionKeysArray = $payment->getAdditionalInformation(self::BUCKAROO_RECEIVED_TRANSACTIONS);` is the problem. This else block wants to add the received transaction status to the STATUSES array, but instead of getting the existing array value and just adding a new key, it uses another array (BUCKAROO_RECEIVED_TRANSACTIONS) as the base and then assigns it back to the BUCKAROO_RECEIVED_TRANSACTIONS_STATUSES, overwriting the old value.

It's okay when you have only one refund per order, but when you have multiple refunds that need approval and they are approved at the same problem the problem starts. I can explain with a simple step-by-step explanation.

1. Imagine that we have two transactions: ABC100 and ABC1001. Both are refunds with PENDING_APPROVAL status.
2. Push from ABC100 is sent to Magento, the **else** block will be executed cause **BUCKAROO_RECEIVED_TRANSACTIONS_STATUSES** array has already the payment capture transaction with 190 status and BUCKAROO_RECEIVED_TRANSACTIONS which is used as a base array. So the final value of BUCKAROO_RECEIVED_TRANSACTIONS_STATUSES will be:
```
{
    "CAPTURE_TRANSACTION": "190",
    "ABC100": "794"
}
```
3. Push from ABC101 is sent to Magento and again the **else** block is executed. As **BUCKAROO_RECEIVED_TRANSACTIONS** is used as a base array, it will contain only the capture transaction status, not the already existing refund (ABC100), so the final result of **BUCKAROO_RECEIVED_TRANSACTIONS_STATUSES** will be:
```
{
    "CAPTURE_TRANSACTION": "190",
    "ABC101": "794"
}
```
4. When ABC100 refund tx is approved, it will send a 190 status to Magento, so **handleAwaitingApprovalRefunds** method will skip but the **isPushNeeded** will return false because it doesn't have the **ABC100** status in the **BUCKAROO_RECEIVED_TRANSACTIONS_STATUSES** array and the following validation will not work:
```
if ($this->hasPostData('add_initiated_by_magento', 1)
    && $this->hasPostData('add_service_action_from_magento', ['refund'])
) {
    $statusCodeSuccess = $this->helper->getStatusCode('BUCKAROO_MAGENTO2_STATUSCODE_SUCCESS');
    if ($this->hasPostData('brq_statuscode', $statusCodeSuccess)) {
        if ($this->receivePushCheckDuplicates(
            $this->helper->getStatusCode('BUCKAROO_MAGENTO2_STATUSCODE_PENDING_APPROVAL')
        )) {
            $this->logging->addDebug(__METHOD__ . '|4|');
            return true;
        }
    }
    $this->logging->addDebug(__METHOD__ . '|5|');
    return false;

}
```

### Solution

The solution is simple, instead of using **BUCKAROO_RECEIVED_TRANSACTIONS** we should use **BUCKAROO_RECEIVED_TRANSACTIONS_STATUSES** as a base array, using the existing array value to increment a new status.

I also refactored the method a little bit (making it simple and more readable).
--

@Buckaroo-Rens this time I followed the guidelines :D 