### PR TITLE
BTI-120-Magento-2-Add-payment-method-Google-Pay

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "magento/module-tax": "^100.4",
         "magento/module-ui": "^101.2",
         "laminas/laminas-validator": "^2.64",
-        "buckaroo/sdk": "^1.22.1",
+        "buckaroo/sdk": "^1.23.1",
         "monolog/monolog": "^2.9 || ^3.0",
         "psr/log": "^2.0 || ^3.0",
         "ext-json": "*",

--- a/etc/adminhtml/system/payment_methods/googlepay.xml
+++ b/etc/adminhtml/system/payment_methods/googlepay.xml
@@ -75,8 +75,8 @@
 
             <field id="google_merchant_id" translate="label comment tooltip" type="text" sortOrder="37" showInDefault="1" showInWebsite="1" showInStore="1">
                 <label>Google Pay Merchant ID</label>
-                <comment><![CDATA[Enter your Google Pay Merchant ID (e.g. BCR2DN4TXXXXXXXX). Required for production/live mode.]]></comment>
-                <tooltip>Your Google Pay Merchant ID can be found in the Google Pay Business Console at https://pay.google.com/business/console. This is different from your Buckaroo merchant GUID and is required for Google Pay to work in production.</tooltip>
+                <comment><![CDATA[Enter your Google Pay Merchant ID (e.g. BCR2DN4TXXXXXXXX). Find it in the <a href="https://pay.google.com/business/console" target="_blank">Google Pay Business Console</a>.]]></comment>
+                <tooltip>This is different from your Buckaroo Gateway Merchant ID and is required for Google Pay to work.</tooltip>
                 <config_path>payment/buckaroo_magento2_googlepay/google_merchant_id</config_path>
             </field>
 

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -2925,14 +2925,9 @@
     </virtualType>
 
     <!-- Google Pay Order Command -->
-    <virtualType name="GooglepayOrderCommand" type="Buckaroo\Magento2\Gateway\Command\GatewayCommand">
+    <virtualType name="GooglepayOrderCommand" type="BuckarooRemainderOrderCommand">
         <arguments>
             <argument name="requestBuilder" xsi:type="object">GooglepayOrderRequest</argument>
-            <argument name="transferFactory" xsi:type="object">Buckaroo\Magento2\Gateway\Http\SDKTransferFactory</argument>
-            <argument name="client" xsi:type="object">TransactionPay</argument>
-            <argument name="handler" xsi:type="object">OrderResponseHandler</argument>
-            <argument name="validator" xsi:type="object">Buckaroo\Magento2\Gateway\Validator\ResponseCodeSDKValidator</argument>
-            <argument name="errorMessageMapper" xsi:type="object">Buckaroo\Magento2\Gateway\ErrorMapper\ErrorMessageMapper</argument>
         </arguments>
     </virtualType>
 
@@ -2940,7 +2935,7 @@
     <virtualType name="GooglepayOrderRequest" type="Buckaroo\Magento2\Gateway\Request\BuckarooBuilderComposite">
         <arguments>
             <argument name="builders" xsi:type="array">
-                <item name="order_request" xsi:type="string">BuckarooOrderRequest</item>
+                <item name="order" xsi:type="string">BuckarooRemainderRequest</item>
                 <item name="googlepay" xsi:type="string">Buckaroo\Magento2\Gateway\Request\AdditionalInformation\GooglepayConditionalDataBuilder</item>
             </argument>
         </arguments>

--- a/view/frontend/web/css/express-payments.css
+++ b/view/frontend/web/css/express-payments.css
@@ -7,7 +7,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    margin: 10px 0;
+    margin: 0;
     width: 100%;
     max-width: 350px;
     box-sizing: border-box;
@@ -25,7 +25,7 @@
 .buckaroo-paypal-express {
     width: 100%;
     max-width: 350px;
-    margin: 10px 0;
+    margin: 0;
     box-sizing: border-box;
     cursor: pointer;
 }
