### PR TITLE
BTI-120-Magento-2-Add-payment-method-Google-Pay

### DIFF
--- a/Model/ConfigProvider/Method/Googlepay.php
+++ b/Model/ConfigProvider/Method/Googlepay.php
@@ -42,6 +42,7 @@ class Googlepay extends AbstractConfigProvider
     public const XPATH_GOOGLEPAY_INTEGRATION_MODE                  = 'integration_mode';
     public const XPATH_GOOGLEPAY_DONT_ASK_BILLING_INFO_IN_CHECKOUT = 'dont_ask_billing_info_in_checkout';
     public const XPATH_ACCOUNT_MERCHANT_GUID                       = 'merchant_guid';
+    public const XPATH_GOOGLE_MERCHANT_ID                          = 'google_merchant_id';
 
     /**
      * @var array
@@ -103,7 +104,7 @@ class Googlepay extends AbstractConfigProvider
             'countryCode'                  => $this->getDefaultCountry(),
             'guid'                         => $this->getMerchantGuid(),
             'gatewayMerchantId'            => $this->getMerchantGuid(),
-            'merchantId'                   => $this->getMerchantGuid(),
+            'merchantId'                   => $this->getGoogleMerchantId(),
             'availableButtons'             => $this->getAvailableButtons(),
             'buttonStyle'                  => $this->getButtonStyle(),
             'dontAskBillingInfoInCheckout' => (int)$this->getDontAskBillingInfoInCheckout(),
@@ -124,6 +125,18 @@ class Googlepay extends AbstractConfigProvider
     public function getMerchantGuid($store = null)
     {
         return $this->getMethodConfigValue(self::XPATH_ACCOUNT_MERCHANT_GUID, $store);
+    }
+
+    /**
+     * Get Google Pay Merchant ID
+     *
+     * @param null|int|string $store
+     *
+     * @return mixed
+     */
+    public function getGoogleMerchantId($store = null)
+    {
+        return $this->getMethodConfigValue(self::XPATH_GOOGLE_MERCHANT_ID, $store);
     }
 
     /**

--- a/etc/adminhtml/system/payment_methods/googlepay.xml
+++ b/etc/adminhtml/system/payment_methods/googlepay.xml
@@ -67,10 +67,17 @@
             <label>Method specific configuration</label>
 
             <field id="merchant_guid" translate="label comment tooltip" type="text" sortOrder="36" showInDefault="1" showInWebsite="1" showInStore="1">
-                <label>(Merchant) guid</label>
-                <comment><![CDATA[Enter your Buckaroo merchant guid.]]></comment>
-                <tooltip>The (Merchant) Guid can be retrieved in Buckaroo Plaza under My Buckaroo > General > Guid.</tooltip>
+                <label>Gateway Merchant ID</label>
+                <comment><![CDATA[Enter your Buckaroo GatewayMerchantID for Google Pay.]]></comment>
+                <tooltip>The GatewayMerchantID can be found in Buckaroo Plaza under Services > Google Pay.</tooltip>
                 <config_path>payment/buckaroo_magento2_googlepay/merchant_guid</config_path>
+            </field>
+
+            <field id="google_merchant_id" translate="label comment tooltip" type="text" sortOrder="37" showInDefault="1" showInWebsite="1" showInStore="1">
+                <label>Google Pay Merchant ID</label>
+                <comment><![CDATA[Enter your Google Pay Merchant ID (e.g. BCR2DN4TXXXXXXXX). Required for production/live mode.]]></comment>
+                <tooltip>Your Google Pay Merchant ID can be found in the Google Pay Business Console at https://pay.google.com/business/console. This is different from your Buckaroo merchant GUID and is required for Google Pay to work in production.</tooltip>
+                <config_path>payment/buckaroo_magento2_googlepay/google_merchant_id</config_path>
             </field>
 
             <field id="available_buttons" translate="label comment" type="multiselect" sortOrder="10" showInDefault="1" showInWebsite="1" showInStore="1">


### PR DESCRIPTION
add Google Pay Merchant ID configuration to Google Pay integration