### PR TITLE
BP-3894 Update Applepay.php

### DIFF
--- a/Block/Catalog/Product/View/Applepay.php
+++ b/Block/Catalog/Product/View/Applepay.php
@@ -62,8 +62,11 @@ class Applepay extends Template
      */
     public function canShowButton($page)
     {
+        $applepayButtons = $this->applepayConfigProvider->getAvailableButtons();
+
         return $this->isModuleActive() &&
-            in_array($page, $this->applepayConfigProvider->getAvailableButtons()) &&
+            is_array($applepayButtons) &&
+            in_array($page, $applepayButtons) &&
             $this->applepayConfigProvider->isApplePayEnabled($this->_storeManager->getStore());
     }
 


### PR DESCRIPTION
The 'getAvailableButtons' method can return a boolean (false) instead of an array.

I think the getAvailableButtons method should just return an empty array if there are no available buttons, but considering Hyrum's law I would consider that a breaking change requiring a minor version update. This Pull Request should be minimal impact, warranting a release in a patch-version.