### PR TITLE
BP-4269 Add ConsumerEmail to request parameters

### DIFF
--- a/Model/Method/Trustly.php
+++ b/Model/Method/Trustly.php
@@ -65,6 +65,10 @@ class Trustly extends AbstractMethod
                     '_' => $billingAddress->getLastName(),
                     'Name' => 'CustomerLastName',
                 ],
+                [
+                    '_' => $billingAddress->getEmail(),
+                    'Name' => 'ConsumerEmail',
+                ],            
             ],
         ];
 


### PR DESCRIPTION
To fix the error Parameter 'ConsumerEmail' is missing when using the Trustly payment method. See #1200 