### PR TITLE
BP-5098-Refunding-Giftcards-doesn-t-work

### DIFF
--- a/Block/AdminInfo.php
+++ b/Block/AdminInfo.php
@@ -146,11 +146,11 @@ class AdminInfo extends ConfigurableInfo
     /**
      * Get giftcard logo url by code
      *
-     * @param string $code
+     * @param array $code Giftcard array with 'code' and 'logo' keys
      *
      * @return string
      */
-    public function getGiftcardLogo(string $code): string
+    public function getGiftcardLogo(array $code): string
     {
         return $this->logoService->getGiftcardLogo($code);
     }

--- a/Gateway/Request/BasicParameter/PaymentMethodDataBuilder.php
+++ b/Gateway/Request/BasicParameter/PaymentMethodDataBuilder.php
@@ -22,11 +22,27 @@ declare(strict_types=1);
 namespace Buckaroo\Magento2\Gateway\Request\BasicParameter;
 
 use Buckaroo\Magento2\Gateway\Helper\SubjectReader;
+use Buckaroo\Magento2\Helper\PaymentGroupTransaction;
 use Buckaroo\Magento2\Model\Method\BuckarooAdapter;
 use Magento\Payment\Gateway\Request\BuilderInterface;
 
 class PaymentMethodDataBuilder implements BuilderInterface
 {
+    /**
+     * @var PaymentGroupTransaction
+     */
+    private $paymentGroupTransaction;
+
+    /**
+     * Constructor
+     *
+     * @param PaymentGroupTransaction $paymentGroupTransaction
+     */
+    public function __construct(
+        PaymentGroupTransaction $paymentGroupTransaction
+    ) {
+        $this->paymentGroupTransaction = $paymentGroupTransaction;
+    }
 
     /**
      * @inheritdoc
@@ -35,9 +51,35 @@ class PaymentMethodDataBuilder implements BuilderInterface
     {
         $paymentDO = SubjectReader::readPayment($buildSubject);
         $payment = $paymentDO->getPayment();
+        $order = $paymentDO->getOrder();
 
         $method = $payment->getMethodInstance()->getCode() ?? 'buckaroo_magento2_ideal';
         $providerType = str_replace('buckaroo_magento2_', '', $method);
+
+        // Edge case: If method is "giftcards" but no group transactions exist,
+        // it means the user selected giftcard but paid 100% with another method (e.g., iDEAL)
+        // Get the actual payment method from transaction details
+        if ($providerType === 'giftcards') {
+            $groupTransactionAmount = $this->paymentGroupTransaction->getGroupTransactionAmount(
+                $order->getOrderIncrementId()
+            );
+            
+            // No group transactions = no giftcards were actually used
+            if ($groupTransactionAmount <= 0) {
+                $rawDetailsInfo = $payment->getAdditionalInformation('raw_details_info');
+                
+                if (is_array($rawDetailsInfo) && !empty($rawDetailsInfo)) {
+                    $firstTransaction = reset($rawDetailsInfo);
+                    if (isset($firstTransaction['brq_transaction_method'])) {
+                        $actualMethod = strtolower($firstTransaction['brq_transaction_method']);
+                        // Only override if it's not a giftcard service and not empty
+                        if ($actualMethod !== 'giftcards' && !empty($actualMethod)) {
+                            $providerType = $actualMethod;
+                        }
+                    }
+                }
+            }
+        }
 
         return [
             'payment_method' => $providerType,

--- a/Model/Giftcard/Response/Giftcard.php
+++ b/Model/Giftcard/Response/Giftcard.php
@@ -129,9 +129,6 @@ class Giftcard
 
         if ($this->response->isSuccess()) {
             $this->saveGroupTransaction();
-            if ($this->quote->getGrandTotal() > $this->response->getAmount()) {
-                $this->createOrderFromQuote();
-            }
         } else {
             $this->saveGroupTransaction();
             $this->createOrderFromQuote();
@@ -167,7 +164,7 @@ class Giftcard
             $order = $order ?? $this->createOrder();
         }
 
-        if ($order) {
+        if ($order && $order->getEntityId()) {
             $this->quote->setOrigOrderId($order->getEntityId());
         }
 
@@ -180,8 +177,11 @@ class Giftcard
             $orderId
         ));
 
-        $this->quote->setIsActive(true);
-        $this->quote->save();
+        // Keep quote active only if order was created
+        if ($order && $order->getEntityId()) {
+            $this->quote->setIsActive(true);
+            $this->quote->save();
+        }
 
         return $order;
     }

--- a/view/adminhtml/templates/info/payment_method.phtml
+++ b/view/adminhtml/templates/info/payment_method.phtml
@@ -25,7 +25,30 @@
 ?>
 <?php /** @var \Buckaroo\Magento2\Model\Method\BuckarooAdapter $method */ ?>
 <?php
-if ($giftCards = $block->getGiftCards()) {
+// Check if this is a mixed payment (group transaction with multiple payment methods)
+$allPaymentMethods = $block->getAllGroupTransactionPaymentMethods();
+if (!empty($allPaymentMethods)) {
+    // Display all payment methods for mixed payments
+    foreach ($allPaymentMethods as $paymentMethod) { ?>
+        <div class="bk-payment-wrap">
+            <div class="bk-img-wrap">
+                <?php if ($paymentMethod['type'] === 'giftcard'): ?>
+                    <img src="<?php echo $block->escapeHtml($block->getGiftcardLogo($paymentMethod)) ?>" alt=""/>
+                <?php else: ?>
+                    <img src="<?php echo $block->escapeHtml($block->getPaymentLogo($paymentMethod['code'])) ?>" alt=""/>
+                <?php endif; ?>
+            </div>
+            <div class="bk-label-wrap">
+                <?php echo $block->escapeHtml($paymentMethod['label']) ?>
+                <?php if (isset($paymentMethod['amount'])): ?>
+                    <span style="color: #666; font-size: 0.9em;"> (€<?php echo $block->escapeHtml(number_format((float)$paymentMethod['amount'], 2)) ?>)</span>
+                <?php endif; ?>
+            </div>
+        </div>
+        <?php
+    }
+} elseif ($giftCards = $block->getGiftCards()) {
+    // Fallback to old logic for giftcard-only payments (backward compatibility)
     foreach ($giftCards as $giftCard) { ?>
         <div class="bk-payment-wrap">
             <div class="bk-img-wrap">
@@ -38,17 +61,19 @@ if ($giftCards = $block->getGiftCards()) {
         <?php
     }
     $additionalInfo = $block->getGiftcardAdditionalData();
-    $methodTitle = $block->getPaymentLogo(strtolower(str_replace('Buckaroo ', '', $additionalInfo['method_title'])));
-    ?>
-    <div class="bk-payment-wrap">
-        <div class="bk-img-wrap">
-            <img src=" <?php echo $block->escapeHtml($methodTitle) ?>" alt=""/>
+    if ($additionalInfo && isset($additionalInfo['method_title'])) {
+        $methodTitle = $block->getPaymentLogo(strtolower(str_replace('Buckaroo ', '', $additionalInfo['method_title'])));
+        ?>
+        <div class="bk-payment-wrap">
+            <div class="bk-img-wrap">
+                <img src=" <?php echo $block->escapeHtml($methodTitle) ?>" alt=""/>
+            </div>
+            <div class="bk-label-wrap">
+                <?php echo $block->escapeHtml($additionalInfo['method_title']) ?>
+            </div>
         </div>
-        <div class="bk-label-wrap">
-            <?php echo $block->escapeHtml($additionalInfo['method_title']) ?>
-        </div>
-    </div>
-    <?php
+        <?php
+    }
 }
 ?>
 
@@ -60,17 +85,45 @@ if ($method = $block->getPayPerEmailMethod()) { ?>
 <?php } ?>
 
 <?php $method = $block->getMethod(); ?>
-<div class="bk-payment-wrap">
-    <?php if ($method->buckarooPaymentMethodCode !== 'voucher' && $method->buckarooPaymentMethodCode !== 'giftcards') { ?>
-        <div class="bk-img-wrap">
-            <img src=" <?php echo $block->escapeHtml($block->getPaymentLogo($method->buckarooPaymentMethodCode)) ?>"
-                 alt=""/>
-        </div>
-        <div class="bk-label-wrap">
-            <?php echo $block->escapeHtml($block->getMethod()->getTitle()) ?>
-        </div>
-    <?php } ?>
-</div>
+<?php // Only show this section if we haven't already displayed payment methods via group transactions ?>
+<?php if (empty($allPaymentMethods)): ?>
+    <?php 
+    // If payment method is giftcards/voucher but no group transactions exist,
+    // it means the user selected giftcard but paid with something else (e.g., full payment via iDEAL)
+    // In this case, we should show the ACTUAL payment method used
+    $hasGroupTransactions = !empty($block->getGiftCards());
+    $showPaymentMethod = $method->buckarooPaymentMethodCode !== 'voucher' 
+                         && $method->buckarooPaymentMethodCode !== 'giftcards';
+    
+    $displayCode = $method->buckarooPaymentMethodCode;
+    $displayTitle = $block->getMethod()->getTitle();
+    
+    // Edge case: giftcards method selected but no actual giftcards used
+    // Get the actual payment method from transaction details
+    if (!$showPaymentMethod && !$hasGroupTransactions) {
+        $actualMethod = $block->getActualPaymentMethodFromTransaction();
+        if ($actualMethod) {
+            $displayCode = $actualMethod['code'];
+            $displayTitle = $actualMethod['label'];
+            $showPaymentMethod = true;
+        } else {
+            // Fallback: still show the selected method
+            $showPaymentMethod = true;
+        }
+    }
+    ?>
+    <div class="bk-payment-wrap">
+        <?php if ($showPaymentMethod) { ?>
+            <div class="bk-img-wrap">
+                <img src=" <?php echo $block->escapeHtml($block->getPaymentLogo($displayCode)) ?>"
+                     alt=""/>
+            </div>
+            <div class="bk-label-wrap">
+                <?php echo $block->escapeHtml($displayTitle) ?>
+            </div>
+        <?php } ?>
+    </div>
+<?php endif; ?>
 
 <?php if ($specificPaymentDetails = $block->getSpecificPaymentDetails()) : ?>
     <div class="bk-payment-wrap">

--- a/view/frontend/web/template/payment/buckaroo_magento2_giftcards.html
+++ b/view/frontend/web/template/payment/buckaroo_magento2_giftcards.html
@@ -119,7 +119,7 @@
                     <div class="fieldset card_front width-100">
 
                         <div class="field required width-100" >
-                            <label class="label" for="buckaroo_magento2_giftcards_cardnumber"> <span data-bind="i18n: 'Card number:'"> </span> </label>
+                            <label class="label" data-bind="attr: {'for': 'buckaroo_magento2_giftcards_cardnumber_' + code}"> <span data-bind="i18n: 'Card number:'"> </span> </label>
                             <div class="control">
                                 <input type="text"
                                        class="input-text field buckaroo_magento2_giftcards_input"
@@ -128,6 +128,7 @@
                                         valueUpdate: 'blur',
                                         value: $parent.cardNumber,
                                         attr: {
+                                            'id': 'buckaroo_magento2_giftcards_cardnumber_' + code,
                                             'data-card': code,
                                             'data-validate': JSON.stringify({ 'required': true })
                                         }">
@@ -139,7 +140,7 @@
                         <div class="magnet_stripe width-100"></div>
 
                         <div class="field required card_security width-100" >
-                            <label class="label width-65-l" for="buckaroo_magento2_giftcards_pin"> <span data-bind="i18n: 'PIN / Security code:'"> </span> </label>
+                            <label class="label width-65-l" data-bind="attr: {'for': 'buckaroo_magento2_giftcards_pin_' + code}"> <span data-bind="i18n: 'PIN / Security code:'"> </span> </label>
                             <div class="control card-info-input width-25-l">
                                 <input type="text"
                                        class="input-text field buckaroo_magento2_giftcards_input"
@@ -148,23 +149,20 @@
                                         valueUpdate: 'blur',
                                         value: $parent.pin,
                                         attr: {
+                                            'id': 'buckaroo_magento2_giftcards_pin_' + code,
                                             'data-validate': JSON.stringify({ 'required': true })
                                         }">
                             </div>
                         </div>
                     </div>
 
-                    <div class="field width-100">
-                        <span data-bind="i18n: 'Please make sure all fields are filled in correctly before proceeding.' "></span>
-                        <span class="apply-gift-card action primary" data-bind="
-                            click: $parent.applyGiftcard.bind($parent),
-                            i18n: 'Apply Gift Card'">
-                        </span>
-                    </div>
-
                     </div>
                 </fieldset>
             </form>
+
+            <div class="field width-100" style="margin-top: 15px;">
+                <span data-bind="i18n: 'Please make sure all fields are filled in correctly before proceeding.' "></span>
+            </div>
 
             <div class="checkout-agreements-block">
                 <!-- ko foreach: $parents[1].getRegion('before-place-order') -->
@@ -172,7 +170,24 @@
                 <!--/ko-->
             </div>
 
-             <!-- ko if: $parent.alreadyFullPayed() -->
+            <!-- ko if: !$parent.alreadyFullPayed() -->
+            <div class="actions-toolbar">
+                <div class="primary">
+                    <button class="action primary checkout"
+                            type="submit"
+                            data-bind="
+                            click: $parent.applyGiftcard.bind($parent),
+                            attr: {title: $t('Apply Gift Card')},
+                            enable: ($parent.getCode() == $parent.isChecked() && $parent.currentGiftcard() == code)
+                            "
+                            disabled>
+                        <span data-bind="i18n: 'Apply Gift Card'"></span>
+                    </button>
+                </div>
+            </div>
+            <!--/ko-->
+
+            <!-- ko if: $parent.alreadyFullPayed() -->
             <div class="actions-toolbar">
                 <div class="primary">
                     <button class="action primary checkout"


### PR DESCRIPTION
fix: improve mixed payment handling and display for giftcards and other methods

- Enhance payment method breakdown for mixed payments in admin and frontend
- Refactor giftcard logo retrieval to support array input
- Add logic to detect and display actual payment method when giftcards are selected but not used
- Update payment fee calculation to show separate lines for each payment method
- Respect Magento auto-return configuration for creditmemo item stock handling
- Improve giftcard form accessibility and UX in checkout