### PR TITLE
Bti 1140 magento 2 order confirmation email not sent for bank transfer orders with buckaroo status 792

### DIFF
--- a/Model/Push/DefaultProcessor.php
+++ b/Model/Push/DefaultProcessor.php
@@ -54,7 +54,6 @@ use Magento\Sales\Model\Order\Invoice;
 use Magento\Sales\Model\Order\Payment;
 use Magento\Sales\Model\Order\Payment as OrderPayment;
 use Magento\Sales\Model\Order\Payment\Transaction;
-use Buckaroo\Magento2\Model\Transaction\Status\Response;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
@@ -1988,11 +1987,9 @@ class DefaultProcessor implements PushProcessorInterface
         $orderIsCanceledOrWillBeCanceled = $this->order->isCanceled() || $this->order->getState() === Order::STATE_CANCELED;
 
         $statusCode = $this->pushRequest->getStatusCode();
-        $statusCodeInt = $statusCode !== null ? (int)$statusCode : 0;
-        $isSuccessfulPayment = $this->isSuccessfulPaymentStatus($statusCodeInt);
 
-        if ($this->shouldSendPendingPaymentEmail($isSuccessfulPayment, $store, $paymentMethod)) {
-            $this->logger->addDebug('[' . __METHOD__ . ':' . __LINE__ . '] - Process Pending Push - SEND EMAIL (Success Status: ' . $statusCode . ')');
+        if ($this->shouldSendPendingPaymentEmail($orderIsCanceledOrWillBeCanceled, $store, $paymentMethod)) {
+            $this->logger->addDebug('[' . __METHOD__ . ':' . __LINE__ . '] - Process Pending Push - SEND EMAIL (Pending Status: ' . $statusCode . ')');
             $this->orderRequestService->sendOrderEmail($this->order);
         } else {
             $this->logger->addDebug('[' . __METHOD__ . ':' . __LINE__ . '] - Process Pending Push - SKIP EMAIL (Status: ' . $statusCode . ', EmailSent: ' . ($this->order->getEmailSent() ? 'Yes' : 'No') . ', OrderCanceled: ' . ($orderIsCanceledOrWillBeCanceled ? 'Yes' : 'No') . ')');
@@ -2000,18 +1997,23 @@ class DefaultProcessor implements PushProcessorInterface
     }
 
     /**
-     * Check if pending payment email should be sent
+     * Check if a pending payment email should be sent
      *
-     * @param bool  $isSuccessfulPayment
+     * This path is only reachable for methods where canProcessPendingPush() is true
+     * (Transfer, SEPA Direct Debit, PayPerEmail); for those a pending status
+     * (790/791/792) is the expected "order placed" signal, so the confirmation
+     * email must be sent unless the order is canceled.
+     *
+     * @param bool  $orderIsCanceledOrWillBeCanceled
      * @param mixed $store
      * @param mixed $paymentMethod
      *
      * @return bool
      */
-    private function shouldSendPendingPaymentEmail(bool $isSuccessfulPayment, $store, $paymentMethod): bool
+    private function shouldSendPendingPaymentEmail(bool $orderIsCanceledOrWillBeCanceled, $store, $paymentMethod): bool
     {
         return !$this->order->getEmailSent()
-            && $isSuccessfulPayment
+            && !$orderIsCanceledOrWillBeCanceled
             && (
                 $this->configAccount->getOrderConfirmationEmail($store)
                 || $paymentMethod->getConfigData('order_email', $store)
@@ -2184,18 +2186,6 @@ class DefaultProcessor implements PushProcessorInterface
         $words = explode('_', $field);
         $transformedWords = array_map('ucfirst', $words);
         return __(implode(' ', $transformedWords));
-    }
-
-    /**
-     * Checks if a given status code is a successful payment status.
-     *
-     * @param int $statusCode
-     *
-     * @return bool
-     */
-    private function isSuccessfulPaymentStatus(int $statusCode): bool
-    {
-        return $statusCode === Response::STATUSCODE_SUCCESS;
     }
 
     /**

--- a/Test/Unit/Model/Push/DefaultProcessorTest.php
+++ b/Test/Unit/Model/Push/DefaultProcessorTest.php
@@ -1,0 +1,202 @@
+<?php
+declare(strict_types=1);
+
+namespace Buckaroo\Magento2\Test\Unit\Model\Push;
+
+use Magento\Sales\Model\Order;
+
+class DefaultProcessorTest extends \Buckaroo\Magento2\Test\BaseTest
+{
+    protected $instanceClass = 'Buckaroo\Magento2\Model\Push\DefaultProcessor';
+
+    private $orderRequestServiceMock;
+    private $pushTransactionTypeMock;
+    private $loggerMock;
+    private $helperMock;
+    private $transactionMock;
+    private $groupTransactionMock;
+    private $buckarooStatusCodeMock;
+    private $orderStatusFactoryMock;
+    private $configAccountMock;
+    private $giftCardRefundServiceMock;
+    private $uncancelServiceMock;
+    private $resourceConnectionMock;
+    private $giftcardCollectionMock;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->orderRequestServiceMock = $this->getFakeMock('Buckaroo\Magento2\Service\Push\OrderRequestService')->getMock();
+        $this->pushTransactionTypeMock = $this->getFakeMock('Buckaroo\Magento2\Model\Push\PushTransactionType')->getMock();
+        $this->loggerMock = $this->getFakeMock('Buckaroo\Magento2\Logging\BuckarooLoggerInterface')->getMock();
+        $this->helperMock = $this->getFakeMock('Buckaroo\Magento2\Helper\Data')->getMock();
+        $this->transactionMock = $this->getFakeMock('Magento\Sales\Api\Data\TransactionInterface')->getMock();
+        $this->groupTransactionMock = $this->getFakeMock('Buckaroo\Magento2\Helper\PaymentGroupTransaction')->getMock();
+        $this->buckarooStatusCodeMock = $this->getFakeMock('Buckaroo\Magento2\Model\BuckarooStatusCode')->getMock();
+        $this->orderStatusFactoryMock = $this->getFakeMock('Buckaroo\Magento2\Model\OrderStatusFactory')->getMock();
+        $this->configAccountMock = $this->getFakeMock('Buckaroo\Magento2\Model\ConfigProvider\Account')->getMock();
+        $this->giftCardRefundServiceMock = $this->getFakeMock('Buckaroo\Magento2\Model\Service\GiftCardRefundService')->getMock();
+        $this->uncancelServiceMock = $this->getFakeMock('Buckaroo\Magento2\Service\Order\Uncancel')->getMock();
+        $this->resourceConnectionMock = $this->getFakeMock('Magento\Framework\App\ResourceConnection')->getMock();
+        $this->giftcardCollectionMock = $this->getFakeMock('Buckaroo\Magento2\Model\ResourceModel\Giftcard\Collection')->getMock();
+    }
+
+    public function getInstance(array $args = [])
+    {
+        return parent::getInstance([
+            'orderRequestService' => $this->orderRequestServiceMock,
+            'pushTransactionType' => $this->pushTransactionTypeMock,
+            'logger' => $this->loggerMock,
+            'helper' => $this->helperMock,
+            'transaction' => $this->transactionMock,
+            'groupTransaction' => $this->groupTransactionMock,
+            'buckarooStatusCode' => $this->buckarooStatusCodeMock,
+            'orderStatusFactory' => $this->orderStatusFactoryMock,
+            'configAccount' => $this->configAccountMock,
+            'giftCardRefundService' => $this->giftCardRefundServiceMock,
+            'uncancelService' => $this->uncancelServiceMock,
+            'resourceConnection' => $this->resourceConnectionMock,
+            'giftcardCollection' => $this->giftcardCollectionMock,
+        ] + $args);
+    }
+
+    public static function pendingPaymentEmailProvider(): array
+    {
+        return [
+            'sends when not sent, not canceled, global config on' => [
+                'emailSent' => false,
+                'orderIsCanceled' => false,
+                'globalConfigEnabled' => true,
+                'methodOrderEmail' => null,
+                'expected' => true,
+            ],
+            'sends via method-level order_email when global config off' => [
+                'emailSent' => false,
+                'orderIsCanceled' => false,
+                'globalConfigEnabled' => false,
+                'methodOrderEmail' => '1',
+                'expected' => true,
+            ],
+            'skips when email already sent' => [
+                'emailSent' => true,
+                'orderIsCanceled' => false,
+                'globalConfigEnabled' => true,
+                'methodOrderEmail' => null,
+                'expected' => false,
+            ],
+            'skips when order is canceled' => [
+                'emailSent' => false,
+                'orderIsCanceled' => true,
+                'globalConfigEnabled' => true,
+                'methodOrderEmail' => null,
+                'expected' => false,
+            ],
+            'skips when all email configs are off' => [
+                'emailSent' => false,
+                'orderIsCanceled' => false,
+                'globalConfigEnabled' => false,
+                'methodOrderEmail' => 0,
+                'expected' => false,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider pendingPaymentEmailProvider
+     */
+    public function testShouldSendPendingPaymentEmail(
+        bool $emailSent,
+        bool $orderIsCanceled,
+        bool $globalConfigEnabled,
+        $methodOrderEmail,
+        bool $expected
+    ): void {
+        $instance = $this->getInstance();
+
+        $orderMock = $this->getFakeMock('Magento\Sales\Model\Order')->getMock();
+        $orderMock->method('getEmailSent')->willReturn($emailSent);
+
+        $storeMock = $this->getFakeMock('Magento\Store\Model\Store')->getMock();
+
+        $methodInstanceMock = $this->getFakeMock('Magento\Payment\Model\MethodInterface')->getMock();
+        $methodInstanceMock->method('getConfigData')->willReturn($methodOrderEmail);
+
+        $this->configAccountMock->method('getOrderConfirmationEmail')->willReturn($globalConfigEnabled);
+
+        $this->setProperty('order', $orderMock, $instance);
+
+        $result = $this->invokeArgs(
+            'shouldSendPendingPaymentEmail',
+            [$orderIsCanceled, $storeMock, $methodInstanceMock],
+            $instance
+        );
+
+        $this->assertSame($expected, $result);
+    }
+
+    public function testProcessPendingPaymentEmailSendsEmailForWaitingOnConsumerPush(): void
+    {
+        $instance = $this->getInstance();
+
+        $storeMock = $this->getFakeMock('Magento\Store\Model\Store')->getMock();
+
+        $orderMock = $this->getFakeMock('Magento\Sales\Model\Order')->getMock();
+        $orderMock->method('getStore')->willReturn($storeMock);
+        $orderMock->method('getEmailSent')->willReturn(false);
+        $orderMock->method('isCanceled')->willReturn(false);
+        $orderMock->method('getState')->willReturn(Order::STATE_NEW);
+
+        $methodInstanceMock = $this->getFakeMock('Magento\Payment\Model\MethodInterface')->getMock();
+
+        $paymentMock = $this->getFakeMock('Magento\Sales\Model\Order\Payment')->getMock();
+        $paymentMock->method('getMethodInstance')->willReturn($methodInstanceMock);
+
+        $pushRequestMock = $this->getFakeMock('Buckaroo\Magento2\Api\Data\PushRequestInterface')->getMock();
+        $pushRequestMock->method('getStatusCode')->willReturn('792');
+
+        $this->configAccountMock->method('getOrderConfirmationEmail')->willReturn(true);
+
+        $this->orderRequestServiceMock->expects($this->once())
+            ->method('sendOrderEmail')
+            ->with($orderMock);
+
+        $this->setProperty('order', $orderMock, $instance);
+        $this->setProperty('payment', $paymentMock, $instance);
+        $this->setProperty('pushRequest', $pushRequestMock, $instance);
+
+        $this->invokeArgs('processPendingPaymentEmail', [], $instance);
+    }
+
+    public function testProcessPendingPaymentEmailSkipsEmailForCanceledOrder(): void
+    {
+        $instance = $this->getInstance();
+
+        $storeMock = $this->getFakeMock('Magento\Store\Model\Store')->getMock();
+
+        $orderMock = $this->getFakeMock('Magento\Sales\Model\Order')->getMock();
+        $orderMock->method('getStore')->willReturn($storeMock);
+        $orderMock->method('getEmailSent')->willReturn(false);
+        $orderMock->method('isCanceled')->willReturn(true);
+        $orderMock->method('getState')->willReturn(Order::STATE_CANCELED);
+
+        $methodInstanceMock = $this->getFakeMock('Magento\Payment\Model\MethodInterface')->getMock();
+
+        $paymentMock = $this->getFakeMock('Magento\Sales\Model\Order\Payment')->getMock();
+        $paymentMock->method('getMethodInstance')->willReturn($methodInstanceMock);
+
+        $pushRequestMock = $this->getFakeMock('Buckaroo\Magento2\Api\Data\PushRequestInterface')->getMock();
+        $pushRequestMock->method('getStatusCode')->willReturn('792');
+
+        $this->configAccountMock->method('getOrderConfirmationEmail')->willReturn(true);
+
+        $this->orderRequestServiceMock->expects($this->never())
+            ->method('sendOrderEmail');
+
+        $this->setProperty('order', $orderMock, $instance);
+        $this->setProperty('payment', $paymentMock, $instance);
+        $this->setProperty('pushRequest', $pushRequestMock, $instance);
+
+        $this->invokeArgs('processPendingPaymentEmail', [], $instance);
+    }
+}


### PR DESCRIPTION
update pending payment email logic for Bank Transfer orders and add unit tests
