### PR TITLE
BP-4217-Apple-Pay-should-not-be-visible-in-the-checkout-on-non-Apple-devices

### DIFF
--- a/view/frontend/web/js/view/checkout/applepay/pay.js
+++ b/view/frontend/web/js/view/checkout/applepay/pay.js
@@ -106,15 +106,14 @@ define(
             },
 
             canShowApplePay: function () {
-                return BuckarooSdk.ApplePay.checkApplePaySupport(window.checkoutConfig.payment.buckaroo.applepay.guid)
+                BuckarooSdk.ApplePay.checkApplePaySupport(window.checkoutConfig.payment.buckaroo.applepay.guid)
                     .then(function (applePaySupported) {
                         this.canShowMethod(applePaySupported);
-                        return applePaySupported;
                     }.bind(this))
                     .catch(function (error) {
                         this.canShowMethod(false);
-                        return false;
                     }.bind(this));
+                return this.canShowMethod();
             },
 
             setQuote: function (newQuote) {

--- a/view/frontend/web/js/view/payment/method-renderer/applepay.js
+++ b/view/frontend/web/js/view/payment/method-renderer/applepay.js
@@ -59,6 +59,7 @@ define(
 
                 initObservable: function () {
                     this._super().observe([]);
+                    applepayPay.canShowApplePay();
 
                     applepayPay.transactionResult.subscribe(
                         function () {
@@ -87,7 +88,7 @@ define(
                 },
 
                 canShowPaymentMethod: ko.computed(function () {
-                    return applepayPay.canShowApplePay();
+                    return applepayPay.canShowMethod();
                 }),
 
                 /**


### PR DESCRIPTION
refactor applepay: update method to check Apple Pay support and impreve visibility logic