### PR TITLE
BP-3564-Incorrect-calculation-of-Grand-Total-Excluding-Tax-in-js-978

### DIFF
--- a/view/frontend/web/js/view/checkout/summary/remaining-amount.js
+++ b/view/frontend/web/js/view/checkout/summary/remaining-amount.js
@@ -11,14 +11,17 @@ define([
             template: 'Buckaroo_Magento2/checkout/summary/remaining-amount'
         },
         isDisplayed: function () {
-            return this.getAlreadyPaidTotal() < 0;
+            return this.getRemainingAmount() > 0;
         },
         getValue: function () {
+            return this.getFormattedPrice(this.getRemainingAmount());
+        },
+        getRemainingAmount: function () {
             var remainingAmount = 0;
             if (totals.getSegment('remaining_amount')) {
                 remainingAmount = totals.getSegment('remaining_amount').value;
             }
-            return this.getFormattedPrice(remainingAmount);
+            return parseFloat(remainingAmount) || 0;
         },
         getAlreadyPaidTotal: function () {
             var remainingAmount = 0;

--- a/view/frontend/web/js/view/payment/method-renderer/giftcards.js
+++ b/view/frontend/web/js/view/payment/method-renderer/giftcards.js
@@ -28,6 +28,8 @@ define(
         'mage/translate',
         'mage/url',
         'Magento_Ui/js/modal/alert',
+        'Magento_Checkout/js/action/get-totals',
+        'Magento_Customer/js/customer-data',
     ],
     function (
         $,
@@ -38,6 +40,8 @@ define(
         $t,
         url,
         alert,
+        getTotalsAction,
+        customerData,
     ) {
         'use strict';
 
@@ -58,6 +62,13 @@ define(
             });
             $('.buckaroo_magento2_flow_authorize').remove();
             checkLabels();
+        }
+
+        function refreshTotals()
+        {
+            var deferred = $.Deferred();
+            getTotalsAction([], deferred);
+            customerData.reload(['cart'], true);
         }
 
         return Component.extend(
@@ -197,6 +208,8 @@ define(
                             }
                             checkPayments();
                         }
+                        // Refresh checkout summary totals so 'Already Paid' and 'Remaining Amount' appear immediately
+                        refreshTotals();
                         if (data.error) {
                                 alert({
                                     title: $t('Error'),

--- a/view/frontend/web/js/view/payment/method-renderer/voucher.js
+++ b/view/frontend/web/js/view/payment/method-renderer/voucher.js
@@ -25,6 +25,8 @@ define(
         'Magento_Ui/js/modal/alert',
         'mage/url',
         'mage/translate',
+        'Magento_Checkout/js/action/get-totals',
+        'Magento_Customer/js/customer-data',
     ],
     function (
         $,
@@ -32,6 +34,8 @@ define(
         alert,
         url,
         $t,
+        getTotalsAction,
+        customerData,
     ) {
         'use strict';
 
@@ -70,6 +74,11 @@ define(
                             }
 
                             this.isSubmitting(false);
+
+                            // Ensure checkout summary totals are refreshed so custom totals appear immediately
+                            var deferred = $.Deferred();
+                            getTotalsAction([], deferred);
+                            customerData.reload(['cart'], true);
 
                             if (data.error) {
                                 self.displayErrorModal(self, data.error);


### PR DESCRIPTION
fix: refresh checkout summary totals to display 'Already Paid' and 'Remaining Amount' immediately