### PR TITLE
Bti 666 magento 2 order adapter get customer id returns incorrect type 1516

### DIFF
--- a/Gateway/Data/Order/OrderAdapter.php
+++ b/Gateway/Data/Order/OrderAdapter.php
@@ -61,7 +61,7 @@ class OrderAdapter implements OrderAdapterInterface
      */
     public function getCurrencyCode(): string
     {
-        return $this->order->getBaseCurrencyCode();
+        return (string)$this->order->getBaseCurrencyCode();
     }
 
     /**
@@ -71,7 +71,7 @@ class OrderAdapter implements OrderAdapterInterface
      */
     public function getOrderIncrementId(): string
     {
-        return $this->order->getIncrementId();
+        return (string)$this->order->getIncrementId();
     }
 
     /**
@@ -81,7 +81,8 @@ class OrderAdapter implements OrderAdapterInterface
      */
     public function getCustomerId(): ?int
     {
-        return $this->order->getCustomerId();
+        $customerId = $this->order->getCustomerId();
+        return $customerId !== null ? (int)$customerId : null;
     }
 
     /**
@@ -123,7 +124,8 @@ class OrderAdapter implements OrderAdapterInterface
      */
     public function getStoreId(): ?int
     {
-        return (int)$this->order->getStoreId();
+        $storeId = $this->order->getStoreId();
+        return $storeId !== null ? (int)$storeId : null;
     }
 
     /**
@@ -143,7 +145,7 @@ class OrderAdapter implements OrderAdapterInterface
      */
     public function getGrandTotalAmount(): float
     {
-        return $this->order->getBaseGrandTotal();
+        return (float)($this->order->getBaseGrandTotal() ?? 0.0);
     }
 
     /**


### PR DESCRIPTION
Fix type handling in OrderAdapter methods to ensure correct return types for currency, order increment ID, customer ID, store ID, and grand total amount