### PR TITLE
fix: apply Klarna Pay Later + invoice-on-shipment fix to develop-1.x

### DIFF
--- a/Model/Push.php
+++ b/Model/Push.php
@@ -881,7 +881,6 @@ class Push implements PushInterface
         if ($this->hasPostData('add_initiated_by_magento', 1)
             && $this->hasPostData('brq_transaction_method', ['klarnakp', 'KlarnaKp'])
             && $this->hasPostData('add_service_action_from_magento', 'pay')
-            && isset($this->postData['brq_service_klarnakp_captureid'])
         ) {
             return false;
         }
@@ -1833,8 +1832,12 @@ class Push implements PushInterface
                 )
             ) {
                 $this->logging->addDebug(__METHOD__ . '|5_1|');
-                $this->dontSaveOrderUponSuccessPush = true;
-                return true;
+                // Only skip if the invoice already exists; otherwise let the push process
+                // so the invoice can still be created when the synchronous capture failed.
+                if ($this->order->hasInvoices()) {
+                    $this->dontSaveOrderUponSuccessPush = true;
+                    return true;
+                }
             } else {
                 $this->logging->addDebug(__METHOD__ . '|6|');
 
@@ -2104,6 +2107,18 @@ class Push implements PushInterface
         $invoiceHandlingConfig = $this->configAccount->getInvoiceHandling();
 
         if ($invoiceHandlingConfig == InvoiceHandlingOptions::SHIPMENT) {
+            $isKlarnaKp = $this->hasPostData('brq_transaction_method', 'KlarnaKp')
+                || $this->hasPostData('brq_primary_service', 'KlarnaKp');
+            $autoPayKey = $this->postData['brq_service_klarnakp_autopaytransactionkey'] ?? '';
+            $captureId  = $this->postData['brq_service_klarnakp_captureid'] ?? '';
+
+            if ($isKlarnaKp && (!empty($autoPayKey) || !empty($captureId))) {
+                $payment->setAdditionalInformation('buckaroo_already_captured', true);
+                if (!empty($autoPayKey)) {
+                    $payment->setAdditionalInformation(AbstractMethod::BUCKAROO_ORIGINAL_TRANSACTION_KEY_KEY, $autoPayKey);
+                }
+            }
+
             if (!$payment->getAdditionalInformation(InvoiceHandlingOptions::INVOICE_HANDLING)) {
                 $payment->setAdditionalInformation(InvoiceHandlingOptions::INVOICE_HANDLING, $invoiceHandlingConfig);
                 $payment->save();

--- a/Observer/SalesOrderShipmentAfter.php
+++ b/Observer/SalesOrderShipmentAfter.php
@@ -192,6 +192,10 @@ class SalesOrderShipmentAfter implements ObserverInterface
         $this->logger->addDebug(__METHOD__ . '|1|' . var_export($order->getDiscountAmount(), true));
 
         try {
+            if ($order->hasInvoices()) {
+                return null;
+            }
+
             if (!$order->canInvoice()) {
                 return null;
             }
@@ -205,7 +209,12 @@ class SalesOrderShipmentAfter implements ObserverInterface
                 $message = 'Automatically invoiced shipped items.';
             }
 
-            $invoice->setRequestedCaptureCase(\Magento\Sales\Model\Order\Invoice::CAPTURE_ONLINE);
+            $wasCaptured = (bool)$order->getPayment()->getAdditionalInformation('buckaroo_already_captured');
+            $invoice->setRequestedCaptureCase(
+                $wasCaptured
+                    ? \Magento\Sales\Model\Order\Invoice::CAPTURE_OFFLINE
+                    : \Magento\Sales\Model\Order\Invoice::CAPTURE_ONLINE
+            );
             $invoice->register();
             $invoice->getOrder()->setCustomerNoteNotify(false);
             $invoice->getOrder()->setIsInProcess(true);
@@ -228,6 +237,17 @@ class SalesOrderShipmentAfter implements ObserverInterface
             $this->logger->addDebug(__METHOD__ . '|4|');
         } catch (\Exception $e) {
             $order->addStatusHistoryComment('Exception message: ' . $e->getMessage(), false);
+
+            if (!$order->hasInvoices()) {
+                foreach ($order->getAllItems() as $item) {
+                    if ($item->getQtyInvoiced() > 0) {
+                        $item->setQtyInvoiced(0);
+                    }
+                }
+                $order->setTotalInvoiced(0)->setBaseTotalInvoiced(0);
+                $order->setTotalPaid(0)->setBaseTotalPaid(0);
+                $order->setTotalDue($order->getGrandTotal())->setBaseTotalDue($order->getBaseGrandTotal());
+            }
             $order->save();
             return null;
         }


### PR DESCRIPTION
Resolves conflict between develop-1.x refactor of saveInvoice() and BTI-904 Klarna KP handling. Merges both changes:
- Klarna KP capture detection placed inside the shipment-handling early return block (develop-1.x structure preserved)
- hasInvoices() guard prevents double-invoicing in observer
- CAPTURE_OFFLINE used when Klarna already captured to avoid double charge
- Exception handler rolls back invoiced amounts to prevent stuck orders