### PR TITLE
fix: enable reactivation of canceled orders on successful payment pus…

### DIFF
--- a/Model/Push/AfterpayProcessor.php
+++ b/Model/Push/AfterpayProcessor.php
@@ -29,7 +29,9 @@ use Buckaroo\Magento2\Model\ConfigProvider\Account;
 use Buckaroo\Magento2\Model\ConfigProvider\Method\Afterpay20;
 use Buckaroo\Magento2\Model\OrderStatusFactory;
 use Buckaroo\Magento2\Model\Service\GiftCardRefundService;
+use Buckaroo\Magento2\Service\Order\Uncancel;
 use Buckaroo\Magento2\Service\Push\OrderRequestService;
+use Magento\Framework\App\ResourceConnection;
 use Magento\Sales\Api\Data\TransactionInterface;
 
 class AfterpayProcessor extends DefaultProcessor
@@ -50,6 +52,8 @@ class AfterpayProcessor extends DefaultProcessor
      * @param OrderStatusFactory      $orderStatusFactory
      * @param Account                 $configAccount
      * @param GiftCardRefundService   $giftCardRefundService
+     * @param Uncancel                $uncancelService
+     * @param \Magento\Framework\App\ResourceConnection $resourceConnection
      * @param Afterpay20              $afterpayConfig
      *
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
@@ -65,6 +69,8 @@ class AfterpayProcessor extends DefaultProcessor
         OrderStatusFactory $orderStatusFactory,
         Account $configAccount,
         GiftCardRefundService $giftCardRefundService,
+        Uncancel $uncancelService,
+        \Magento\Framework\App\ResourceConnection $resourceConnection,
         Afterpay20 $afterpayConfig
     ) {
         parent::__construct(
@@ -77,7 +83,9 @@ class AfterpayProcessor extends DefaultProcessor
             $buckarooStatusCode,
             $orderStatusFactory,
             $configAccount,
-            $giftCardRefundService
+            $giftCardRefundService,
+            $uncancelService,
+            $resourceConnection
         );
         $this->afterpayConfig = $afterpayConfig;
     }

--- a/Model/Push/KlarnaKpProcessor.php
+++ b/Model/Push/KlarnaKpProcessor.php
@@ -29,7 +29,9 @@ use Buckaroo\Magento2\Model\ConfigProvider\Account;
 use Buckaroo\Magento2\Model\ConfigProvider\Method\Klarnakp;
 use Buckaroo\Magento2\Model\OrderStatusFactory;
 use Buckaroo\Magento2\Model\Service\GiftCardRefundService;
+use Buckaroo\Magento2\Service\Order\Uncancel;
 use Buckaroo\Magento2\Service\Push\OrderRequestService;
+use Magento\Framework\App\ResourceConnection;
 use Magento\Sales\Api\Data\TransactionInterface;
 use Magento\Sales\Model\Order;
 
@@ -54,6 +56,8 @@ class KlarnaKpProcessor extends DefaultProcessor
      * @param OrderStatusFactory      $orderStatusFactory
      * @param Account                 $configAccount
      * @param GiftCardRefundService   $giftCardRefundService
+     * @param Uncancel                $uncancelService
+     * @param ResourceConnection $resourceConnection
      * @param Klarnakp                $klarnakpConfig
      *
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
@@ -69,6 +73,8 @@ class KlarnaKpProcessor extends DefaultProcessor
         OrderStatusFactory $orderStatusFactory,
         Account $configAccount,
         GiftCardRefundService $giftCardRefundService,
+        Uncancel $uncancelService,
+        ResourceConnection $resourceConnection,
         Klarnakp $klarnakpConfig
     ) {
         parent::__construct(
@@ -81,7 +87,9 @@ class KlarnaKpProcessor extends DefaultProcessor
             $buckarooStatusCode,
             $orderStatusFactory,
             $configAccount,
-            $giftCardRefundService
+            $giftCardRefundService,
+            $uncancelService,
+            $resourceConnection
         );
         $this->klarnakpConfig = $klarnakpConfig;
     }

