### PR TITLE
Bti 923 magento 2 adjust php restriction to accept compatibillity for php 8.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "magento/module-store": "^101.1",
         "magento/module-tax": "^100.4",
         "magento/module-ui": "^101.2",
-        "laminas/laminas-validator": "^2.64",
+        "laminas/laminas-validator": "~2.64.0",
         "buckaroo/sdk": "^1.23.2",
         "monolog/monolog": "^2.9 || ^3.0",
         "psr/log": "^2.0 || ^3.0",

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "buckaroo/magento2",
     "description": "Buckaroo Magento 2 extension",
     "require": {
-        "php": "^8.0 || ^8.1 || ^8.2 || ^8.3 || ^8.4",
+        "php": "^8.1 || ^8.2 || ^8.3 || ^8.4",
         "magento/module-payment": ">=100.3.3",
         "magento/framework": ">=103.0.0",
         "magento/module-backend": "^102.0",
@@ -22,7 +22,7 @@
         "magento/module-store": "^101.1",
         "magento/module-tax": "^100.4",
         "magento/module-ui": "^101.2",
-        "laminas/laminas-validator": "~2.64.0",
+        "laminas/laminas-validator": "^2.64",
         "buckaroo/sdk": "^1.23.2",
         "monolog/monolog": "^2.9 || ^3.0",
         "psr/log": "^2.0 || ^3.0",


### PR DESCRIPTION
adjust laminas-validator version constraint for compatibility with PHP 8.1