### PR TITLE
BP-4579-Order-fails-with-PayByBank-Error-Payment-data-object-should-be-provided

### DIFF
--- a/Gateway/Validator/IssuerValidator.php
+++ b/Gateway/Validator/IssuerValidator.php
@@ -21,7 +21,6 @@ declare(strict_types=1);
 
 namespace Buckaroo\Magento2\Gateway\Validator;
 
-use Buckaroo\Magento2\Gateway\Helper\SubjectReader;
 use Buckaroo\Magento2\Model\ConfigProvider\Method\ConfigProviderInterface;
 use Buckaroo\Magento2\Model\ConfigProvider\Factory;
 use Magento\Framework\App\Request\Http as HttpRequest;
@@ -78,9 +77,7 @@ class IssuerValidator extends AbstractValidator
      */
     public function validate(array $validationSubject): ResultInterface
     {
-        $paymentDO = SubjectReader::readPayment($validationSubject);
-        /** @var InfoInterface $paymentInfo */
-        $paymentInfo = $paymentDO->getPayment();
+        $paymentInfo = $validationSubject['payment'];
         $config = $this->getConfig($paymentInfo);
 
         if (method_exists($config, 'canShowIssuers') && !$config->canShowIssuers()) {


### PR DESCRIPTION
refactor: simplify payment information retrieval in IssuerValidator