### PR TITLE
Method assertInternalType is deprecated

### DIFF
--- a/Test/BaseTest.php
+++ b/Test/BaseTest.php
@@ -257,4 +257,9 @@ abstract class BaseTest extends TestCaseFinder
 
         return $mock;
     }
+
+    protected function assertInternalType(string $type, $value)
+    {
+        $this->assertEquals($type, gettype($value));
+    }
 }


### PR DESCRIPTION
Create a mock for the `assertInternalType` method which is removed from PHPUnit. See also https://github.com/sebastianbergmann/phpunit/issues/3369