### PR TITLE
BP-5151-Apple-Pay-not-working-on-Hyva-Checkout-version-1.3.3-98

### DIFF
--- a/Block/Catalog/Product/View/Applepay.php
+++ b/Block/Catalog/Product/View/Applepay.php
@@ -221,7 +221,7 @@ class Applepay extends Template
      *
      * @return Product|null
      */
-    private function getProduct()
+    public function getProduct()
     {
         if ($this->product === null && $this->registry) {
             $this->product = $this->registry->registry('product');

--- a/Gateway/Request/AdditionalInformation/ApplepayDataBuilder.php
+++ b/Gateway/Request/AdditionalInformation/ApplepayDataBuilder.php
@@ -48,9 +48,9 @@ class ApplepayDataBuilder implements BuilderInterface
      *
      * @param PaymentDataObjectInterface $paymentDO
      *
-     * @return string|null
+     * @return string Empty string if billing contact is not available
      */
-    protected function getCustomerCardName(PaymentDataObjectInterface $paymentDO): ?string
+    protected function getCustomerCardName(PaymentDataObjectInterface $paymentDO): string
     {
         $billingContact = \json_decode(
             stripslashes((string)$paymentDO->getPayment()->getAdditionalInformation('billingContact'))
@@ -63,6 +63,7 @@ class ApplepayDataBuilder implements BuilderInterface
             return $billingContact->givenName . ' ' . $billingContact->familyName;
         }
 
-        return null;
+        // Return empty string instead of null to satisfy SDK strict typing
+        return '';
     }
 }

--- a/view/frontend/web/js/action/place-order.js
+++ b/view/frontend/web/js/action/place-order.js
@@ -108,6 +108,7 @@ define(
             ).done(
                 function (response) {
                     let jsonResponse = $.parseJSON(response);
+                    
                     if (typeof jsonResponse === 'object' && typeof jsonResponse.limitReachedMessage === 'string') {
                         alert({
                             title: $t('Error'),
@@ -154,7 +155,10 @@ define(
                     } else if (redirectOnSuccess) {
                         window.location.replace(url.build('checkout/onepage/success/'));
                     }
-                    window.checkoutConfig.payment.buckaroo.response = response;
+                    
+                    // Store parsed JSON response (not the string)
+                    window.checkoutConfig.payment.buckaroo.response = jsonResponse;
+                    
                     fullScreenLoader.stopLoader();
                 }
             ).fail(


### PR DESCRIPTION
update: enhance Apple Pay integration with product validation and error handling