### PR TITLE
BP-2865 - Creating an invoice using the 'Invoice' doesn't create capture

### DIFF
--- a/Model/Service/CreateInvoice.php
+++ b/Model/Service/CreateInvoice.php
@@ -100,7 +100,7 @@ class CreateInvoice
     {
         $this->payment = $order->getPayment();
 
-        $this->addTransactionData();
+        $this->addTransactionData($this->payment);
 
         $this->logger->addDebug(__METHOD__ . '|1| - Save Invoice');
 
@@ -150,9 +150,9 @@ class CreateInvoice
      * @return Order\Payment
      * @throws \Magento\Framework\Exception\LocalizedException
      */
-    public function addTransactionData($transactionKey = false, $datas = false)
+    public function addTransactionData($payment, $transactionKey = false, $datas = false)
     {
-        $transactionKey = $transactionKey ?: $this->payment->getAdditionalInformation(
+        $transactionKey = $transactionKey ?: $payment->getAdditionalInformation(
             BuckarooAdapter::BUCKAROO_ORIGINAL_TRANSACTION_KEY_KEY
         );
 
@@ -165,7 +165,7 @@ class CreateInvoice
          */
         if(!$datas)
         {
-            $rawDetails = $this->payment->getAdditionalInformation(Transaction::RAW_DETAILS);
+            $rawDetails = $payment->getAdditionalInformation(Transaction::RAW_DETAILS);
             $rawInfo = $rawDetails[$transactionKey] ?? [];
         } else {
             $rawInfo  = $this->helper->getTransactionAdditionalInfo($datas);
@@ -174,19 +174,19 @@ class CreateInvoice
         /**
          * @noinspection PhpUndefinedMethodInspection
          */
-        $this->payment->setTransactionAdditionalInfo(Transaction::RAW_DETAILS, $rawInfo);
+        $payment->setTransactionAdditionalInfo(Transaction::RAW_DETAILS, $rawInfo);
 
         /**
          * Save the payment's transaction key.
          */
-        $this->payment->setTransactionId($transactionKey . '-capture');
+        $payment->setTransactionId($transactionKey . '-capture');
 
-        $this->payment->setParentTransactionId($transactionKey);
-        $this->payment->setAdditionalInformation(
+        $payment->setParentTransactionId($transactionKey);
+        $payment->setAdditionalInformation(
             BuckarooAdapter::BUCKAROO_ORIGINAL_TRANSACTION_KEY_KEY,
             $transactionKey
         );
 
-        return $this->payment;
+        return $payment;
     }
 }

--- a/Model/Service/CreateInvoice.php
+++ b/Model/Service/CreateInvoice.php
@@ -38,11 +38,6 @@ use Magento\Sales\Model\Order\Payment\Transaction;
 class CreateInvoice
 {
     /**
-     * @var Order\Payment
-     */
-    private Order\Payment $payment;
-
-    /**
      * @var Log
      */
     protected Log $logger;
@@ -98,9 +93,10 @@ class CreateInvoice
      */
     public function createInvoiceGeneralSetting(Order $order): bool
     {
-        $this->payment = $order->getPayment();
+        /** @var Order\Payment $payment */
+        $payment = $order->getPayment();
 
-        $this->addTransactionData($this->payment);
+        $this->addTransactionData($payment);
 
         $this->logger->addDebug(__METHOD__ . '|1| - Save Invoice');
 
@@ -111,13 +107,13 @@ class CreateInvoice
         }
 
         //Fix for suspected fraud when the order currency does not match with the payment's currency
-        $amount = ($this->payment->isSameCurrency()
-            && $this->payment->isCaptureFinal($order->getGrandTotal())) ?
+        $amount = ($payment->isSameCurrency()
+            && $payment->isCaptureFinal($order->getGrandTotal())) ?
             $order->getGrandTotal() : $order->getBaseTotalDue();
-        $this->payment->registerCaptureNotification($amount);
-        $this->payment->save();
+        $payment->registerCaptureNotification($amount);
+        $payment->save();
 
-        $transactionKey = (string)$this->payment->getAdditionalInformation(
+        $transactionKey = (string)$payment->getAdditionalInformation(
             BuckarooAdapter::BUCKAROO_ORIGINAL_TRANSACTION_KEY_KEY
         );
 

--- a/Observer/SetTransactionOnInvoiceObserver.php
+++ b/Observer/SetTransactionOnInvoiceObserver.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the MIT License
+ * It is available through the world-wide-web at this URL:
+ * https://tldrlegal.com/license/mit-license
+ * If you are unable to obtain it through the world-wide-web, please email
+ * to support@buckaroo.nl, so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade this module to newer
+ * versions in the future. If you wish to customize this module for your
+ * needs please contact support@buckaroo.nl for more information.
+ *
+ * @copyright Copyright (c) Buckaroo B.V.
+ * @license   https://tldrlegal.com/license/mit-license
+ */
+declare(strict_types=1);
+
+namespace Buckaroo\Magento2\Observer;
+
+use Buckaroo\Magento2\Model\Config\Source\InvoiceHandlingOptions;
+use Buckaroo\Magento2\Model\ConfigProvider\Account;
+use Buckaroo\Magento2\Model\Service\CreateInvoice;
+use Buckaroo\Magento2\Service\CheckPaymentType;
+use Magento\Framework\Event\Observer;
+use Magento\Framework\Event\ObserverInterface;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Sales\Model\Order;
+use Magento\Sales\Model\Order\Invoice;
+use Magento\Sales\Model\Order\Payment\State\CommandInterface;
+use Magento\Sales\Model\Order\Payment\Transaction;
+
+class SetTransactionOnInvoiceObserver implements ObserverInterface
+{
+    /**
+     * @var CheckPaymentType
+     */
+    public CheckPaymentType $checkPaymentType;
+
+    /**
+     * @var CommandInterface
+     */
+    protected CommandInterface $stateCommand;
+
+    /**
+     * @var Account
+     */
+    private Account $configAccount;
+
+    /**
+     * @var CreateInvoice
+     */
+    private CreateInvoice $createInvoiceService;
+
+    public function __construct(
+        CommandInterface $stateCommand,
+        Account $configAccount,
+        CheckPaymentType $checkPaymentType,
+        CreateInvoice $createInvoiceService
+    ) {
+        $this->stateCommand = $stateCommand;
+        $this->configAccount = $configAccount;
+        $this->checkPaymentType = $checkPaymentType;
+        $this->createInvoiceService = $createInvoiceService;
+    }
+
+    /**
+     * Set transaction id on invoiced for invoice after shippment
+     *
+     * @param Observer $observer
+     * @return $this
+     * @throws LocalizedException
+     */
+    public function execute(Observer $observer)
+    {
+        /* @var $invoice Invoice */
+        $invoice = $observer->getEvent()->getInvoice();
+
+        /* @var $order Order */
+        $order = $observer->getEvent()->getOrder();
+        $payment = $order->getPayment();
+
+        $amount = $invoice->getGrandTotal();
+        $paymentMethod = $payment->getMethod();
+        if ($this->checkPaymentType->isBuckarooMethod($paymentMethod) &&
+            $this->configAccount->getInvoiceHandling() == InvoiceHandlingOptions::SHIPMENT &&
+            empty($invoice->getTransactionId()) &&
+            empty($payment->getTransactionId())
+        ) {
+
+            $this->createInvoiceService->addTransactionData($payment);
+
+            $message = $this->stateCommand->execute($payment, $amount, $order);
+            $transaction = $payment->addTransaction(
+                Transaction::TYPE_CAPTURE,
+                $invoice,
+                true
+            );
+            $message = $payment->prependMessage($message);
+            $payment->addTransactionCommentsToOrder($transaction, $message);
+        }
+
+        return $this;
+    }
+}

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -440,6 +440,12 @@
         </arguments>
     </type>
 
+    <type name="Buckaroo\Magento2\Observer\SetTransactionOnInvoiceObserver">
+        <arguments>
+            <argument name="stateCommand" xsi:type="object">Magento\Sales\Model\Order\Payment\State\RegisterCaptureNotificationCommand</argument>
+        </arguments>
+    </type>
+
     <type name="Magento\Framework\View\Asset\Minification">
         <plugin name="my-exclude" type="Buckaroo\Magento2\Plugin\ExcludeFilesFromMinification" />
     </type>

--- a/etc/events.xml
+++ b/etc/events.xml
@@ -34,6 +34,8 @@
     <event name="sales_order_invoice_register">
         <observer name="buckaroo_magento2_group_transaction_register" instance="Buckaroo\Magento2\Observer\GroupTransactionRegister" />
         <observer name="buckaroo_magento2_fee_invoice" instance="Buckaroo\Magento2\Observer\InvoiceRegister" />
+        <observer name="buckaroo_magento2_set_transaction" instance="Buckaroo\Magento2\Observer\SetTransactionOnInvoiceObserver" />
+
     </event>
     <event name="sales_order_invoice_pay">
         <observer name="buckaroo_magento2_group_transaction_register" instance="Buckaroo\Magento2\Observer\GroupTransactionRegister" />


### PR DESCRIPTION
BP-2865 - Creating an invoice using the 'Invoice' doesn't create capture transaction

The transaction is not created when the invoice is made using the invoice button, which results in only the offline refund