### PR TITLE
BP-3516 Apple Pay phone number is only added to the shipping address

### DIFF
--- a/Controller/Applepay/SaveOrder.php
+++ b/Controller/Applepay/SaveOrder.php
@@ -182,7 +182,13 @@ class SaveOrder extends AbstractApplepay
             if (!$this->quoteAddressService->setShippingAddress($quote, $payment['shippingContact'])) {
                 return $this->commonResponse(false, true);
             }
-            if (!$this->quoteAddressService->setBillingAddress($quote, $payment['billingContact'])) {
+            if (
+                !$this->quoteAddressService->setBillingAddress(
+                    $quote,
+                    $payment['billingContact'],
+                    $payment['shippingContact']['phoneNumber'] ?? null
+                )
+            ) {
                 return $this->commonResponse(false, true);
             }
 

--- a/Model/Service/QuoteAddressService.php
+++ b/Model/Service/QuoteAddressService.php
@@ -174,11 +174,12 @@ class QuoteAddressService
      *
      * @param array $wallet
      * @param string $type
+     * @param string|null $phone
      * @return array
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      * @SuppressWarnings(PHPMD.NPathComplexity)
      */
-    public function processAddressFromWallet(array $wallet, string $type = 'shipping'): array
+    public function processAddressFromWallet(array $wallet, string $type = 'shipping', $phone = null): array
     {
         $address = [
             'prefix'     => '',
@@ -198,6 +199,11 @@ class QuoteAddressService
             'fax'        => '',
             'vat_id'     => ''
         ];
+
+        if ($phone !== null) {
+            $address['telephone'] = $phone;
+        }
+
         $address['street'] = implode("\n", $address['street']);
         if ($type == 'shipping') {
             $address['email'] = $wallet['emailAddress'] ?? '';
@@ -267,12 +273,13 @@ class QuoteAddressService
      *
      * @param Quote $quote
      * @param array $data
+     * @param string|null $phone
      * @return true
      * @throws ExpressMethodsException
      */
-    public function setBillingAddress(Quote &$quote, array $data): bool
+    public function setBillingAddress(Quote &$quote, array $data, $phone = null): bool
     {
-        $billingAddress = $this->processAddressFromWallet($data, 'billing');
+        $billingAddress = $this->processAddressFromWallet($data, 'billing', $phone);
         $quote->getBillingAddress()->addData($billingAddress);
 
         $errors = $quote->getBillingAddress()->validate();

--- a/Model/Service/QuoteAddressService.php
+++ b/Model/Service/QuoteAddressService.php
@@ -200,8 +200,8 @@ class QuoteAddressService
             'vat_id'     => ''
         ];
 
-        if ($phone !== null) {
-            $address['telephone'] = $phone;
+        if ($phone !== null && !isset($wallet['phoneNumber'])) {
+            $address['telephone'] =  $phone;
         }
 
         $address['street'] = implode("\n", $address['street']);


### PR DESCRIPTION
Changed the billing address to get the phone from the shipping address if the billing phone is missing