### PR TITLE
Make BaseTest compatible with newer PHPUnit versions

### DIFF
--- a/Test/BaseTest.php
+++ b/Test/BaseTest.php
@@ -45,7 +45,7 @@ abstract class BaseTest extends TestCaseFinder
         return $this->getObject($this->instanceClass, $args);
     }
 
-    public function setUp()
+    public function setUp(): void
     {
         /**
          * Require functions.php to be able to use the translate function


### PR DESCRIPTION
This PR makes sure that the `setUp` method of all relevant tests is compatible with up-to-date PHPUnit versions (8 and up) as included in Magento 2.4.+