### PR TITLE
Bti 1141 magento 2 incorrect culture code send nl nl instead of nl be for belgium customers for klarna mor

### DIFF
--- a/Gateway/Request/CultureDataBuilder.php
+++ b/Gateway/Request/CultureDataBuilder.php
@@ -1,0 +1,94 @@
+<?php
+/**
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the MIT License
+ * It is available through the world-wide-web at this URL:
+ * https://tldrlegal.com/license/mit-license
+ * If you are unable to obtain it through the world-wide-web, please email
+ * to support@buckaroo.nl, so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade this module to newer
+ * versions in the future. If you wish to customize this module for your
+ * needs please contact support@buckaroo.nl for more information.
+ *
+ * @copyright Copyright (c) Buckaroo B.V.
+ * @license   https://tldrlegal.com/license/mit-license
+ */
+declare(strict_types=1);
+
+namespace Buckaroo\Magento2\Gateway\Request;
+
+use Buckaroo\Magento2\Service\Culture\CultureCodeResolver;
+use Magento\Sales\Model\Order;
+
+/**
+ * Emits the billing-country-based culture code so the Buckaroo SDK client sends
+ * the correct "Culture" header for the transaction (see BuckarooAdapter).
+ *
+ * The value is keyed under {@see self::CULTURE_KEY}, which the adapter consumes
+ * and strips before the request body is sent.
+ */
+class CultureDataBuilder extends AbstractDataBuilder
+{
+    /**
+     * Build-subject key carrying the resolved culture code to the adapter.
+     */
+    public const CULTURE_KEY = 'buckaroo_culture';
+
+    /**
+     * @var CultureCodeResolver
+     */
+    private $cultureCodeResolver;
+
+    /**
+     * @param CultureCodeResolver $cultureCodeResolver
+     */
+    public function __construct(CultureCodeResolver $cultureCodeResolver)
+    {
+        $this->cultureCodeResolver = $cultureCodeResolver;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function build(array $buildSubject): array
+    {
+        parent::initialize($buildSubject);
+
+        $order = $this->getOrder();
+
+        $countryId = null;
+        $billingAddress = $order->getBillingAddress();
+        if ($billingAddress !== null) {
+            $countryId = $billingAddress->getCountryId();
+        }
+
+        return [
+            self::CULTURE_KEY => $this->cultureCodeResolver->resolve($countryId, $this->getStoreLocale($order)),
+        ];
+    }
+
+    /**
+     * Get the locale of the store view the order was placed on.
+     *
+     * Used only to disambiguate multi-language countries; it is deterministic
+     * across reserve and capture.
+     *
+     * @param Order $order
+     *
+     * @return string|null
+     */
+    private function getStoreLocale(Order $order): ?string
+    {
+        try {
+            $locale = (string)$order->getStore()->getConfig('general/locale/code');
+
+            return $locale !== '' ? $locale : null;
+        } catch (\Throwable $exception) {
+            return null;
+        }
+    }
+}

--- a/Model/Adapter/BuckarooAdapter.php
+++ b/Model/Adapter/BuckarooAdapter.php
@@ -29,6 +29,7 @@ use Buckaroo\Magento2\Exception;
 use Buckaroo\Magento2\Observer\AddInTestModeMessage;
 use Magento\Framework\Phrase;
 use Buckaroo\Magento2\Gateway\Request\CreditManagement\BuilderComposite;
+use Buckaroo\Magento2\Gateway\Request\CultureDataBuilder;
 use Buckaroo\Magento2\Logging\BuckarooLoggerInterface;
 use Buckaroo\Magento2\Model\Config\Source\Enablemode;
 use Buckaroo\Magento2\Model\ConfigProvider\Account;
@@ -165,7 +166,15 @@ class BuckarooAdapter
         // Extract original transaction mode if available (for post-transaction operations)
         $originalTransactionWasTest = $data[AddInTestModeMessage::PAYMENT_IN_TEST_MODE] ?? null;
 
-        $this->setClientSdk($method, $orderStoreId, $skipActiveCheck, $originalTransactionWasTest);
+        // Extract the billing-country-based culture (set by CultureDataBuilder) so the SDK client
+        // sends the correct "Culture" header. Strip it so it never reaches the request body.
+        $cultureOverride = null;
+        if (isset($data[CultureDataBuilder::CULTURE_KEY])) {
+            $cultureOverride = (string)$data[CultureDataBuilder::CULTURE_KEY];
+            unset($data[CultureDataBuilder::CULTURE_KEY]);
+        }
+
+        $this->setClientSdk($method, $orderStoreId, $skipActiveCheck, $originalTransactionWasTest, $cultureOverride);
         $payment = $this->buckaroo->method($this->getMethodName($method));
 
         try {
@@ -202,10 +211,11 @@ class BuckarooAdapter
     /**
      * Set Client SDK base on account configuration and payment method configuration
      *
-     * @param string    $paymentMethod
-     * @param int|null  $orderStoreId                Store ID from the order (for refund/capture operations)
-     * @param bool      $skipActiveCheck
-     * @param bool|null $originalTransactionWasTest  Whether original transaction was in test mode
+     * @param string      $paymentMethod
+     * @param int|null    $orderStoreId                Store ID from the order (for refund/capture operations)
+     * @param bool        $skipActiveCheck
+     * @param bool|null   $originalTransactionWasTest  Whether original transaction was in test mode
+     * @param string|null $cultureOverride             Culture code derived from the order billing country
      * @throws \Exception
      * @return void
      */
@@ -213,7 +223,8 @@ class BuckarooAdapter
         $paymentMethod = '',
         ?int $orderStoreId = null,
         bool $skipActiveCheck = false,
-        ?bool $originalTransactionWasTest = null
+        ?bool $originalTransactionWasTest = null,
+        ?string $cultureOverride = null
     ): void {
         /** @var Account $configProviderAccount */
         $configProviderAccount = $this->configProviderFactory->get('account');
@@ -233,6 +244,9 @@ class BuckarooAdapter
         $accountMode = $configProviderAccount->getActive($storeId);
         $clientMode = $this->getClientMode($accountMode, $storeId, $paymentMethod, $skipActiveCheck, $originalTransactionWasTest);
 
+        // Prefer the order billing-country culture; fall back to the store/customer locale.
+        $culture = $cultureOverride ?? str_replace('_', '-', $this->localeResolver->getLocale());
+
         $this->buckaroo = new BuckarooClient(new DefaultConfig(
             $this->encryptor->decrypt($configProviderAccount->getMerchantKey($storeId)),
             $this->encryptor->decrypt($configProviderAccount->getSecretKey($storeId)),
@@ -246,7 +260,7 @@ class BuckarooAdapter
             'Buckaroo',
             'Magento2',
             Data::BUCKAROO_VERSION,
-            str_replace('_', '-', $this->localeResolver->getLocale()),
+            $culture,
             null, // Disable SDK logging - SDK's BuckarooException handles null gracefully in log() method
             null, // timeout
             null  // connectTimeout

--- a/Service/Culture/CultureCodeResolver.php
+++ b/Service/Culture/CultureCodeResolver.php
@@ -1,0 +1,161 @@
+<?php
+/**
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the MIT License
+ * It is available through the world-wide-web at this URL:
+ * https://tldrlegal.com/license/mit-license
+ * If you are unable to obtain it through the world-wide-web, please email
+ * to support@buckaroo.nl, so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade this module to newer
+ * versions in the future. If you wish to customize this module for your
+ * needs please contact support@buckaroo.nl for more information.
+ *
+ * @copyright Copyright (c) Buckaroo B.V.
+ * @license   https://tldrlegal.com/license/mit-license
+ */
+declare(strict_types=1);
+
+namespace Buckaroo\Magento2\Service\Culture;
+
+/**
+ * Resolves the Buckaroo "Culture" code for a transaction.
+ *
+ * The billing country is the authoritative signal: it selects the set of culture
+ * codes Buckaroo/Klarna accept for that country. Within a country that has more
+ * than one supported language (e.g. Belgium, Switzerland) an optional locale hint
+ * (the store view locale the order was placed on) picks the matching language.
+ * When the hint does not match, the country's primary culture is used.
+ */
+class CultureCodeResolver
+{
+    /**
+     * Culture used when the billing country and locale hint provide no usable match.
+     *
+     * Matches the Buckaroo SDK's own default and is accepted by Klarna everywhere.
+     */
+    public const DEFAULT_CULTURE = 'en-GB';
+
+    /**
+     * Supported culture codes per billing country (ISO 3166-1 alpha-2).
+     *
+     * The first entry of each list is the country's primary/default culture.
+     *
+     * @var array<string, string[]>
+     */
+    public const COUNTRY_CULTURES = [
+        'NL' => ['nl-NL', 'en-NL'],
+        'BE' => ['nl-BE', 'fr-BE', 'be-BE', 'en-BE'],
+        'DE' => ['de-DE', 'en-DE'],
+        'AT' => ['de-AT', 'en-AT'],
+        'CH' => ['de-CH', 'fr-CH', 'it-CH', 'en-CH'],
+        'SE' => ['sv-SE', 'en-SE'],
+        'NO' => ['nb-NO', 'en-NO'],
+        'DK' => ['da-DK', 'en-DK'],
+        'FI' => ['fi-FI', 'sv-FI', 'en-FI'],
+        'GB' => ['en-GB'],
+        'IE' => ['en-IE'],
+        'FR' => ['fr-FR', 'en-FR'],
+        'IT' => ['it-IT', 'en-IT'],
+        'ES' => ['es-ES', 'en-ES'],
+        'PT' => ['pt-PT', 'en-PT'],
+        'PL' => ['pl-PL', 'en-PL'],
+        'US' => ['en-US'],
+    ];
+
+    /**
+     * Resolve the culture code for a billing country and optional locale hint.
+     *
+     * @param string|null $countryId  Billing address country id (ISO 3166-1 alpha-2)
+     * @param string|null $localeHint Locale to disambiguate multi-language countries (e.g. "fr_BE", "nl-NL")
+     *
+     * @return string A culture code from the supported whitelist
+     */
+    public function resolve(?string $countryId, ?string $localeHint = null): string
+    {
+        $country = strtoupper(trim((string)$countryId));
+        $language = $this->extractLanguage($localeHint);
+
+        if (isset(self::COUNTRY_CULTURES[$country])) {
+            $cultures = self::COUNTRY_CULTURES[$country];
+
+            if ($language !== null) {
+                foreach ($cultures as $culture) {
+                    if (strpos($culture, $language . '-') === 0) {
+                        return $culture;
+                    }
+                }
+            }
+
+            return $cultures[0];
+        }
+
+        // Unmapped country: honour the locale hint verbatim when it is a supported culture.
+        $normalized = $this->normalizeLocale($localeHint);
+        if ($normalized !== null && in_array($normalized, $this->getSupportedCultures(), true)) {
+            return $normalized;
+        }
+
+        return self::DEFAULT_CULTURE;
+    }
+
+    /**
+     * Flattened list of every supported culture code.
+     *
+     * @return string[]
+     */
+    public function getSupportedCultures(): array
+    {
+        return array_values(array_unique(array_merge([], ...array_values(self::COUNTRY_CULTURES))));
+    }
+
+    /**
+     * Extract the lowercase 2-letter language part from a locale string.
+     *
+     * @param string|null $localeHint
+     *
+     * @return string|null
+     */
+    private function extractLanguage(?string $localeHint): ?string
+    {
+        if ($localeHint === null || trim($localeHint) === '') {
+            return null;
+        }
+
+        $parts = preg_split('/[_-]/', trim($localeHint));
+        $language = strtolower($parts[0] ?? '');
+
+        return preg_match('/^[a-z]{2}$/', $language) === 1 ? $language : null;
+    }
+
+    /**
+     * Normalize a locale hint to the "xx-YY" culture format, or null when it is not a full locale.
+     *
+     * @param string|null $localeHint
+     *
+     * @return string|null
+     */
+    private function normalizeLocale(?string $localeHint): ?string
+    {
+        if ($localeHint === null || trim($localeHint) === '') {
+            return null;
+        }
+
+        $parts = preg_split('/[_-]/', trim($localeHint));
+        if (count($parts) < 2) {
+            return null;
+        }
+
+        $language = strtolower($parts[0]);
+        $region = strtoupper($parts[1]);
+
+        if (preg_match('/^[a-z]{2}$/', $language) !== 1 || preg_match('/^[A-Z]{2}$/', $region) !== 1) {
+            return null;
+        }
+
+        return $language . '-' . $region;
+    }
+}

--- a/Test/Unit/Gateway/Request/CultureDataBuilderTest.php
+++ b/Test/Unit/Gateway/Request/CultureDataBuilderTest.php
@@ -21,13 +21,24 @@ declare(strict_types=1);
 
 namespace Buckaroo\Magento2\Test\Unit\Gateway\Request;
 
+use Buckaroo\Magento2\Gateway\Data\Order\OrderAdapter;
 use Buckaroo\Magento2\Gateway\Request\CultureDataBuilder;
 use Buckaroo\Magento2\Service\Culture\CultureCodeResolver;
+use Magento\Payment\Gateway\Data\PaymentDataObjectInterface;
+use Magento\Payment\Model\InfoInterface;
 use Magento\Sales\Api\Data\OrderAddressInterface;
+use Magento\Sales\Model\Order;
 use Magento\Store\Model\Store;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
 
-class CultureDataBuilderTest extends AbstractDataBuilderTest
+class CultureDataBuilderTest extends TestCase
 {
+    /**
+     * @var MockObject|Order
+     */
+    private $orderMock;
+
     /**
      * @var CultureDataBuilder
      */
@@ -35,7 +46,7 @@ class CultureDataBuilderTest extends AbstractDataBuilderTest
 
     protected function setUp(): void
     {
-        parent::setUp();
+        $this->orderMock = $this->createMock(Order::class);
 
         // Real resolver: this test verifies the builder feeds it the right inputs.
         $this->builder = new CultureDataBuilder(new CultureCodeResolver());
@@ -57,9 +68,7 @@ class CultureDataBuilderTest extends AbstractDataBuilderTest
 
     public function testBuildWithoutBillingAddressHonoursStoreLocale(): void
     {
-        $store = $this->createMock(Store::class);
-        $store->method('getConfig')->with('general/locale/code')->willReturn('nl_NL');
-        $this->orderMock->method('getStore')->willReturn($store);
+        $this->mockStoreLocale('nl_NL');
         $this->orderMock->method('getBillingAddress')->willReturn(null);
 
         $result = $this->builder->build(['payment' => $this->getPaymentDOMock()]);
@@ -70,9 +79,7 @@ class CultureDataBuilderTest extends AbstractDataBuilderTest
 
     public function testBuildFallsBackToDefaultWhenNothingUsable(): void
     {
-        $store = $this->createMock(Store::class);
-        $store->method('getConfig')->with('general/locale/code')->willReturn('xx_YY');
-        $this->orderMock->method('getStore')->willReturn($store);
+        $this->mockStoreLocale('xx_YY');
         $this->orderMock->method('getBillingAddress')->willReturn(null);
 
         $result = $this->builder->build(['payment' => $this->getPaymentDOMock()]);
@@ -85,10 +92,7 @@ class CultureDataBuilderTest extends AbstractDataBuilderTest
         $store = $this->createMock(Store::class);
         $store->method('getConfig')->willThrowException(new \RuntimeException('no store'));
         $this->orderMock->method('getStore')->willReturn($store);
-
-        $billingAddress = $this->createMock(OrderAddressInterface::class);
-        $billingAddress->method('getCountryId')->willReturn('BE');
-        $this->orderMock->method('getBillingAddress')->willReturn($billingAddress);
+        $this->mockBillingCountry('BE');
 
         $result = $this->builder->build(['payment' => $this->getPaymentDOMock()]);
 
@@ -104,14 +108,51 @@ class CultureDataBuilderTest extends AbstractDataBuilderTest
      */
     private function buildWith(string $countryId, string $storeLocale): array
     {
+        $this->mockStoreLocale($storeLocale);
+        $this->mockBillingCountry($countryId);
+
+        return $this->builder->build(['payment' => $this->getPaymentDOMock()]);
+    }
+
+    /**
+     * @param string $storeLocale
+     *
+     * @return void
+     */
+    private function mockStoreLocale(string $storeLocale): void
+    {
         $store = $this->createMock(Store::class);
         $store->method('getConfig')->with('general/locale/code')->willReturn($storeLocale);
         $this->orderMock->method('getStore')->willReturn($store);
+    }
 
+    /**
+     * @param string $countryId
+     *
+     * @return void
+     */
+    private function mockBillingCountry(string $countryId): void
+    {
         $billingAddress = $this->createMock(OrderAddressInterface::class);
         $billingAddress->method('getCountryId')->willReturn($countryId);
         $this->orderMock->method('getBillingAddress')->willReturn($billingAddress);
+    }
 
-        return $this->builder->build(['payment' => $this->getPaymentDOMock()]);
+    /**
+     * Build a payment data object mock exposing the order.
+     *
+     * @return MockObject|PaymentDataObjectInterface
+     */
+    private function getPaymentDOMock()
+    {
+        $paymentDOMock = $this->createMock(PaymentDataObjectInterface::class);
+
+        $orderAdapter = $this->createMock(OrderAdapter::class);
+        $orderAdapter->method('getOrder')->willReturn($this->orderMock);
+        $paymentDOMock->method('getOrder')->willReturn($orderAdapter);
+
+        $paymentDOMock->method('getPayment')->willReturn($this->createMock(InfoInterface::class));
+
+        return $paymentDOMock;
     }
 }

--- a/Test/Unit/Gateway/Request/CultureDataBuilderTest.php
+++ b/Test/Unit/Gateway/Request/CultureDataBuilderTest.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the MIT License
+ * It is available through the world-wide-web at this URL:
+ * https://tldrlegal.com/license/mit-license
+ * If you are unable to obtain it through the world-wide-web, please email
+ * to support@buckaroo.nl, so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade this module to newer
+ * versions in the future. If you wish to customize this module for your
+ * needs please contact support@buckaroo.nl for more information.
+ *
+ * @copyright Copyright (c) Buckaroo B.V.
+ * @license   https://tldrlegal.com/license/mit-license
+ */
+declare(strict_types=1);
+
+namespace Buckaroo\Magento2\Test\Unit\Gateway\Request;
+
+use Buckaroo\Magento2\Gateway\Request\CultureDataBuilder;
+use Buckaroo\Magento2\Service\Culture\CultureCodeResolver;
+use Magento\Sales\Api\Data\OrderAddressInterface;
+use Magento\Store\Model\Store;
+
+class CultureDataBuilderTest extends AbstractDataBuilderTest
+{
+    /**
+     * @var CultureDataBuilder
+     */
+    private $builder;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Real resolver: this test verifies the builder feeds it the right inputs.
+        $this->builder = new CultureDataBuilder(new CultureCodeResolver());
+    }
+
+    public function testBuildResolvesBelgiumToDutchOnDutchStore(): void
+    {
+        $result = $this->buildWith('BE', 'nl_NL');
+
+        $this->assertSame(['buckaroo_culture' => 'nl-BE'], $result);
+    }
+
+    public function testBuildResolvesBelgiumFrenchStoreToFrench(): void
+    {
+        $result = $this->buildWith('BE', 'fr_BE');
+
+        $this->assertSame(['buckaroo_culture' => 'fr-BE'], $result);
+    }
+
+    public function testBuildWithoutBillingAddressHonoursStoreLocale(): void
+    {
+        $store = $this->createMock(Store::class);
+        $store->method('getConfig')->with('general/locale/code')->willReturn('nl_NL');
+        $this->orderMock->method('getStore')->willReturn($store);
+        $this->orderMock->method('getBillingAddress')->willReturn(null);
+
+        $result = $this->builder->build(['payment' => $this->getPaymentDOMock()]);
+
+        // No billing country: fall back to the (whitelisted) store locale verbatim.
+        $this->assertSame(['buckaroo_culture' => 'nl-NL'], $result);
+    }
+
+    public function testBuildFallsBackToDefaultWhenNothingUsable(): void
+    {
+        $store = $this->createMock(Store::class);
+        $store->method('getConfig')->with('general/locale/code')->willReturn('xx_YY');
+        $this->orderMock->method('getStore')->willReturn($store);
+        $this->orderMock->method('getBillingAddress')->willReturn(null);
+
+        $result = $this->builder->build(['payment' => $this->getPaymentDOMock()]);
+
+        $this->assertSame(['buckaroo_culture' => CultureCodeResolver::DEFAULT_CULTURE], $result);
+    }
+
+    public function testBuildToleratesStoreLocaleFailure(): void
+    {
+        $store = $this->createMock(Store::class);
+        $store->method('getConfig')->willThrowException(new \RuntimeException('no store'));
+        $this->orderMock->method('getStore')->willReturn($store);
+
+        $billingAddress = $this->createMock(OrderAddressInterface::class);
+        $billingAddress->method('getCountryId')->willReturn('BE');
+        $this->orderMock->method('getBillingAddress')->willReturn($billingAddress);
+
+        $result = $this->builder->build(['payment' => $this->getPaymentDOMock()]);
+
+        // Locale hint unavailable -> primary culture for the country.
+        $this->assertSame(['buckaroo_culture' => 'nl-BE'], $result);
+    }
+
+    /**
+     * @param string $countryId
+     * @param string $storeLocale
+     *
+     * @return array
+     */
+    private function buildWith(string $countryId, string $storeLocale): array
+    {
+        $store = $this->createMock(Store::class);
+        $store->method('getConfig')->with('general/locale/code')->willReturn($storeLocale);
+        $this->orderMock->method('getStore')->willReturn($store);
+
+        $billingAddress = $this->createMock(OrderAddressInterface::class);
+        $billingAddress->method('getCountryId')->willReturn($countryId);
+        $this->orderMock->method('getBillingAddress')->willReturn($billingAddress);
+
+        return $this->builder->build(['payment' => $this->getPaymentDOMock()]);
+    }
+}

--- a/Test/Unit/Service/Culture/CultureCodeResolverTest.php
+++ b/Test/Unit/Service/Culture/CultureCodeResolverTest.php
@@ -1,0 +1,115 @@
+<?php
+/**
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the MIT License
+ * It is available through the world-wide-web at this URL:
+ * https://tldrlegal.com/license/mit-license
+ * If you are unable to obtain it through the world-wide-web, please email
+ * to support@buckaroo.nl, so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade this module to newer
+ * versions in the future. If you wish to customize this module for your
+ * needs please contact support@buckaroo.nl for more information.
+ *
+ * @copyright Copyright (c) Buckaroo B.V.
+ * @license   https://tldrlegal.com/license/mit-license
+ */
+declare(strict_types=1);
+
+namespace Buckaroo\Magento2\Test\Unit\Service\Culture;
+
+use Buckaroo\Magento2\Service\Culture\CultureCodeResolver;
+use PHPUnit\Framework\TestCase;
+
+class CultureCodeResolverTest extends TestCase
+{
+    /**
+     * @var CultureCodeResolver
+     */
+    private $resolver;
+
+    protected function setUp(): void
+    {
+        $this->resolver = new CultureCodeResolver();
+    }
+
+    /**
+     * @dataProvider resolveProvider
+     */
+    public function testResolve(?string $country, ?string $localeHint, string $expected): void
+    {
+        $this->assertSame($expected, $this->resolver->resolve($country, $localeHint));
+    }
+
+    /**
+     * @return array<string, array{0: string|null, 1: string|null, 2: string}>
+     */
+    public static function resolveProvider(): array
+    {
+        return [
+            // The reported bug: Belgium order on a Dutch store must be nl-BE, not nl-NL.
+            'BE dutch store'             => ['BE', 'nl_NL', 'nl-BE'],
+            'BE french browser'          => ['BE', 'fr_BE', 'fr-BE'],
+            'BE french store'            => ['BE', 'fr_FR', 'fr-BE'],
+            'BE english store'           => ['BE', 'en_US', 'en-BE'],
+            'BE no hint -> primary'      => ['BE', null, 'nl-BE'],
+            'BE unknown lang -> primary' => ['BE', 'pl_PL', 'nl-BE'],
+
+            // Netherlands
+            'NL default'                 => ['NL', 'nl_NL', 'nl-NL'],
+            'NL english'                 => ['NL', 'en_US', 'en-NL'],
+
+            // Switzerland (four supported languages)
+            'CH german'                  => ['CH', 'de_CH', 'de-CH'],
+            'CH french'                  => ['CH', 'fr_FR', 'fr-CH'],
+            'CH italian'                 => ['CH', 'it_IT', 'it-CH'],
+            'CH no hint -> primary'      => ['CH', null, 'de-CH'],
+
+            // Single-language / requested countries
+            'DE'                         => ['DE', 'de_DE', 'de-DE'],
+            'AT'                         => ['AT', 'de_AT', 'de-AT'],
+            'FR'                         => ['FR', 'fr_FR', 'fr-FR'],
+            'IT'                         => ['IT', 'it_IT', 'it-IT'],
+            'ES'                         => ['ES', 'es_ES', 'es-ES'],
+            'PT'                         => ['PT', 'pt_PT', 'pt-PT'],
+            'PL'                         => ['PL', 'pl_PL', 'pl-PL'],
+            'FI finnish'                 => ['FI', 'fi_FI', 'fi-FI'],
+            'FI swedish'                 => ['FI', 'sv_SE', 'sv-FI'],
+            'GB'                         => ['GB', 'en_GB', 'en-GB'],
+            'SE'                         => ['SE', 'sv_SE', 'sv-SE'],
+            'NO'                         => ['NO', 'nb_NO', 'nb-NO'],
+            'DK'                         => ['DK', 'da_DK', 'da-DK'],
+
+            // Country id casing is normalized
+            'lowercase country'          => ['be', 'fr_BE', 'fr-BE'],
+
+            // Unmapped country: honour a valid locale hint, else default
+            'unmapped valid hint'        => ['LU', 'de_DE', 'de-DE'],
+            'unmapped unknown hint'      => ['LU', 'xx_YY', CultureCodeResolver::DEFAULT_CULTURE],
+            'unmapped no hint'           => ['LU', null, CultureCodeResolver::DEFAULT_CULTURE],
+
+            // Missing / empty billing country
+            'empty country no hint'      => ['', null, CultureCodeResolver::DEFAULT_CULTURE],
+            'null country'               => [null, null, CultureCodeResolver::DEFAULT_CULTURE],
+        ];
+    }
+
+    public function testEveryResolvedCultureIsWhitelisted(): void
+    {
+        $supported = $this->resolver->getSupportedCultures();
+
+        foreach (array_keys(CultureCodeResolver::COUNTRY_CULTURES) as $country) {
+            foreach (['nl', 'fr', 'de', 'it', 'en', 'sv', null] as $lang) {
+                $hint = $lang === null ? null : $lang . '_XX';
+                $this->assertContains(
+                    $this->resolver->resolve($country, $hint),
+                    $supported,
+                    sprintf('Culture for %s / %s must be whitelisted', $country, (string)$lang)
+                );
+            }
+        }
+    }
+}

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -1445,6 +1445,7 @@
                 <item name="order_request" xsi:type="string">BuckarooOrderRequest</item>
                 <item name="customer" xsi:type="string">CustomerKlarnaDataBuilder</item>
                 <item name="articles" xsi:type="string">Buckaroo\Magento2\Gateway\Request\Articles\ArticlesDataBuilder</item>
+                <item name="culture" xsi:type="string">Buckaroo\Magento2\Gateway\Request\CultureDataBuilder</item>
                 <!-- Override BuckarooOrderRequest's "pay" action so the redirect returns service_action_from_magento=reserve -->
                 <item name="additional_parameters" xsi:type="string">AdditionalParametersReserveDataBuilder</item>
             </argument>
@@ -1520,6 +1521,7 @@
                 <item name="datarequest_key" xsi:type="string">Buckaroo\Magento2\Gateway\Request\DataRequestKeyDataBuilder</item>
                 <item name="order" xsi:type="string">Buckaroo\Magento2\Gateway\Request\BasicParameter\OrderNumberDataBuilder</item>
                 <item name="articles" xsi:type="string">Buckaroo\Magento2\Gateway\Request\Articles\InvoicedArticlesDataBuilder</item>
+                <item name="culture" xsi:type="string">Buckaroo\Magento2\Gateway\Request\CultureDataBuilder</item>
             </argument>
         </arguments>
     </virtualType>
@@ -1549,6 +1551,7 @@
                 <item name="additional_parameters" xsi:type="string">AdditionalParametersCancelReservationDataBuilder</item>
                 <item name="datarequest_key" xsi:type="string">Buckaroo\Magento2\Gateway\Request\DataRequestKeyDataBuilder</item>
                 <item name="invoice" xsi:type="string">Buckaroo\Magento2\Gateway\Request\BasicParameter\InvoiceDataBuilder</item>
+                <item name="culture" xsi:type="string">Buckaroo\Magento2\Gateway\Request\CultureDataBuilder</item>
             </argument>
         </arguments>
     </virtualType>
@@ -1571,6 +1574,7 @@
                 <item name="method" xsi:type="string">Buckaroo\Magento2\Gateway\Request\BasicParameter\PaymentMethodDataBuilder</item>
                 <item name="store_id" xsi:type="string">Buckaroo\Magento2\Gateway\Request\BasicParameter\StoreIdDataBuilder</item>
                 <item name="datarequest_key" xsi:type="string">Buckaroo\Magento2\Gateway\Request\UpdateReservationDataBuilder</item>
+                <item name="culture" xsi:type="string">Buckaroo\Magento2\Gateway\Request\CultureDataBuilder</item>
             </argument>
         </arguments>
     </virtualType>
@@ -1593,6 +1597,7 @@
                 <item name="method" xsi:type="string">Buckaroo\Magento2\Gateway\Request\BasicParameter\PaymentMethodDataBuilder</item>
                 <item name="store_id" xsi:type="string">Buckaroo\Magento2\Gateway\Request\BasicParameter\StoreIdDataBuilder</item>
                 <item name="datarequest_key" xsi:type="string">Buckaroo\Magento2\Gateway\Request\ExtendReservationDataBuilder</item>
+                <item name="culture" xsi:type="string">Buckaroo\Magento2\Gateway\Request\CultureDataBuilder</item>
             </argument>
         </arguments>
     </virtualType>


### PR DESCRIPTION
implement culture code handling for Klarna transactions based on billing country