### PR TITLE
Bti 923 magento 2 adjust php restriction to accept compatibillity for php 8.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "magento/module-store": "^101.1",
         "magento/module-tax": "^100.4",
         "magento/module-ui": "^101.2",
-        "laminas/laminas-validator": "^2.64",
+        "laminas/laminas-validator": "^2.13 || ^3.0",
         "buckaroo/sdk": "^1.23.2",
         "monolog/monolog": "^2.9 || ^3.0",
         "psr/log": "^2.0 || ^3.0",


### PR DESCRIPTION
fix: update laminas-validator version constraint for PHP 8.1 compatibility