### PR TITLE
BTI-937-Magento-2-Fix-PayLink-visibility-setting-not-respected-on-custom-Magento-2-themes

### DIFF
--- a/Gateway/Validator/AreaCodeValidator.php
+++ b/Gateway/Validator/AreaCodeValidator.php
@@ -21,28 +21,26 @@ declare(strict_types=1);
 
 namespace Buckaroo\Magento2\Gateway\Validator;
 
-use Buckaroo\Magento2\Exception;
 use Buckaroo\Magento2\Gateway\Helper\SubjectReader;
+use Buckaroo\Magento2\Model\ConfigProvider\Method\Factory as MethodConfigProviderFactory;
 use Magento\Framework\App\Area;
 use Magento\Framework\App\State;
-use Magento\Framework\Exception\LocalizedException;
 use Magento\Payment\Gateway\Validator\AbstractValidator;
 use Magento\Payment\Gateway\Validator\ResultInterface;
 use Magento\Payment\Gateway\Validator\ResultInterfaceFactory;
-use Buckaroo\Magento2\Model\ConfigProvider\Factory as ConfigProviderFactory;
 
 class AreaCodeValidator extends AbstractValidator
 {
     private State $state;
-    private ConfigProviderFactory $configProviderFactory;
+    private MethodConfigProviderFactory $methodConfigProviderFactory;
 
     public function __construct(
         ResultInterfaceFactory $resultFactory,
         State $state,
-        ConfigProviderFactory $configProviderFactory
+        MethodConfigProviderFactory $methodConfigProviderFactory
     ) {
         $this->state = $state;
-        $this->configProviderFactory = $configProviderFactory;
+        $this->methodConfigProviderFactory = $methodConfigProviderFactory;
         parent::__construct($resultFactory);
     }
 
@@ -54,19 +52,18 @@ class AreaCodeValidator extends AbstractValidator
         try {
             $areaCode = $this->state->getAreaCode();
         } catch (\Exception $e) {
-            // If area code cannot be determined, do not block (or choose your desired default)
             return $this->createResult(true);
         }
 
-        // Existing admin toggle
+        // Block methods that are disabled in backend
         $isAvailableInBackend = $method->getConfigData('available_in_backend');
         if ($areaCode === Area::AREA_ADMINHTML && $isAvailableInBackend !== null && (int)$isAvailableInBackend === 0) {
             $isValid = false;
         }
 
-        // PayPerEmail front/back/both toggle
-        if ($isValid && $method->getCode() === 'buckaroo_magento2_payperemail') {
-            $cp = $this->configProviderFactory->get('payperemail');
+        // Check area-code visibility for any method that declares it (e.g. PayPerEmail, PayLink)
+        if ($isValid && $this->methodConfigProviderFactory->has($method->getCode())) {
+            $cp = $this->methodConfigProviderFactory->get($method->getCode());
             if (method_exists($cp, 'isVisibleForAreaCode') && !$cp->isVisibleForAreaCode($areaCode)) {
                 $isValid = false;
             }

--- a/Model/ConfigProvider/Method/AbstractConfigProvider.php
+++ b/Model/ConfigProvider/Method/AbstractConfigProvider.php
@@ -607,4 +607,9 @@ abstract class AbstractConfigProvider extends BaseAbstractConfigProvider impleme
     {
         return $this->getMethodConfigValue(static::CUSTOMER_ADDITIONAL_INFO, $store);
     }
+
+    public function isVisibleForAreaCode(string $areaCode): bool
+    {
+        return true;
+    }
 }

--- a/Model/ConfigProvider/Method/ConfigProviderInterface.php
+++ b/Model/ConfigProvider/Method/ConfigProviderInterface.php
@@ -130,4 +130,14 @@ interface ConfigProviderInterface
      * @return string
      */
     public function getImageUrl($imgName);
+
+    /**
+     * Whether the payment method is visible for the given Magento area code.
+     * Returns true by default; override to restrict to adminhtml or frontend only.
+     *
+     * @param string $areaCode
+     *
+     * @return bool
+     */
+    public function isVisibleForAreaCode(string $areaCode): bool;
 }

--- a/Model/ConfigProvider/Method/Factory.php
+++ b/Model/ConfigProvider/Method/Factory.php
@@ -98,7 +98,7 @@ class Factory
     public function has($providerType)
     {
         if (empty($this->configProviders)) {
-            throw new \LogicException('ConfigProvider adapter is not set.');
+            return false;
         }
 
         $providerType = str_replace('buckaroo_magento2_', '', $providerType);

--- a/Model/ConfigProvider/Method/PayLink.php
+++ b/Model/ConfigProvider/Method/PayLink.php
@@ -21,6 +21,7 @@ declare(strict_types=1);
 
 namespace Buckaroo\Magento2\Model\ConfigProvider\Method;
 
+use Magento\Framework\App\Area;
 use Magento\Store\Model\ScopeInterface;
 
 class PayLink extends AbstractConfigProvider
@@ -39,11 +40,7 @@ class PayLink extends AbstractConfigProvider
      */
     public function isVisibleForAreaCode(string $areaCode): bool
     {
-        if ($areaCode == 'adminhtml') {
-            return true;
-        }
-
-        return false;
+        return $areaCode === Area::AREA_ADMINHTML;
     }
 
     /**

--- a/Model/ConfigProvider/Method/PayPerEmail.php
+++ b/Model/ConfigProvider/Method/PayPerEmail.php
@@ -22,6 +22,7 @@ declare(strict_types=1);
 namespace Buckaroo\Magento2\Model\ConfigProvider\Method;
 
 use Buckaroo\Magento2\Exception;
+use Magento\Framework\App\Area;
 
 class PayPerEmail extends AbstractConfigProvider
 {
@@ -136,20 +137,21 @@ class PayPerEmail extends AbstractConfigProvider
      *
      * @return bool
      */
-    public function isVisibleForAreaCode($areaCode)
+    public function isVisibleForAreaCode(string $areaCode): bool
     {
         if (null === $this->getVisibleFrontBack()) {
             return false;
         }
 
-        $forFrontend = ('frontend' === $this->getVisibleFrontBack() || 'both' === $this->getVisibleFrontBack());
-        $forBackend = ('backend' === $this->getVisibleFrontBack() || 'both' === $this->getVisibleFrontBack());
+        $visibleFrontBack = $this->getVisibleFrontBack();
+        $forFrontend = ($visibleFrontBack === 'frontend' || $visibleFrontBack === 'both');
+        $forBackend  = ($visibleFrontBack === 'backend'  || $visibleFrontBack === 'both');
 
-        if (($areaCode == 'adminhtml' && !$forBackend) || ($areaCode != 'adminhtml' && !$forFrontend)) {
-            return false;
+        if ($areaCode === Area::AREA_ADMINHTML) {
+            return $forBackend;
         }
 
-        return true;
+        return $forFrontend;
     }
 
     /**

--- a/Test/BaseTest.php
+++ b/Test/BaseTest.php
@@ -53,6 +53,14 @@ abstract class BaseTest extends TestCase
         return $this->getObject($this->instanceClass, $args);
     }
 
+    public static function setUpBeforeClass(): void
+    {
+        if (!defined('BP')) {
+            define('BP', dirname(__DIR__, 5));
+        }
+        parent::setUpBeforeClass();
+    }
+
     public function setUp(): void
     {
         ini_set('error_reporting', E_ALL);

--- a/Test/Unit/Gateway/Validator/AreaCodeValidatorTest.php
+++ b/Test/Unit/Gateway/Validator/AreaCodeValidatorTest.php
@@ -3,7 +3,8 @@
 namespace Buckaroo\Magento2\Test\Unit\Gateway\Validator;
 
 use Buckaroo\Magento2\Gateway\Validator\AreaCodeValidator;
-use Buckaroo\Magento2\Model\ConfigProvider\Factory as ConfigProviderFactory;
+use Buckaroo\Magento2\Model\ConfigProvider\Method\Factory as MethodConfigProviderFactory;
+use Buckaroo\Magento2\Model\ConfigProvider\Method\ConfigProviderInterface;
 use Magento\Framework\App\Area;
 use Magento\Framework\App\State;
 use Magento\Payment\Gateway\Validator\ResultInterface;
@@ -14,24 +15,16 @@ use PHPUnit\Framework\TestCase;
 
 class AreaCodeValidatorTest extends TestCase
 {
-    /**
-     * @var ResultInterfaceFactory|MockObject
-     */
+    /** @var ResultInterfaceFactory|MockObject */
     private $resultFactory;
 
-    /**
-     * @var State|MockObject
-     */
+    /** @var State|MockObject */
     private $state;
 
-    /**
-     * @var ConfigProviderFactory|MockObject
-     */
-    private $configProviderFactory;
+    /** @var MethodConfigProviderFactory|MockObject */
+    private $methodConfigProviderFactory;
 
-    /**
-     * @var AreaCodeValidator
-     */
+    /** @var AreaCodeValidator */
     private $validator;
 
     protected function setUp(): void
@@ -43,79 +36,96 @@ class AreaCodeValidatorTest extends TestCase
 
         $this->state = $this->createMock(State::class);
 
-        $this->configProviderFactory = $this->createMock(ConfigProviderFactory::class);
+        $this->methodConfigProviderFactory = $this->createMock(MethodConfigProviderFactory::class);
 
         $this->validator = new AreaCodeValidator(
             $this->resultFactory,
             $this->state,
-            $this->configProviderFactory
+            $this->methodConfigProviderFactory
         );
     }
 
     /**
      * @dataProvider validateDataProvider
-     *
-     * @param mixed $areaCode
-     * @param mixed $configData
-     * @param mixed $expectedResult
      */
-    public function testValidate($areaCode, $configData, $expectedResult)
-    {
-        $validationSubject = [
-            'paymentMethodInstance' => $this->createMock(MethodInterface::class)
-        ];
-
-        $this->state->method('getAreaCode')
-            ->willReturn($areaCode);
-
-        $validationSubject['paymentMethodInstance']->method('getConfigData')
+    public function testValidate(
+        string $areaCode,
+        ?string $availableInBackend,
+        bool $hasProvider,
+        ?bool $isVisibleForAreaCode,
+        bool $expectedResult
+    ): void {
+        $method = $this->createMock(MethodInterface::class);
+        $method->method('getCode')->willReturn('buckaroo_magento2_testmethod');
+        $method->method('getConfigData')
             ->with('available_in_backend')
-            ->willReturn($configData);
+            ->willReturn($availableInBackend);
+
+        $this->state->method('getAreaCode')->willReturn($areaCode);
+
+        $this->methodConfigProviderFactory->method('has')->willReturn($hasProvider);
+
+        if ($hasProvider && $isVisibleForAreaCode !== null) {
+            $cp = $this->createMock(ConfigProviderInterface::class);
+            $cp->method('isVisibleForAreaCode')->willReturn($isVisibleForAreaCode);
+            $this->methodConfigProviderFactory->method('get')->willReturn($cp);
+        }
 
         $resultMock = $this->createMock(ResultInterface::class);
-
         $this->resultFactory->method('create')
             ->with(['isValid' => $expectedResult, 'failsDescription' => [], 'errorCodes' => []])
             ->willReturn($resultMock);
 
-        $result = $this->validator->validate($validationSubject);
+        $result = $this->validator->validate(['paymentMethodInstance' => $method]);
 
         $this->assertSame($resultMock, $result);
     }
 
-    public static function validateDataProvider()
+    public static function validateDataProvider(): array
     {
         return [
-            'backend with config data 0' => [
-                'areaCode' => Area::AREA_ADMINHTML,
-                'configData' => '0',
-                'expectedResult' => false
+            'admin, available_in_backend=0 → blocked' => [
+                Area::AREA_ADMINHTML, '0', false, null, false,
             ],
-            'backend with config data 1' => [
-                'areaCode' => Area::AREA_ADMINHTML,
-                'configData' => '1',
-                'expectedResult' => true
+            'admin, available_in_backend=1 → allowed' => [
+                Area::AREA_ADMINHTML, '1', false, null, true,
             ],
-            'backend without config data' => [
-                'areaCode' => Area::AREA_ADMINHTML,
-                'configData' => null,
-                'expectedResult' => true
+            'admin, no available_in_backend config → allowed' => [
+                Area::AREA_ADMINHTML, null, false, null, true,
             ],
-            'front end with config data 0' => [
-                'areaCode' => Area::AREA_FRONTEND,
-                'configData' => '0',
-                'expectedResult' => true
+            'frontend, available_in_backend=0 → allowed (flag only applies to admin)' => [
+                Area::AREA_FRONTEND, '0', false, null, true,
             ],
-            'front end with config data 1' => [
-                'areaCode' => Area::AREA_FRONTEND,
-                'configData' => '1',
-                'expectedResult' => true
+            'frontend, no provider → allowed' => [
+                Area::AREA_FRONTEND, null, false, null, true,
             ],
-            'front end without config data' => [
-                'areaCode' => Area::AREA_FRONTEND,
-                'configData' => null,
-                'expectedResult' => true
+            'frontend, provider returns visible=true → allowed' => [
+                Area::AREA_FRONTEND, null, true, true, true,
+            ],
+            'frontend, provider returns visible=false → blocked' => [
+                Area::AREA_FRONTEND, null, true, false, false,
+            ],
+            'admin, provider returns visible=true → allowed' => [
+                Area::AREA_ADMINHTML, null, true, true, true,
+            ],
+            'admin, provider returns visible=false → blocked' => [
+                Area::AREA_ADMINHTML, null, true, false, false,
             ],
         ];
+    }
+
+    public function testAreaCodeExceptionAllowsPayment(): void
+    {
+        $method = $this->createMock(MethodInterface::class);
+        $this->state->method('getAreaCode')->willThrowException(new \Exception('Area not set'));
+
+        $resultMock = $this->createMock(ResultInterface::class);
+        $this->resultFactory->method('create')
+            ->with(['isValid' => true, 'failsDescription' => [], 'errorCodes' => []])
+            ->willReturn($resultMock);
+
+        $result = $this->validator->validate(['paymentMethodInstance' => $method]);
+
+        $this->assertSame($resultMock, $result);
     }
 }

--- a/Test/Unit/Model/ConfigProvider/Method/PayPerEmailTest.php
+++ b/Test/Unit/Model/ConfigProvider/Method/PayPerEmailTest.php
@@ -160,7 +160,7 @@ class PayPerEmailTest extends BaseTest
     public static function isVisibleForAreaCodeProvider()
     {
         return [
-            "visibleFrontBack is null" => [null, null, false],
+            "visibleFrontBack is null" => [null, 'frontend', false],
             "visibleFrontBack is frontend areacode adminhtml" => ['frontend', 'adminhtml', false],
             "visibleFrontBack is frontend areacode frontend"  => ['frontend', 'frontend', true],
             "visibleFrontBack is backend areacode adminhtml"  => ['backend', 'adminhtml', true],

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -3180,7 +3180,6 @@
             <argument name="validators" xsi:type="array">
                 <item name="buckaroo_availability" xsi:type="string">BuckarooAvailabilityValidator</item>
                 <item name="country" xsi:type="string">Buckaroo\Magento2\Gateway\Validator\CountryValidator</item>
-                <item name="availability" xsi:type="string">Buckaroo\Magento2\Gateway\Validator\AreaCodeValidator</item>
             </argument>
         </arguments>
     </virtualType>
@@ -3228,9 +3227,21 @@
         <arguments>
             <argument name="code" xsi:type="const">Buckaroo\Magento2\Model\ConfigProvider\Method\PayLink::CODE</argument>
             <argument name="valueHandlerPool" xsi:type="object">PayLinkValueHandlerPool</argument>
+            <argument name="validatorPool" xsi:type="object">PayLinkValidatorPool</argument>
             <argument name="commandPool" xsi:type="object">PayLinkGatewayCommandPool</argument>
         </arguments>
     </virtualType>
+
+    <!-- PayLink validators infrastructure -->
+    <virtualType name="PayLinkValidatorPool" type="Magento\Payment\Gateway\Validator\ValidatorPool">
+        <arguments>
+            <argument name="validators" xsi:type="array">
+                <item name="buckaroo_availability" xsi:type="string">BuckarooAvailabilityValidator</item>
+                <item name="country" xsi:type="string">Buckaroo\Magento2\Gateway\Validator\CountryValidator</item>
+            </argument>
+        </arguments>
+    </virtualType>
+    <!-- END PayLink validators infrastructure -->
     <!-- PayLink Value handlers infrastructure -->
     <virtualType name="PayLinkValueHandlerPool" type="Magento\Payment\Gateway\Config\ValueHandlerPool">
         <arguments>


### PR DESCRIPTION
implement PayLink visibility settings for custom themes