### PR TITLE
BP-5122-Incorrect-docblocks-break-SOAP-API-1428

### DIFF
--- a/Api/ApplyVoucherInterface.php
+++ b/Api/ApplyVoucherInterface.php
@@ -30,7 +30,7 @@ interface ApplyVoucherInterface
      *
      * @param string $voucherCode
      *
-     * @return PayResponseInterface
+     * @return \Buckaroo\Magento2\Api\Data\Giftcard\PayResponseInterface
      */
     public function apply(string $voucherCode): PayResponseInterface;
 }

--- a/Api/Data/Giftcard/GetTransactionsResponseInterface.php
+++ b/Api/Data/Giftcard/GetTransactionsResponseInterface.php
@@ -26,7 +26,7 @@ interface GetTransactionsResponseInterface
     /**
      * Get the list of transactions for this cart
      *
-     * @return TransactionResponseInterface[]
+     * @return \Buckaroo\Magento2\Api\Data\Giftcard\TransactionResponseInterface[]
      */
     public function getTransactions(): array;
 

--- a/Api/Data/Giftcard/PayResponseInterface.php
+++ b/Api/Data/Giftcard/PayResponseInterface.php
@@ -58,7 +58,7 @@ interface PayResponseInterface
     /**
      * Get user message
      *
-     * @return Phrase|string|null
+     * @return string|null
      *
      * @api
      */
@@ -67,7 +67,7 @@ interface PayResponseInterface
     /**
      * Get user remaining amount message
      *
-     * @return Phrase|string|null
+     * @return string|null
      *
      * @api
      */

--- a/Api/GiftcardTransactionInterface.php
+++ b/Api/GiftcardTransactionInterface.php
@@ -29,7 +29,7 @@ interface GiftcardTransactionInterface
      *
      * @param string $cartId
      *
-     * @return GetTransactionsResponseInterface
+     * @return \Buckaroo\Magento2\Api\Data\Giftcard\GetTransactionsResponseInterface
      */
     public function get(string $cartId);
 }

--- a/Api/IdealQuoteCreateInterface.php
+++ b/Api/IdealQuoteCreateInterface.php
@@ -31,7 +31,7 @@ interface IdealQuoteCreateInterface
      * @param string      $page
      * @param string|null $orderData
      *
-     * @return QuoteCreateResponseInterface
+     * @return \Buckaroo\Magento2\Api\Data\Ideal\QuoteCreateResponseInterface
      */
     public function execute(
         string $page,

--- a/Api/PayWithGiftcardInterface.php
+++ b/Api/PayWithGiftcardInterface.php
@@ -32,7 +32,7 @@ interface PayWithGiftcardInterface
      * @param string              $giftcardId
      * @param PayRequestInterface $payment
      *
-     * @return PayResponseInterface
+     * @return \Buckaroo\Magento2\Api\Data\Giftcard\PayResponseInterface
      */
     public function pay(string $cartId, string $giftcardId, PayRequestInterface $payment);
 }

--- a/Api/PaypalExpressOrderCreateInterface.php
+++ b/Api/PaypalExpressOrderCreateInterface.php
@@ -30,7 +30,7 @@ interface PaypalExpressOrderCreateInterface
      * @param string      $paypal_order_id
      * @param string|null $cart_id
      *
-     * @return OrderCreateResponseInterface
+     * @return \Buckaroo\Magento2\Api\Data\PaypalExpress\OrderCreateResponseInterface
      */
     public function execute(
         string $paypal_order_id,

--- a/Api/PaypalExpressQuoteCreateInterface.php
+++ b/Api/PaypalExpressQuoteCreateInterface.php
@@ -33,7 +33,7 @@ interface PaypalExpressQuoteCreateInterface
    * @param string                          $page
    * @param string|null                     $orderData
    *
-   * @return QuoteCreateResponseInterface
+   * @return \Buckaroo\Magento2\Api\Data\PaypalExpress\QuoteCreateResponseInterface
    */
     public function execute(
         ShippingAddressRequestInterface $shippingAddress,


### PR DESCRIPTION
fix: update interface docblocks to use fully qualified return types and correct PayResponseInterface return type