### PR TITLE
BP-3677-Some-payment-methods-are-not-working-error

### DIFF
--- a/Model/Method/AbstractMethod.php
+++ b/Model/Method/AbstractMethod.php
@@ -750,7 +750,9 @@ abstract class AbstractMethod extends \Magento\Payment\Model\Method\AbstractMeth
         }
 
         $transaction = $transactionBuilder->build();
-        if($transactionBuilder->getServices()['Action'] == 'PayFastCheckout'){
+
+        $services = $transactionBuilder->getServices();
+        if (isset($services['Action']) && $services['Action'] == 'PayFastCheckout') {
             $transaction->setData('Order', '');
         }
 


### PR DESCRIPTION
fix error "Action" key doesn't exist