### PR TITLE
BP-5151-Apple-Pay-not-working-on-Hyva-Checkout-version-1.3.3-98

### DIFF
--- a/view/frontend/web/js/action/place-order.js
+++ b/view/frontend/web/js/action/place-order.js
@@ -108,7 +108,7 @@ define(
             ).done(
                 function (response) {
                     let jsonResponse = $.parseJSON(response);
-                    
+
                     if (typeof jsonResponse === 'object' && typeof jsonResponse.limitReachedMessage === 'string') {
                         alert({
                             title: $t('Error'),
@@ -155,10 +155,10 @@ define(
                     } else if (redirectOnSuccess) {
                         window.location.replace(url.build('checkout/onepage/success/'));
                     }
-                    
+
                     // Store parsed JSON response (not the string)
                     window.checkoutConfig.payment.buckaroo.response = jsonResponse;
-                    
+
                     fullScreenLoader.stopLoader();
                 }
             ).fail(


### PR DESCRIPTION
update: clean up whitespace in place-order.js for improved readability