@@ -34,7 +34,7 @@
 #apple-pay-wrapper {
     width: 100%;
     max-width: 350px;
-    margin: 10px 0;
+    margin: 0;
     box-sizing: border-box;
     cursor: pointer;
 }
@@ -43,7 +43,7 @@
 #google-pay-wrapper {
     width: 100%;
     max-width: 350px;
-    margin: 10px 0;
+    margin: 0;
     box-sizing: border-box;
     cursor: pointer;
 }
@@ -122,7 +122,7 @@
     cursor: pointer;
 }
 
-/* Express Payment Component Containers - Cursor Pointer */
+/* Express Payment Component Containers - shared spacing & cursor */
 #apple-pay-catalog-product-view-component,
 #apple-pay-catalog-cart-view-component,
 #google-pay-catalog-product-view-component,
@@ -130,6 +130,14 @@
 #paypal-express-button-component,
 #fast-checkout-ideal-btn-component {
     cursor: pointer;
+    margin-bottom: 8px;
+}
+
+/* Extra vertical padding on non-Apple-Pay buttons to match Apple Pay .actions height */
+#google-pay-wrapper,
+#paypal-express-wrapper,
+#fast-checkout-ideal-btn {
+    padding: 5px 0;
 }
 
 /* Google Pay Component Container */
@@ -137,7 +145,7 @@
 #google-pay-catalog-cart-view-component {
     width: 100%;
     max-width: 350px;
-    margin: 10px 0;
+    margin: 0;
     box-sizing: border-box;
 }
 
@@ -152,22 +160,39 @@
     display: flex;
     flex-direction: column;
     align-items: center;
+    gap: 8px;
 }
 
 .buckaroo-box-to-cart .fieldset {
     width: 100%;
     max-width: 350px;
+    margin: 0;
+    padding: 0;
 }
 
 .buckaroo-box-to-cart .actions {
+    display: flex;
+    align-items: stretch;
     width: 100%;
+    margin: 0;
+    padding: 0;
+    line-height: 0;
+    font-size: 0;
+}
+
+/* Remove default box-tocart margins when used inside express button stack */
+.buckaroo-box-to-cart .box-tocart {
+    margin: 0;
+    padding: 0;
+    width: 100%;
+    max-width: 350px;
 }
 
 /* PayPal Express button component container */
 #paypal-express-button-component {
     width: 100%;
     max-width: 350px;
-    margin: 10px 0;
+    margin: 0;
     box-sizing: border-box;
 }
 
@@ -178,7 +203,7 @@
     display: flex;
     align-items: center;
     gap: 12px;
-    margin: 10px 0;
+    margin: 0;
     border-radius: 5px;
     max-width: 500px;
     height: 55px;

--- a/view/frontend/web/js/view/checkout/googlepay/pay.js
+++ b/view/frontend/web/js/view/checkout/googlepay/pay.js
@@ -336,10 +336,16 @@ define(
                     }
                     currencyCode = config.currency || 'EUR';
                 } else {
-                    // Checkout mode - use quote data
-                    var quoteData = window.checkoutConfig.quoteData || {};
-                    grandTotal = parseFloat(quoteData.grand_total) || 1.00;
-                    currencyCode = quoteData.quote_currency_code || config.currency || 'EUR';
+                    // Checkout mode - use remaining amount when giftcard/voucher partially paid
+                    var remainingSegment = totals.getSegment('remaining_amount');
+                    if (remainingSegment && parseFloat(remainingSegment.value) > 0) {
+                        grandTotal = parseFloat(remainingSegment.value);
+                    } else {
+                        var quoteData = window.checkoutConfig.quoteData || {};
+                        grandTotal = parseFloat(quoteData.grand_total) || 1.00;
+                    }
+                    var checkoutQuoteData = window.checkoutConfig.quoteData || {};
+                    currencyCode = checkoutQuoteData.quote_currency_code || config.currency || 'EUR';
                 }
 
                 // Determine button container based on mode


### PR DESCRIPTION
Eenhance Google Pay integration with updated merchant ID handling and improved checkout logic