### PR TITLE
BP-5303-No-payment-methods-are-showed-on-the-Second-Chance-page

### DIFF
--- a/Controller/Checkout/SecondChance.php
+++ b/Controller/Checkout/SecondChance.php
@@ -75,10 +75,10 @@ class SecondChance extends Action
         if ($token = $this->getRequest()->getParam('token')) {
             try {
                 $secondChance = $this->secondChanceRepository->getSecondChanceByToken($token);
-                
+
                 // Verify quote was properly set in session
                 $quote = $this->checkoutSession->getQuote();
-                
+
                 if (!$quote || !$quote->getId()) {
                     $this->logger->addError('SecondChance: No quote in session after restoration', [
                         'token' => substr($token, 0, 8) . '...',
@@ -87,19 +87,7 @@ class SecondChance extends Action
                     $this->messageManager->addErrorMessage(__('Unable to restore your cart. Please try again or contact support.'));
                     return $this->handleRedirect('checkout/cart');
                 }
-                
-                // Log quote details for debugging
-                $this->logger->addDebug('SecondChance: Quote restored successfully', [
-                    'quote_id' => $quote->getId(),
-                    'order_id' => $secondChance->getOrderId(),
-                    'reserved_order_id' => $quote->getReservedOrderId(),
-                    'items_count' => $quote->getItemsCount(),
-                    'payment_method' => $quote->getPayment()->getMethod(),
-                    'has_billing' => $quote->getBillingAddress() ? $quote->getBillingAddress()->getCountryId() : 'no',
-                    'has_shipping' => $quote->getShippingAddress() ? $quote->getShippingAddress()->getCountryId() : 'no',
-                    'shipping_method' => $quote->getShippingAddress() ? $quote->getShippingAddress()->getShippingMethod() : 'no'
-                ]);
-                
+
                 $this->messageManager->addSuccessMessage(__('Your cart has been restored. You can now complete your purchase.'));
             } catch (Exception $e) {
                 $this->logger->addError('SecondChance token error', [
@@ -117,7 +105,7 @@ class SecondChance extends Action
             return $this->handleRedirect('checkout/cart');
         }
 
-        return $this->handleRedirect('checkout', ['_fragment' => 'payment']);
+        return $this->handleRedirect('checkout');
     }
 
     public function handleRedirect($path, $arguments = [])

--- a/Model/SecondChanceRepository.php
+++ b/Model/SecondChanceRepository.php
@@ -483,16 +483,14 @@ class SecondChanceRepository implements SecondChanceRepositoryInterface
             // Apply the reserved order ID with suffix to the new quote
             if ($newOrderId && $quote && $quote->getId()) {
                 $quote->setReservedOrderId($newOrderId);
-                $quote->save();
 
-                // CRITICAL: Force this quote to be THE quote for checkout
-                // Clear any old quote from session and explicitly set this one
                 $this->checkoutSession->clearQuote();
                 $this->checkoutSession->clearStorage();
                 $this->checkoutSession->replaceQuote($quote);
                 $this->checkoutSession->setQuoteId($quote->getId());
 
-                $this->logging->addDebug('Second Chance: Quote recreated with order ID: ' . $newOrderId);
+                // Save quote after session is set to ensure proper context
+                $quote->save();
             }
         }
 

--- a/Service/Sales/Quote/Recreate.php
+++ b/Service/Sales/Quote/Recreate.php
@@ -454,6 +454,24 @@ class Recreate
     private function isPaymentMethodAvailable($methodCode, $quote)
     {
         try {
+            // Ensure quote has required data for availability check
+            if (!$quote->getBillingAddress() || !$quote->getBillingAddress()->getCountryId()) {
+                $this->logger->addDebug('Second Chance: Cannot check payment method - missing billing address', [
+                    'method' => $methodCode,
+                    'quote_id' => $quote->getId()
+                ]);
+                return false;
+            }
+
+            // Ensure store context is set
+            if (!$quote->getStoreId()) {
+                $this->logger->addDebug('Second Chance: Cannot check payment method - missing store ID', [
+                    'method' => $methodCode,
+                    'quote_id' => $quote->getId()
+                ]);
+                return false;
+            }
+
             $methodInstance = $this->paymentHelper->getMethodInstance($methodCode);
             if (!$methodInstance) {
                 return false;


### PR DESCRIPTION
update: improve Second Chance flow by enhancing payment method checks and removing unnecessary logging