### PR TITLE
BTI-704-Magento-2-Transfer-payment-results-in-a-second-chance-trigger

### DIFF
--- a/Observer/CreateSecondChanceRecord.php
+++ b/Observer/CreateSecondChanceRecord.php
@@ -20,6 +20,7 @@
 
 namespace Buckaroo\Magento2\Observer;
 
+use Buckaroo\Magento2\Model\ConfigProvider\Method\Transfer;
 use Magento\Framework\Event\Observer;
 use Magento\Framework\Event\ObserverInterface;
 use Magento\Framework\Exception\LocalizedException;
@@ -108,6 +109,10 @@ class CreateSecondChanceRecord implements ObserverInterface
 
         $payment = $order->getPayment();
         if (!$payment || strpos($payment->getMethod(), 'buckaroo') === false) {
+            return false;
+        }
+
+        if ($payment->getMethod() === Transfer::CODE) {
             return false;
         }
 

--- a/Test/Unit/Observer/CreateSecondChanceRecordTest.php
+++ b/Test/Unit/Observer/CreateSecondChanceRecordTest.php
@@ -52,6 +52,9 @@ class CreateSecondChanceRecordTest extends \Buckaroo\Magento2\Test\BaseTest
             'valid buckaroo order canceled' => [
                 124, 'canceled', 'buckaroo_magento2_paypal', true,  false, 1, 1
             ],
+            'transfer payment is excluded' => [
+                129, 'pending_payment', 'buckaroo_magento2_transfer', true, false, 0, 0
+            ],
             'order with non-buckaroo payment method' => [
                 125, 'pending_payment', 'checkmo', true,  false, 0, 0
             ],


### PR DESCRIPTION
Exclude transfer payment method from second chance record creation