### PR TITLE
Bti 621 magento 2 unequal whitespace between express payment buttons

### DIFF
--- a/view/frontend/web/css/express-payments.css
+++ b/view/frontend/web/css/express-payments.css
@@ -35,6 +35,10 @@
     }
 }
 
+#apple-pay-wrapper{
+    margin-bottom: 14px;
+}
+
 #apple-pay-wrapper,
 #google-pay-wrapper,
 #fast-checkout-ideal-btn-component .actions {


### PR DESCRIPTION
add margin to apple pay wrapper for improved spacing