### PR TITLE
BP-5265-Riverty-Spam-Prevention-not-working

### DIFF
--- a/Service/SpamLimitService.php
+++ b/Service/SpamLimitService.php
@@ -189,6 +189,6 @@ class SpamLimitService
     {
         $this->checkoutSession->setRestoreQuoteLastOrder($payment->getOrder()->getId());
         $this->checkoutSession->setBuckarooFailedMaxAttempts(true);
-        $payment->getPayment()->setAdditionalInformation(BuckarooAdapter::PAYMENT_ATTEMPTS_REACHED_MESSAGE, $message);
+        $payment->setAdditionalInformation(BuckarooAdapter::PAYMENT_ATTEMPTS_REACHED_MESSAGE, $message);
     }
 }


### PR DESCRIPTION
fix: ensure limit reach message is cast to string in SpamLimitService