### PR TITLE
Bti 174 magento 2 remove transaction id text from order history message after offline refund for riverty

### DIFF
--- a/Plugin/OrderStatusHistoryCommentPlugin.php
+++ b/Plugin/OrderStatusHistoryCommentPlugin.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the MIT License
+ * It is available through the world-wide-web at this URL:
+ * https://tldrlegal.com/license/mit-license
+ * If you are unable to obtain it through the world-wide-web, please email
+ * to support@buckaroo.nl, so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade this module to newer
+ * versions in the future. If you wish to customize this module for your
+ * needs please contact support@buckaroo.nl for more information.
+ *
+ * @copyright Copyright (c) Buckaroo B.V.
+ * @license   https://tldrlegal.com/license/mit-license
+ */
+declare(strict_types=1);
+
+namespace Buckaroo\Magento2\Plugin;
+
+use Buckaroo\Magento2\Service\CheckPaymentType;
+use Magento\Sales\Model\Order;
+
+class OrderStatusHistoryCommentPlugin
+{
+    private const OFFLINE_REFUND_COMMENT_PATTERN =
+        '/^(?<message>We refunded .*? offline\.) Transaction ID: ".+"$/u';
+
+    /**
+     * @var CheckPaymentType
+     */
+    private $checkPaymentType;
+
+    public function __construct(CheckPaymentType $checkPaymentType)
+    {
+        $this->checkPaymentType = $checkPaymentType;
+    }
+
+    /**
+     * Strip the appended transaction identifier from Buckaroo offline refund comments.
+     *
+     * @param Order $subject
+     * @param string|\Magento\Framework\Phrase $comment
+     * @param bool|string $status
+     * @return array
+     */
+    public function beforeAddStatusHistoryComment(Order $subject, $comment, $status = false): array
+    {
+        if (!$this->checkPaymentType->isBuckarooPayment($subject->getPayment())) {
+            return [$comment, $status];
+        }
+
+        $commentText = (string)$comment;
+        if (preg_match(self::OFFLINE_REFUND_COMMENT_PATTERN, $commentText, $matches) !== 1) {
+            return [$comment, $status];
+        }
+
+        return [$matches['message'], $status];
+    }
+}

--- a/Test/Unit/Plugin/OrderStatusHistoryCommentPluginTest.php
+++ b/Test/Unit/Plugin/OrderStatusHistoryCommentPluginTest.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Buckaroo\Magento2\Test\Unit\Plugin;
+
+use Buckaroo\Magento2\Plugin\OrderStatusHistoryCommentPlugin;
+use Buckaroo\Magento2\Service\CheckPaymentType;
+use Buckaroo\Magento2\Test\BaseTest;
+use Magento\Sales\Model\Order;
+
+class OrderStatusHistoryCommentPluginTest extends BaseTest
+{
+    protected $instanceClass = OrderStatusHistoryCommentPlugin::class;
+
+    public function testOfflineRefundCommentIsCleanedForBuckarooPayment(): void
+    {
+        $orderMock = $this->getOrderMock();
+        $comment = 'We refunded $59.00 offline. Transaction ID: "A7BDD18D052843098E3461FE3EDA423B-capture"';
+
+        $result = $this->getInstance([
+            'checkPaymentType' => $this->getCheckPaymentTypeMock(true),
+        ])->beforeAddStatusHistoryComment($orderMock, $comment, 'closed');
+
+        $this->assertSame(['We refunded $59.00 offline.', 'closed'], $result);
+    }
+
+    public function testOnlineRefundCommentIsLeftUntouched(): void
+    {
+        $orderMock = $this->getOrderMock();
+        $comment = 'We refunded $59.00 online. Transaction ID: "A7BDD18D052843098E3461FE3EDA423B-refund"';
+
+        $result = $this->getInstance([
+            'checkPaymentType' => $this->getCheckPaymentTypeMock(true),
+        ])->beforeAddStatusHistoryComment($orderMock, $comment, 'processing');
+
+        $this->assertSame([$comment, 'processing'], $result);
+    }
+
+    public function testNonBuckarooOfflineRefundCommentIsLeftUntouched(): void
+    {
+        $orderMock = $this->getOrderMock();
+        $comment = 'We refunded $59.00 offline. Transaction ID: "A7BDD18D052843098E3461FE3EDA423B-capture"';
+
+        $result = $this->getInstance([
+            'checkPaymentType' => $this->getCheckPaymentTypeMock(false),
+        ])->beforeAddStatusHistoryComment($orderMock, $comment, false);
+
+        $this->assertSame([$comment, false], $result);
+    }
+
+    public function testBuckarooNonRefundCommentContainingTransactionIdIsLeftUntouched(): void
+    {
+        $orderMock = $this->getOrderMock();
+        $comment = 'Registered notification about captured amount of $59.00. Transaction ID: "A7BDD18D052843098E3461FE3EDA423B-capture"';
+
+        $result = $this->getInstance([
+            'checkPaymentType' => $this->getCheckPaymentTypeMock(true),
+        ])->beforeAddStatusHistoryComment($orderMock, $comment, 'processing');
+
+        $this->assertSame([$comment, 'processing'], $result);
+    }
+
+    private function getOrderMock(): Order
+    {
+        $paymentMock = $this->createMock(\Magento\Sales\Api\Data\OrderPaymentInterface::class);
+
+        $orderMock = $this->getMockBuilder(Order::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getPayment'])
+            ->getMock();
+        $orderMock->method('getPayment')->willReturn($paymentMock);
+
+        return $orderMock;
+    }
+
+    private function getCheckPaymentTypeMock(bool $isBuckarooPayment): CheckPaymentType
+    {
+        $checkPaymentTypeMock = $this->getMockBuilder(CheckPaymentType::class)
+            ->onlyMethods(['isBuckarooPayment'])
+            ->getMock();
+        $checkPaymentTypeMock->method('isBuckarooPayment')->willReturn($isBuckarooPayment);
+
+        return $checkPaymentTypeMock;
+    }
+}

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -102,6 +102,10 @@
         <plugin name="buckaroo_magento2_add_order_extension_attributes" type="Buckaroo\Magento2\Plugin\OrderExtensionAttribute" />
     </type>
 
+    <type name="Magento\Sales\Model\Order">
+        <plugin name="buckaroo_magento2_clean_offline_refund_history_comment" type="Buckaroo\Magento2\Plugin\OrderStatusHistoryCommentPlugin" />
+    </type>
+
     <type name="Magento\Sales\Model\Order\Email\Sender\OrderSender">
         <plugin name="buckaroo_magento2_prevent_core_order_email" type="Buckaroo\Magento2\Plugin\OrderSender" />
     </type>


### PR DESCRIPTION
Add plugin to clean offline refund comments by removing transaction ID