### PR TITLE
Remove unneeded code in tests

### DIFF
--- a/Test/BaseTest.php
+++ b/Test/BaseTest.php
@@ -47,19 +47,6 @@ abstract class BaseTest extends TestCaseFinder
 
     public function setUp()
     {
-        /**
-         * Require functions.php to be able to use the translate function
-         */
-        if (strpos(__DIR__, 'vendor') === false) {
-            include_once __DIR__ . '/../../../../functions.php';
-        } else {
-            include_once __DIR__ . '/../../../../app/functions.php';
-        }
-
-        ini_set('error_reporting', E_ALL);
-        ini_set('display_errors', '1');
-        ini_set('display_startup_errors', '1');
-
         $this->objectManagerHelper = new ObjectManager($this);
     }
 


### PR DESCRIPTION
This PR removes the check for a `functions.php` file which is not needed in Magento 2. Unit tests should be run similarly like `vendor/bin/phpunit --configuration dev/tests/unit/phpunit.xml.dist vendor/buckaroo/magento2/Test/Unit`. This way, the PHP settings should also be moved to the PHPUnit configuration file and not be part of the tests.