### PR TITLE
BP-2940 - Payconiq orders are sometimes getting "Cancelled" when the payment is succesfull

### DIFF
--- a/Model/Push.php
+++ b/Model/Push.php
@@ -591,6 +591,12 @@ class Push implements PushInterface
             return false;
         }
 
+        $statusCodePendingProcessing = $this->helper->getStatusCode('BUCKAROO_MAGENTO2_STATUSCODE_PENDING_PROCESSING');
+        if ($this->hasPostData('brq_statuscode', $statusCodePendingProcessing)
+            && $this->hasPostData('brq_transaction_method', 'payconiq')) {
+            return false;
+        }
+
         return true;
     }
 


### PR DESCRIPTION
the 791 status is not processed at all when the payment method is PayConiq 