### PR TITLE
Bp 5065 fix refund failure when sales order has no client ip address str contains type error

### DIFF
--- a/Gateway/Request/BasicParameter/ClientIPDataBuilder.php
+++ b/Gateway/Request/BasicParameter/ClientIPDataBuilder.php
@@ -76,9 +76,9 @@ class ClientIPDataBuilder implements BuilderInterface
      * Get client ip
      *
      * @param Order $order
-     * @return false|float|string|null
+     * @return string
      */
-    public function getIp(Order $order)
+    public function getIp(Order $order): string
     {
         $ip = $order->getRemoteIp();
         $store = $order->getStore();
@@ -97,7 +97,8 @@ class ClientIPDataBuilder implements BuilderInterface
                 $headers
             );
 
-            return $remoteAddress->getRemoteAddress();
+            $remoteIp = $remoteAddress->getRemoteAddress();
+            return $remoteIp ?: '0.0.0.0';
         }
 
         // trustly anyway should be w/o private ip
@@ -117,7 +118,7 @@ class ClientIPDataBuilder implements BuilderInterface
             $ip = $remoteAddress->getRemoteAddress();
         }
 
-        return $ip;
+        return (string)$ip ?: '0.0.0.0';
     }
 
     /**


### PR DESCRIPTION
[…'0.0.0.0'](fix: ensure client IP retrieval returns a valid string or default to '0.0.0.0')