--- a/Model/Push/PayPerEmailProcessor.php
+++ b/Model/Push/PayPerEmailProcessor.php
@@ -32,7 +32,9 @@ use Buckaroo\Magento2\Model\ConfigProvider\Method\PayPerEmail;
 use Buckaroo\Magento2\Model\Method\BuckarooAdapter;
 use Buckaroo\Magento2\Model\OrderStatusFactory;
 use Buckaroo\Magento2\Model\Service\GiftCardRefundService;
+use Buckaroo\Magento2\Service\Order\Uncancel;
 use Buckaroo\Magento2\Service\Push\OrderRequestService;
+use Magento\Framework\App\ResourceConnection;
 use Magento\Framework\Exception\FileSystemException;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Sales\Api\Data\TransactionInterface;
@@ -66,6 +68,8 @@ class PayPerEmailProcessor extends DefaultProcessor
      * @param OrderStatusFactory      $orderStatusFactory
      * @param Account                 $configAccount
      * @param GiftCardRefundService   $giftCardRefundService
+     * @param Uncancel                $uncancelService
+     * @param \Magento\Framework\App\ResourceConnection $resourceConnection
      * @param PayPerEmail             $configPayPerEmail
      *
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
@@ -81,6 +85,8 @@ class PayPerEmailProcessor extends DefaultProcessor
         OrderStatusFactory      $orderStatusFactory,
         Account                 $configAccount,
         GiftCardRefundService   $giftCardRefundService,
+        Uncancel                $uncancelService,
+        ResourceConnection      $resourceConnection,
         PayPerEmail             $configPayPerEmail
     ) {
         parent::__construct(
@@ -93,7 +99,9 @@ class PayPerEmailProcessor extends DefaultProcessor
             $buckarooStatusCode,
             $orderStatusFactory,
             $configAccount,
-            $giftCardRefundService
+            $giftCardRefundService,
+            $uncancelService,
+            $resourceConnection
         );
         $this->configPayPerEmail = $configPayPerEmail;
     }

--- a/Model/Push/PaypalProcessor.php
+++ b/Model/Push/PaypalProcessor.php
@@ -30,7 +30,9 @@ use Buckaroo\Magento2\Model\ConfigProvider\Account;
 use Buckaroo\Magento2\Model\ConfigProvider\Method\Paypal as PaypalConfig;
 use Buckaroo\Magento2\Model\OrderStatusFactory;
 use Buckaroo\Magento2\Model\Service\GiftCardRefundService;
+use Buckaroo\Magento2\Service\Order\Uncancel;
 use Buckaroo\Magento2\Service\Push\OrderRequestService;
+use Magento\Framework\App\ResourceConnection;
 use Magento\Framework\Exception\LocalizedException;
 use Magento\Sales\Api\Data\TransactionInterface;
 
@@ -52,6 +54,8 @@ class PaypalProcessor extends DefaultProcessor
      * @param OrderStatusFactory      $orderStatusFactory
      * @param Account                 $configAccount
      * @param GiftCardRefundService   $giftCardRefundService
+     * @param Uncancel                $uncancelService
+     * @param ResourceConnection $resourceConnection
      * @param PaypalConfig            $paypalConfig
      *
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
@@ -67,6 +71,8 @@ class PaypalProcessor extends DefaultProcessor
         OrderStatusFactory $orderStatusFactory,
         Account $configAccount,
         GiftCardRefundService $giftCardRefundService,
+        Uncancel $uncancelService,
+        ResourceConnection $resourceConnection,
         PaypalConfig $paypalConfig
     ) {
         parent::__construct(
@@ -79,7 +85,9 @@ class PaypalProcessor extends DefaultProcessor
             $buckarooStatusCode,
             $orderStatusFactory,
             $configAccount,
-            $giftCardRefundService
+            $giftCardRefundService,
+            $uncancelService,
+            $resourceConnection
         );
         $this->paypalConfig = $paypalConfig;
     }

--- a/Model/Push/RefundProcessor.php
+++ b/Model/Push/RefundProcessor.php
@@ -31,7 +31,9 @@ use Buckaroo\Magento2\Model\ConfigProvider\Account;
 use Buckaroo\Magento2\Model\OrderStatusFactory;
 use Buckaroo\Magento2\Model\Refund\Push as RefundPush;
 use Buckaroo\Magento2\Model\Service\GiftCardRefundService;
+use Buckaroo\Magento2\Service\Order\Uncancel;
 use Buckaroo\Magento2\Service\Push\OrderRequestService;
