### PR TITLE
Orders status incorrectly updated to Pending - ensure the total_paid was updated in DB

### DIFF
--- a/Model/Push.php
+++ b/Model/Push.php
@@ -1345,6 +1345,19 @@ class Push implements PushInterface
 
         $this->processSucceededPushAuth($payment);
 
+        // Ensure that total_paid has been modified in the database.
+        $connection = $this->resourceConnection->getConnection();
+        $connection->update(
+            $connection->getTableName('sales_order'),
+            [
+                'total_due'       => $this->order->getTotalDue(),
+                'base_total_due'  => $this->order->getTotalDue(),
+                'total_paid'      => $this->order->getTotalPaid(),
+                'base_total_paid' => $this->order->getBaseTotalPaid(),
+            ],
+            $connection->quoteInto('entity_id = ?', $this->order->getId())
+        );
+
         $this->updateOrderStatus($state, $newStatus, $description, $forceState);
 
         $this->logging->addDebug(__METHOD__ . '|9|');

--- a/Plugin/CommandInterface.php
+++ b/Plugin/CommandInterface.php
@@ -138,7 +138,7 @@ class CommandInterface
         $this->logging->addDebug(__METHOD__ . '|11|' .
             var_export(['getTotalPaid' => $order->getTotalPaid(), 'getGrandTotal' => $order->getGrandTotal()], true)
         );
-        if ($order->getTotalPaid() == $order->getGrandTotal()) {
+        if ($order->getGrandTotal() - $order->getTotalPaid() < 0.001) {
             return false;
         }
 


### PR DESCRIPTION
The total_paid is saved on the saveInvoice function:

app/code/Buckaroo/Magento2/Model/Push.php:1321
if (!$this->saveInvoice()) {}

And it is updated in database at the next line:
$this->order->save();
app/code/Buckaroo/Magento2/Model/Push.php:1551

But to be sure that order saved properly total_paid I added these lines.

On local is always saved on Push.php:1551.