### PR TITLE
BP-3724-Non-existing-class-in-doc-block-for-Api-PaypalExpressQuoteCreateInterface.php

### DIFF
--- a/Api/PaypalExpressQuoteCreateInterface.php
+++ b/Api/PaypalExpressQuoteCreateInterface.php
@@ -31,7 +31,7 @@ interface PaypalExpressQuoteCreateInterface
    * @param \Buckaroo\Magento2\Api\Data\PaypalExpress\ShippingAddressRequestInterface $shipping_address
    * @param string $page
    * @param string|null $order_data
-   * @return \Buckaroo\Magento2\Api\Data\PaypalExpress\QuoteCreateResponseInterface
+   * @return \Buckaroo\Magento2\Api\Data\QuoteCreateResponseInterface
    */
   public function execute(
     ShippingAddressRequestInterface $shipping_address,


### PR DESCRIPTION
fix return path for QuoteCreateResponseInterface