### PR TITLE
Add support for Mage-OS 1.0.x

### DIFF
--- a/Block/Adminhtml/Config/Support/SupportTab.php
+++ b/Block/Adminhtml/Config/Support/SupportTab.php
@@ -213,6 +213,10 @@ class SupportTab extends Template implements RendererInterface
         }
 
         $magentoMajorMinor = $magentoVersion[0] . '.' . $magentoVersion[1];
+        if (!isset($this->phpVersionSupport[$magentoMajorMinor])) {
+            return __('Cannot determine compatible PHP versions');
+        }
+
         $versions = array_keys($this->phpVersionSupport[$magentoMajorMinor]);
         return implode(', ', $versions);
     }


### PR DESCRIPTION
When this module is run under Mage-OS 1.0, the current code gives a Fatal Error due to an unmatched array key. Actually, any version that is not in the array, throws this error. This PR fixes this, with the idea to support Mage-OS.