### PR TITLE
Bp 4926 two consumer financial warning settings showing for billink on the configuration tab

### DIFF
--- a/etc/adminhtml/system/payment_methods/billink.xml
+++ b/etc/adminhtml/system/payment_methods/billink.xml
@@ -157,13 +157,6 @@
                 </depends>
             </field>
 
-            <field id="financial_warning" translate="label comment" type="select" sortOrder="35" showInDefault="1" showInWebsite="1" showInStore="1">
-                <label>Consumer Financial Warning</label>
-                <comment><![CDATA[Due to the regulations for BNPL methods in The Netherlands you’ll  have to warn customers about using a BNPL plan because it can be easy to get into debt. When enabled a warning will be showed in the checkout. Please note that this setting only applies for customers in The Netherlands.]]></comment>
-                <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
-                <config_path>payment/buckaroo_magento2_billink/financial_warning</config_path>
-            </field>
-
             <group id="buckaroo_magento2_visibility" translate="label" type="text" sortOrder="70" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>Method visibility</label>
                 <field id="min_amount" translate="label comment tooltip" type="text" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">


### PR DESCRIPTION
update: remove Consumer Financial Warning setting from Billink configuration