### PR TITLE
BP 4197 deprecated functionality   preg replace()

### DIFF
--- a/Controller/Payconiq/Process.php
+++ b/Controller/Payconiq/Process.php
@@ -134,9 +134,14 @@ class Process extends \Buckaroo\Magento2\Controller\Redirect\Process
     protected function getTransactionKey()
     {
         $transactionKey = $this->getRequest()->getParam('transaction_key');
-        $transactionKey = preg_replace('/[^\w]/', '', $transactionKey ?? '');
 
-        if (empty($transactionKey) || strlen($transactionKey) <= 0) {
+        if ($transactionKey === null || $transactionKey === '') {
+            return false;
+        }
+
+        $transactionKey = preg_replace('/[^\w]/', '', $transactionKey);
+
+        if (empty($transactionKey)) {
             return false;
         }
 


### PR DESCRIPTION
avoids deprecated warnings and cluttering logs for specific merchant