### PR TITLE
BP-4230-Add-support-for-PHP-8.4

### DIFF
--- a/Api/PaypalExpressOrderCreateInterface.php
+++ b/Api/PaypalExpressOrderCreateInterface.php
@@ -31,6 +31,6 @@ interface PaypalExpressOrderCreateInterface
      */
     public function execute(
         string $paypal_order_id,
-        string $cart_id = null
+        ?string $cart_id = null
     );
 }

--- a/Block/Adminhtml/Sales/Order/Creditmemo/Create/BankFields.php
+++ b/Block/Adminhtml/Sales/Order/Creditmemo/Create/BankFields.php
@@ -44,7 +44,7 @@ class BankFields extends Template
      */
     public function __construct(
         Context $context,
-        RefundFieldsFactory $refundFieldsFactory = null
+        ?RefundFieldsFactory $refundFieldsFactory = null
     ) {
         $this->refundFieldsFactory = $refundFieldsFactory;
         parent::__construct($context);

--- a/Block/Catalog/Product/View/Applepay.php
+++ b/Block/Catalog/Product/View/Applepay.php
@@ -78,7 +78,7 @@ class Applepay extends Template
         CompositeConfigProvider $compositeConfigProvider,
         ApplepayConfig $applepayConfigProvider,
         AccountConfig $accountConfigProvider,
-        Registry $registry = null,
+        ?Registry $registry = null,
         array $data = []
     ) {
         parent::__construct($context, $data);

--- a/Block/Catalog/Product/View/IdealFastCheckout.php
+++ b/Block/Catalog/Product/View/IdealFastCheckout.php
@@ -66,7 +66,7 @@ class IdealFastCheckout extends Template
         Encryptor $encryptor,
         Ideal $idealConfig,
         Repository $assetRepo,
-        Registry $registry = null,
+        ?Registry $registry = null,
         array $data = []
     ) {
         parent::__construct($context, $data);

--- a/Block/Catalog/Product/View/PaypalExpress.php
+++ b/Block/Catalog/Product/View/PaypalExpress.php
@@ -71,7 +71,7 @@ class PaypalExpress extends Template
         Account $configProviderAccount,
         Encryptor $encryptor,
         Paypal $paypalConfig,
-        Registry $registry = null,
+        ?Registry $registry = null,
         array $data = []
     ) {
         parent::__construct($context, $data);

--- a/Gateway/Command/GatewayCommand.php
+++ b/Gateway/Command/GatewayCommand.php
@@ -122,7 +122,7 @@ class GatewayCommand implements CommandInterface
         CancelOrder                 $cancelOrder,
         HandlerInterface            $handler = null,
         ValidatorInterface          $validator = null,
-        ErrorMessageMapperInterface $errorMessageMapper = null,
+        ?ErrorMessageMapperInterface $errorMessageMapper = null,
         SkipCommandInterface        $skipCommand = null
     ) {
         $this->requestBuilder = $requestBuilder;

--- a/Gateway/Request/Recipient/AfterpayOldDataBuilder.php
+++ b/Gateway/Request/Recipient/AfterpayOldDataBuilder.php
@@ -142,7 +142,7 @@ class AfterpayOldDataBuilder extends AbstractRecipientDataBuilder
      *
      * @return boolean
      */
-    private function isCompanyEmpty(string $company = null): bool
+    private function isCompanyEmpty(?string $company = null): bool
     {
         if (null === $company) {
             return true;

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -284,7 +284,7 @@ class Data extends AbstractHelper
      *
      * @throws BuckarooException
      */
-    public function getMode(string $paymentMethod = null, $store = null): int
+    public function getMode(?string $paymentMethod = null, $store = null): int
     {
         $baseMode = $this->configProviderAccount->getActive();
 

--- a/Model/Adapter/BuckarooAdapter.php
+++ b/Model/Adapter/BuckarooAdapter.php
@@ -102,7 +102,7 @@ class BuckarooAdapter
         ProductMetadataInterface $productMetadata,
         Resolver $localeResolver,
         StoreManagerInterface $storeManager,
-        array $mapPaymentMethods = null
+        ?array $mapPaymentMethods = null
     ) {
         $this->mapPaymentMethods = $mapPaymentMethods;
         $this->logger = $logger;

--- a/Model/Config/Backend/AllowedCurrencies.php
+++ b/Model/Config/Backend/AllowedCurrencies.php
@@ -74,8 +74,8 @@ class AllowedCurrencies extends Value
         ConfigAllowedCurrencies $configProvider,
         CurrencyBundle $currencyBundle,
         ResolverInterface $localeResolver,
-        AbstractResource $resource = null,
-        AbstractDb $resourceCollection = null,
+        ?AbstractResource $resource = null,
+        ?AbstractDb $resourceCollection = null,
         array $data = []
     ) {
         parent::__construct($context, $registry, $config, $cacheTypeList, $resource, $resourceCollection, $data);

--- a/Model/Config/Backend/TransactionLabel.php
+++ b/Model/Config/Backend/TransactionLabel.php
@@ -54,8 +54,8 @@ class TransactionLabel extends Value
         Registry $registry,
         ScopeConfigInterface $config,
         TypeListInterface $cacheTypeList,
-        AbstractResource $resource = null,
-        AbstractDb $resourceCollection = null,
+        ?AbstractResource $resource = null,
+        ?AbstractDb $resourceCollection = null,
         array $data = []
     ) {
         $this->storeManagerInterface = $storeManagerInterface;

--- a/Model/Config/Source/AllowedCountries.php
+++ b/Model/Config/Source/AllowedCountries.php
@@ -76,7 +76,7 @@ class AllowedCountries implements OptionSourceInterface
      * @return array Format: array(array('value' => '<value>', 'label' => '<label>'), ...)
      * @throws BuckarooException
      */
-    public function toOptionArray(string $method = null): array
+    public function toOptionArray(?string $method = null): array
     {
         if (!$method || !is_string($method)) {
             return $this->localeLists->getOptionCountries();
@@ -112,7 +112,7 @@ class AllowedCountries implements OptionSourceInterface
      * @return array
      * @throws BuckarooException
      */
-    public function __call(string $method, array $params = null)
+    public function __call(string $method, ?array $params = null)
     {
         return $this->toOptionArray($method);
     }

--- a/Model/Config/Source/AllowedCurrencies.php
+++ b/Model/Config/Source/AllowedCurrencies.php
@@ -86,7 +86,7 @@ class AllowedCurrencies implements OptionSourceInterface
      * @return array
      * @throws BuckarooException
      */
-    public function __call(string $method, array $params = null)
+    public function __call(string $method, ?array $params = null)
     {
         return $this->toOptionArray($method);
     }
@@ -98,7 +98,7 @@ class AllowedCurrencies implements OptionSourceInterface
      * @return array Format: array(array('value' => '<value>', 'label' => '<label>'), ...)
      * @throws BuckarooException
      */
-    public function toOptionArray(string $method = null): array
+    public function toOptionArray(?string $method = null): array
     {
         $currencies = $this->allowedCurrenciesConfig->getAllowedCurrencies();
         if ($method) {

--- a/Model/ConfigProvider/AbstractConfigProvider.php
+++ b/Model/ConfigProvider/AbstractConfigProvider.php
@@ -57,7 +57,7 @@ abstract class AbstractConfigProvider implements ConfigProviderInterface, Config
      */
     public function __construct(
         ScopeConfigInterface $scopeConfig,
-        string $methodCode = null,
+        ?string $methodCode = null,
         string $pathPattern = self::DEFAULT_PATH_PATTERN
     ) {
         $this->scopeConfig = $scopeConfig;

--- a/Model/ConfigProvider/Account.php
+++ b/Model/ConfigProvider/Account.php
@@ -212,7 +212,7 @@ class Account extends AbstractConfigProvider
      * @param string|null $label
      * @return string
      */
-    public function getParsedLabel(Store $store, OrderInterface $order, string $label = null)
+    public function getParsedLabel(Store $store, OrderInterface $order, ?string $label = null)
     {
         if ($label === null) {
             $label = $this->getTransactionLabel($store);

--- a/Model/ConfigProvider/Idin.php
+++ b/Model/ConfigProvider/Idin.php
@@ -196,7 +196,7 @@ class Idin extends AbstractConfigProvider
      * @return array
      * @throws NoSuchEntityException
      */
-    public function getIdinStatus(Quote $quote, CustomerInterface $customer = null): array
+    public function getIdinStatus(Quote $quote, ?CustomerInterface $customer = null): array
     {
         if (!$this->checkCountry($customer) ||
             !$this->isIdinEnabled()
@@ -253,7 +253,7 @@ class Idin extends AbstractConfigProvider
      * @param CustomerInterface|null $customer
      * @return boolean
      */
-    protected function isCustomerVerified(CustomerInterface $customer = null): bool
+    protected function isCustomerVerified(?CustomerInterface $customer = null): bool
     {
         if ($customer === null) {
             return $this->checkoutSession->getCustomerIDINIsEighteenOrOlder() === true;

--- a/Model/ConfigProvider/Method/PayPerEmail.php
+++ b/Model/ConfigProvider/Method/PayPerEmail.php
@@ -81,7 +81,7 @@ class PayPerEmail extends AbstractConfigProvider
      * @param int|null $storeId
      * @return false|mixed
      */
-    public function getPaymentMethod(int $storeId = null)
+    public function getPaymentMethod(?int $storeId = null)
     {
         $paymentMethod = $this->getMethodConfigValue(self::XPATH_PAYPEREMAIL_PAYMENT_METHOD, $storeId);
 

--- a/Model/Giftcard/Api/GetTransactionsResponse.php
+++ b/Model/Giftcard/Api/GetTransactionsResponse.php
@@ -70,7 +70,7 @@ class GetTransactionsResponse extends DataObject implements GetTransactionsRespo
         CartRepositoryInterface $cartRepository,
         PaymentGroupTransaction $groupTransaction,
         TransactionResponseInterfaceFactory $trResponseFactory,
-        string $cartId = null
+        ?string $cartId = null
     ) {
         $this->quoteIdMaskFactory = $quoteIdMaskFactory;
         $this->cartRepository = $cartRepository;

--- a/Model/Method/BuckarooAdapter.php
+++ b/Model/Method/BuckarooAdapter.php
@@ -112,11 +112,11 @@ class BuckarooAdapter extends Adapter
         $infoBlockType,
         Factory $configProviderMethodFactory,
         Data $priceHelper,
-        RequestInterface $request = null,
-        CommandPoolInterface $commandPool = null,
-        ValidatorPoolInterface $validatorPool = null,
-        CommandManagerInterface $commandExecutor = null,
-        LoggerInterface $logger = null,
+        ?RequestInterface $request = null,
+        ?CommandPoolInterface $commandPool = null,
+        ?ValidatorPoolInterface $validatorPool = null,
+        ?CommandManagerInterface $commandExecutor = null,
+        ?LoggerInterface $logger = null,
         bool $usesRedirect = true
     ) {
         parent::__construct(
@@ -152,7 +152,7 @@ class BuckarooAdapter extends Adapter
     /**
      * @inheritdoc
      */
-    public function isAvailable(CartInterface $quote = null)
+    public function isAvailable(?CartInterface $quote = null)
     {
         if (null == $quote) {
             return false;

--- a/Model/Order/CreditmemoFactory.php
+++ b/Model/Order/CreditmemoFactory.php
@@ -71,7 +71,7 @@ class CreditmemoFactory extends MagentoCreditmemoFactory
         OrderFactory $convertOrderFactory,
         Config $taxConfig,
         BuckarooLoggerInterface $logger,
-        Json $serializer = null
+        ?Json $serializer = null
     ) {
         $this->logger = $logger;
         parent::__construct($convertOrderFactory, $taxConfig, $serializer);

--- a/Model/PaypalExpress/OrderCreate.php
+++ b/Model/PaypalExpress/OrderCreate.php
@@ -110,7 +110,7 @@ class OrderCreate implements PaypalExpressOrderCreateInterface
     /** @inheritDoc */
     public function execute(
         string $paypal_order_id,
-        string $cart_id = null
+        ?string $cart_id = null
     ) {
         try {
             $orderId = $this->createOrder($paypal_order_id, $cart_id);

--- a/Model/PaypalExpress/QuoteCreate.php
+++ b/Model/PaypalExpress/QuoteCreate.php
@@ -116,7 +116,7 @@ class QuoteCreate implements PaypalExpressQuoteCreateInterface
     public function execute(
         ShippingAddressRequestInterface $shipping_address,
         string $page,
-        string $form_data = null
+        ?string $form_data = null
     ) {
         if ($page === 'product' && is_string($form_data)) {
             $this->quote = $this->createQuote($form_data);

--- a/Model/PaypalStateCodes.php
+++ b/Model/PaypalStateCodes.php
@@ -581,7 +581,7 @@ class PaypalStateCodes
      *
      * @return bool|array
      */
-    public function getValuesFromCodes(string $countryCode = null, string $stateCode = null)
+    public function getValuesFromCodes(?string $countryCode = null, ?string $stateCode = null)
     {
         // We need a countryCode + stateCode and for it to exist in codes
         if (!$countryCode || !$stateCode || !isset($this->codes[$countryCode])) {
@@ -604,7 +604,7 @@ class PaypalStateCodes
      * @param string|null $value
      * @return false|string
      */
-    public function getCodeFromValue(string $countryCode = null, string $value = null)
+    public function getCodeFromValue(?string $countryCode = null, ?string $value = null)
     {
         // We need a countryCode + value and for it to exist in codes
         if (!$countryCode || !$value || !isset($this->codes[$countryCode])) {

--- a/Model/Push/DefaultProcessor.php
+++ b/Model/Push/DefaultProcessor.php
@@ -323,7 +323,7 @@ class DefaultProcessor implements PushProcessorInterface
      * @SuppressWarnings(PHPMD.CyclomaticComplexity)
      * @SuppressWarnings(PHPMD.NPathComplexity)
      */
-    protected function receivePushCheckDuplicates(int $receivedStatusCode = null, string $trxId = null): bool
+    protected function receivePushCheckDuplicates(?int $receivedStatusCode = null, ?string $trxId = null): bool
     {
         $save = false;
         if (!$receivedStatusCode) {

--- a/Model/Total/Quote/Tax/BuckarooFee.php
+++ b/Model/Total/Quote/Tax/BuckarooFee.php
@@ -104,8 +104,8 @@ class BuckarooFee extends CommonTaxCollector
         PaymentGroupTransaction $groupTransaction,
         Calculate $calculate,
         \Buckaroo\Magento2\Model\ConfigProvider\BuckarooFee $configProviderBuckarooFee,
-        TaxHelper $taxHelper = null,
-        QuoteDetailsItemExtensionInterfaceFactory $quoteDetailsItemExtensionInterfaceFactory = null,
+        ?TaxHelper $taxHelper = null,
+        ?QuoteDetailsItemExtensionInterfaceFactory $quoteDetailsItemExtensionInterfaceFactory = null,
         ?CustomerAccountManagement $customerAccountManagement = null
     ) {
         $parent = new \ReflectionClass(parent::class);

--- a/Plugin/CartManagement.php
+++ b/Plugin/CartManagement.php
@@ -65,7 +65,7 @@ class CartManagement
         CartManagementInterface $cardManagement,
         \Closure $proceed,
         $cartId,
-        PaymentInterface $paymentMethod = null
+        ?PaymentInterface $paymentMethod = null
     ) {
         /** @var Quote $quote */
         $quote = $this->quoteRepository->getActive($cartId);

--- a/Plugin/FixSession.php
+++ b/Plugin/FixSession.php
@@ -74,7 +74,7 @@ class FixSession
         PhpCookieManager $subject,
         string $name,
         string $value,
-        PublicCookieMetadata $metadata = null
+        ?PublicCookieMetadata $metadata = null
     ) {
         if (($metadata && method_exists($metadata, 'getSameSite') && ($name == $this->sessionManager->getName()))
             && $metadata->getSameSite() != 'None') {

--- a/Plugin/GuestSaveManager.php
+++ b/Plugin/GuestSaveManager.php
@@ -21,6 +21,8 @@
 namespace Buckaroo\Magento2\Plugin;
 
 use Buckaroo\Magento2\Logging\BuckarooLoggerInterface;
+use Magento\Quote\Api\Data\AddressInterface;
+use Magento\Quote\Api\Data\PaymentInterface;
 
 // @codingStandardsIgnoreStart
 
@@ -97,8 +99,8 @@ if (class_exists('\Onestepcheckout\Iosc\Plugin\GuestSaveManager')) {
          * @param $parent
          * @param $cartId
          * @param $email
-         * @param \Magento\Quote\Api\Data\PaymentInterface $paymentMethod
-         * @param \Magento\Quote\Api\Data\AddressInterface|null $billingAddress
+         * @param PaymentInterface $paymentMethod
+         * @param AddressInterface|null $billingAddress
          * @return void
          * @throws \Magento\Framework\Exception\NoSuchEntityException
          */
@@ -106,8 +108,8 @@ if (class_exists('\Onestepcheckout\Iosc\Plugin\GuestSaveManager')) {
             $parent,
             $cartId,
             $email,
-            \Magento\Quote\Api\Data\PaymentInterface $paymentMethod,
-            \Magento\Quote\Api\Data\AddressInterface $billingAddress = null
+            PaymentInterface $paymentMethod,
+            ?AddressInterface $billingAddress = null
         ) {
             if ($billingAddress == null) {
                 $quoteIdMask = $this->quoteIdMaskFactory->create()->load($cartId, 'masked_id');
@@ -130,8 +132,8 @@ if (class_exists('\Onestepcheckout\Iosc\Plugin\GuestSaveManager')) {
          * @param $parent
          * @param $cartId
          * @param $email
-         * @param \Magento\Quote\Api\Data\PaymentInterface $paymentMethod
-         * @param \Magento\Quote\Api\Data\AddressInterface|null $billingAddress
+         * @param PaymentInterface $paymentMethod
+         * @param AddressInterface|null $billingAddress
          * @return void
          * @throws \Magento\Framework\Exception\NoSuchEntityException
          */
@@ -139,8 +141,8 @@ if (class_exists('\Onestepcheckout\Iosc\Plugin\GuestSaveManager')) {
             $parent,
             $cartId,
             $email,
-            \Magento\Quote\Api\Data\PaymentInterface $paymentMethod,
-            \Magento\Quote\Api\Data\AddressInterface $billingAddress = null
+            PaymentInterface $paymentMethod,
+            ?AddressInterface $billingAddress = null
         ) {
             if ($billingAddress == null) {
                 $quoteIdMask = $this->quoteIdMaskFactory->create()->load($cartId, 'masked_id');

--- a/Service/PayReminderService.php
+++ b/Service/PayReminderService.php
@@ -78,7 +78,7 @@ class PayReminderService
      * @param string|null $incrementId
      * @return float
      */
-    public function getAlreadyPaid(string $incrementId = null): float
+    public function getAlreadyPaid(?string $incrementId = null): float
     {
         if (empty($this->alreadyPaid)) {
             $this->setAlreadyPaid($this->paymentGroupTransaction->getAlreadyPaid($incrementId));


### PR DESCRIPTION
add nullable type hints for various parameters across multiple classes to improve code clarity and compatibility with PHP 8.4