### PR TITLE
BP-5036-Cannot-assign-null-to-property-Buckaroo-PaymentMethods-KlarnaKP-Models-Payload-reservationNumber-of-type-string-in

### DIFF
--- a/Controller/Redirect/Process.php
+++ b/Controller/Redirect/Process.php
@@ -397,8 +397,25 @@ class Process extends Action implements HttpPostActionInterface, HttpGetActionIn
             && !empty($this->redirectRequest->getServiceKlarnakpReservationnumber()));
 
         if (empty($this->order->getBuckarooReservationNumber()) && $isKlarnaKpReserve) {
-            $this->order->setBuckarooReservationNumber($this->redirectRequest->getServiceKlarnakpReservationnumber());
+            $reservationNumber = $this->redirectRequest->getServiceKlarnakpReservationnumber();
+            $this->order->setBuckarooReservationNumber($reservationNumber);
             $this->order->save();
+            
+            $this->logger->addDebug(sprintf(
+                '[KLARNA_KP] | [REDIRECT] | [%s:%s] - Saved reservation number from redirect for order %s: %s',
+                __METHOD__,
+                __LINE__,
+                $this->order->getIncrementId(),
+                $reservationNumber
+            ));
+        } elseif ($isKlarnaKpReserve) {
+            $this->logger->addDebug(sprintf(
+                '[KLARNA_KP] | [REDIRECT] | [%s:%s] - Reservation number already exists for order %s: %s',
+                __METHOD__,
+                __LINE__,
+                $this->order->getIncrementId(),
+                $this->order->getBuckarooReservationNumber()
+            ));
         }
 
         if (!$this->order->getEmailSent()

--- a/Model/Push/KlarnaKpProcessor.php
+++ b/Model/Push/KlarnaKpProcessor.php
@@ -123,11 +123,40 @@ class KlarnaKpProcessor extends DefaultProcessor
 
     protected function setBuckarooReservationNumber(): bool
     {
-        if (!empty($this->pushRequest->getServiceKlarnakpReservationnumber())) {
-            $this->order->setBuckarooReservationNumber($this->pushRequest->getServiceKlarnakpReservationnumber());
+        $reservationNumberFromPush = $this->pushRequest->getServiceKlarnakpReservationnumber();
+        
+        $this->logger->addDebug(sprintf(
+            '[KLARNA_KP] | [%s:%s] - setBuckarooReservationNumber called for order %s | ' .
+            'currentReservationNumber: %s | pushReservationNumber: %s',
+            __METHOD__,
+            __LINE__,
+            $this->order->getIncrementId(),
+            $this->order->getBuckarooReservationNumber() ?? 'NULL',
+            $reservationNumberFromPush ?? 'NULL'
+        ));
+        
+        if (!empty($reservationNumberFromPush)) {
+            $this->order->setBuckarooReservationNumber($reservationNumberFromPush);
             $this->order->save();
+            
+            $this->logger->addDebug(sprintf(
+                '[KLARNA_KP] | [%s:%s] - Successfully saved reservation number from PUSH for order %s: %s',
+                __METHOD__,
+                __LINE__,
+                $this->order->getIncrementId(),
+                $reservationNumberFromPush
+            ));
+            
             return true;
         }
+
+        $this->logger->addWarning(sprintf(
+            '[KLARNA_KP] | [%s:%s] - No reservation number in PUSH for order %s! ' .
+            'Push data may be incomplete or this is not a reserve transaction.',
+            __METHOD__,
+            __LINE__,
+            $this->order->getIncrementId()
+        ));
 
         return false;
     }


### PR DESCRIPTION
update: enhance logging and handle reservation number assignment for Klarna KP transactions