+use Magento\Framework\App\ResourceConnection;
 use Magento\Sales\Api\Data\TransactionInterface;
 
 /**
@@ -55,6 +57,8 @@ class RefundProcessor extends DefaultProcessor
      * @param OrderStatusFactory      $orderStatusFactory
      * @param Account                 $configAccount
      * @param GiftCardRefundService   $giftCardRefundService
+     * @param Uncancel                $uncancelService
+     * @param ResourceConnection $resourceConnection
      * @param RefundPush              $refundPush
      *
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
@@ -70,6 +74,8 @@ class RefundProcessor extends DefaultProcessor
         OrderStatusFactory $orderStatusFactory,
         Account $configAccount,
         GiftCardRefundService $giftCardRefundService,
+        Uncancel $uncancelService,
+        ResourceConnection $resourceConnection,
         RefundPush $refundPush
     ) {
         parent::__construct(
@@ -82,7 +88,9 @@ class RefundProcessor extends DefaultProcessor
             $buckarooStatusCode,
             $orderStatusFactory,
             $configAccount,
-            $giftCardRefundService
+            $giftCardRefundService,
+            $uncancelService,
+            $resourceConnection
         );
         $this->refundPush = $refundPush;
     }

--- a/Service/Order/Uncancel.php
+++ b/Service/Order/Uncancel.php
@@ -1,0 +1,208 @@
+<?php
+/**
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the MIT License
+ * It is available through the world-wide-web at this URL:
+ * https://tldrlegal.com/license/mit-license
+ * If you are unable to obtain it through the world-wide-web, please email
+ * to support@buckaroo.nl, so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade this module to newer
+ * versions in the future. If you wish to customize this module for your
+ * needs please contact support@buckaroo.nl for more information.
+ *
+ * @copyright Copyright (c) Buckaroo B.V.
+ * @license   https://tldrlegal.com/license/mit-license
+ */
+
+namespace Buckaroo\Magento2\Service\Order;
+
+use Buckaroo\Magento2\Logging\BuckarooLoggerInterface;
+use Magento\Framework\Event\ManagerInterface;
+use Magento\Framework\Module\Manager;
+use Magento\Sales\Api\Data\OrderInterface;
+use Magento\Sales\Api\Data\OrderItemInterface;
+use Magento\Sales\Api\OrderRepositoryInterface;
+use Magento\Sales\Model\Order;
+
+/**
+ * Service to properly uncancel/reactivate orders
+ */
+class Uncancel
+{
+    /**
+     * @var OrderRepositoryInterface
+     */
+    private $orderRepository;
+
+    /**
+     * @var ManagerInterface
+     */
+    private $eventManager;
+
+    /**
+     * @var Manager
+     */
+    private $moduleManager;
+
+    /**
+     * @var BuckarooLoggerInterface
+     */
+    private $logger;
+
+    /**
+     * @var bool
+     */
+    private $isInventorySalesApiEnabled;
+
+    /**
+     * @param OrderRepositoryInterface $orderRepository
+     * @param ManagerInterface $eventManager
+     * @param Manager $moduleManager
+     * @param BuckarooLoggerInterface $logger
+     */
+    public function __construct(
+        OrderRepositoryInterface $orderRepository,
+        ManagerInterface $eventManager,
+        Manager $moduleManager,
+        BuckarooLoggerInterface $logger
+    ) {
+        $this->orderRepository = $orderRepository;
+        $this->eventManager = $eventManager;
+        $this->moduleManager = $moduleManager;
+        $this->logger = $logger;
+    }
+
+    /**
+     * Execute order uncancellation
+     *
+     * @param OrderInterface $order
+     * @param string|null $comment
+     * @return void
+     */
+    public function execute(OrderInterface $order, ?string $comment = null): void
+    {
+        $this->isInventorySalesApiEnabled = $this->moduleManager->isEnabled('Magento_InventorySalesApi');
+
+        $this->logger->addDebug(sprintf(
+            '[UNCANCEL_ORDER] | [Service] | [%s:%s] - Uncanceling order: %s',
+            __METHOD__,
+            __LINE__,
+            $order->getIncrementId()
+        ));
+
+        $this->updateOrder($order, $comment);
+        $this->updateOrderItems($order);
+
+        $this->orderRepository->save($order);
+        $this->eventManager->dispatch('buckaroo_order_uncancel', ['order' => $order]);
+
+        $this->logger->addDebug(sprintf(
+            '[UNCANCEL_ORDER] | [Service] | [%s:%s] - Successfully uncanceled order: %s',
+            __METHOD__,
+            __LINE__,
+            $order->getIncrementId()
+        ));
+    }
+
+    /**
+     * Update order state and reset all canceled amounts
+     *
+     * @param OrderInterface $order
+     * @param string|null $comment
+     * @return void
+     */
+    private function updateOrder(OrderInterface $order, ?string $comment = null): void
+    {
+        $order->setState(Order::STATE_NEW);
+
+        $statusComment = $comment ?: __('Order reactivated: Payment completed after cancellation.');
+        $order->addStatusToHistory('pending', $statusComment, false);
+
+        // Reset all canceled amounts at order level
+        $order->setSubtotalCanceled(0);
+        $order->setBaseSubtotalCanceled(0);
+
+        $order->setTaxCanceled(0);
+        $order->setBaseTaxCanceled(0);
+
+        $order->setShippingCanceled(0);
+        $order->setBaseShippingCanceled(0);
+
+        $order->setDiscountCanceled(0);
+        $order->setBaseDiscountCanceled(0);
+
+        $order->setTotalCanceled(0);
+        $order->setBaseTotalCanceled(0);
+    }
+
+    /**
+     * Update order items and reset all canceled quantities
+     *
+     * @param OrderInterface $order
+     * @return void
+     */
+    private function updateOrderItems(OrderInterface $order): void
+    {
+        /** @var OrderItemInterface $item */
+        foreach ($order->getAllItems() as $item) {
+            if ($this->isInventorySalesApiEnabled) {
+                $this->restoreInventoryReservation($item);
+            }
+
+            $this->uncancelItem($item);
+        }
+    }
+
+    /**
+     * Restore inventory reservation for MSI
+     *
+     * @param OrderItemInterface $item
+     * @return void
+     */
+    private function restoreInventoryReservation(OrderItemInterface $item): void
+    {
+        try {
+            // For MSI (Multi-Source Inventory), we need to restore the reservation
+            // This is handled through events that MSI modules listen to
+            $this->eventManager->dispatch('sales_order_item_uncancel', ['item' => $item]);
+        } catch (\Exception $e) {
+            $this->logger->addDebug(sprintf(
+                '[UNCANCEL_ORDER] | [Service] | [%s:%s] - Failed to restore inventory for item %s: %s',
+                __METHOD__,
+                __LINE__,
+                $item->getSku(),
+                $e->getMessage()
+            ));
+        }
+    }
+
+    /**
+     * Reset item canceled quantities and amounts
+     *
+     * @param OrderItemInterface $item
+     * @return void
+     */
+    private function uncancelItem(OrderItemInterface $item): void
+    {
+        $item->setQtyCanceled(0);
+        $item->setTaxCanceled(0);
+        $item->setDiscountTaxCompensationCanceled(0);
+
+        $this->eventManager->dispatch('buckaroo_order_item_uncancel', ['item' => $item]);
+
+        // Handle child items (e.g., configurable product children, bundle items)
+        /** @var OrderItemInterface $child */
+        foreach ($item->getChildrenItems() as $child) {
+            $child->setQtyCanceled(0);
+            $child->setTaxCanceled(0);
+            $child->setDiscountTaxCompensationCanceled(0);
+
+            $this->eventManager->dispatch('buckaroo_order_item_uncancel', ['item' => $child]);
+        }
+    }
+}
+


### PR DESCRIPTION
…h and refactor invoice handling for Klarna/Afterpay

- Add Uncancel service to properly restore canceled orders, including inventory and item quantities
- Refactor DefaultProcessor to reactivate canceled orders when receiving a success push, following Magento core state logic
- Ensure invoice handling flags are set for Klarna/Afterpay SHIPMENT mode after reactivation
- Register new authorization transaction for reactivated orders to support manual capture
- Update capture logic to use reauth transaction as parent for reactivated orders
- Inject Uncancel and ResourceConnection dependencies into payment processors