### PR TITLE
BTI-1207-Magento-2-Add-Support-for-Magento-2.4.9

### DIFF
--- a/Block/Adminhtml/Config/Support/SupportTab.php
+++ b/Block/Adminhtml/Config/Support/SupportTab.php
@@ -39,7 +39,7 @@ class SupportTab extends Template implements RendererInterface
      * @var array
      */
     private $phpVersionSupport = [
-        '2.4' => ['8.1' => ['+'], '8.2' => ['+'], '8.3' => ['+'], '8.4' => ['+']],
+        '2.4' => ['8.1' => ['+'], '8.2' => ['+'], '8.3' => ['+'], '8.4' => ['+'], '8.5' => ['+']],
     ];
 
     /**

--- a/Block/Adminhtml/Giftcard/Edit.php
+++ b/Block/Adminhtml/Giftcard/Edit.php
@@ -56,7 +56,7 @@ class Edit extends Container
 
         if ($giftcard->getId()) {
             $giftcardTitle = $this->escapeHtml($giftcard->getLabel());
-            return (string) __("Edit Giftcard '%s'", $giftcardTitle);
+            return (string) __("Edit Giftcard '%1'", $giftcardTitle);
         }
 
         return (string) __('Add Giftcard');

--- a/Gateway/Command/GatewayCommand.php
+++ b/Gateway/Command/GatewayCommand.php
@@ -311,7 +311,7 @@ class GatewayCommand implements CommandInterface
                 $this->logger->critical('Payment Error: ' . $errorCodeOrMessage);
             }
         } else {
-            $messages[] = (string)$result->getFailsDescription()[0] ?? '';
+            $messages[] = (string)($result->getFailsDescription()[0] ?? '');
         }
 
         $errorMessage = '';

--- a/Gateway/Http/Client/DefaultTransaction.php
+++ b/Gateway/Http/Client/DefaultTransaction.php
@@ -86,7 +86,7 @@ class DefaultTransaction implements ClientInterface
             'client' => static::class
         ];
         $response['object'] = [];
-        $paymentMethod = $data['payment_method'];
+        $paymentMethod = $data['payment_method'] ?? '';
         unset($data['payment_method']);
 
         if ($this->action === TransactionType::REFUND &&

--- a/Gateway/Http/Client/Json.php
+++ b/Gateway/Http/Client/Json.php
@@ -39,12 +39,12 @@ class Json
     /**
      * @var string
      */
-    private $secretKey;
+    private $secretKey = '';
 
     /**
      * @var string
      */
-    private $websiteKey;
+    private $websiteKey = '';
 
     /**
      * @param Curl                    $client

--- a/Gateway/Http/Client/TransactionPayOrInInstallments.php
+++ b/Gateway/Http/Client/TransactionPayOrInInstallments.php
@@ -32,7 +32,7 @@ class TransactionPayOrInInstallments extends DefaultTransaction
     {
         $action = TransactionType::PAY_IN_INSTALLMENTS;
 
-        if ($data['additionalParameters']['service_action_from_magento'] === TransactionType::PAY) {
+        if (($data['additionalParameters']['service_action_from_magento'] ?? null) === TransactionType::PAY) {
             $action = TransactionType::PAY;
         }
 

--- a/Gateway/Request/Articles/ArticlesHandler/AbstractArticlesHandler.php
+++ b/Gateway/Request/Articles/ArticlesHandler/AbstractArticlesHandler.php
@@ -497,19 +497,19 @@ abstract class AbstractArticlesHandler implements ArticleHandlerInterface
         $edition = $this->softwareData->getProductMetaData()->getEdition();
 
         if ($this->order->getDiscountAmount() < 0) {
-            $discount -= abs((double)$this->order->getDiscountAmount());
+            $discount -= abs((float)$this->order->getDiscountAmount());
 
             $includesTax = (bool)$this->scopeConfig->getValue(
                 static::TAX_CALCULATION_INCLUDES_TAX,
                 ScopeInterface::SCOPE_STORE
             );
             if (!$includesTax) {
-                $discount -= abs((double)$this->order->getDiscountTaxCompensationAmount());
+                $discount -= abs((float)$this->order->getDiscountTaxCompensationAmount());
             }
         }
 
         if ($edition == 'Enterprise' && $this->order->getCustomerBalanceAmount() > 0) {
-            $discount -= abs((double)$this->order->getCustomerBalanceAmount());
+            $discount -= abs((float)$this->order->getCustomerBalanceAmount());
         }
 
         return $discount;
@@ -525,7 +525,7 @@ abstract class AbstractArticlesHandler implements ArticleHandlerInterface
         $totalExclTax = 0.0;
         $weightedTax = 0.0;
 
-        foreach ($this->order->getAllVisibleItems() as $item) {
+        foreach (($this->order->getAllVisibleItems() ?: []) as $item) {
             $rowTotal = (float)$item->getRowTotal();
             if ($rowTotal <= 0) {
                 continue;
@@ -564,11 +564,11 @@ abstract class AbstractArticlesHandler implements ArticleHandlerInterface
      */
     public function getServiceCostLine($order, &$itemsTotalAmount = 0, bool $creditmemo = false): array
     {
-        $buckarooFeeLine = (double)$order->getBuckarooFeeInclTax();
+        $buckarooFeeLine = (float)$order->getBuckarooFeeInclTax();
 
         if (!$buckarooFeeLine && ($order->getBuckarooFee() >= 0.01)) {
             $this->buckarooLog->addDebug(__METHOD__ . '|5|');
-            $buckarooFeeLine = (double)$order->getBuckarooFee();
+            $buckarooFeeLine = (float)$order->getBuckarooFee();
         }
 
         $article = [];
@@ -742,7 +742,7 @@ abstract class AbstractArticlesHandler implements ArticleHandlerInterface
     protected function getOrderVatGroups(): array
     {
         $groups = [];
-        foreach ($this->order->getAllVisibleItems() as $item) {
+        foreach (($this->order->getAllVisibleItems() ?: []) as $item) {
             $rowTotal = (float)$item->getRowTotal();
             if ($rowTotal <= 0) {
                 continue;

--- a/Model/ConfigProvider/Account.php
+++ b/Model/ConfigProvider/Account.php
@@ -232,7 +232,7 @@ class Account extends AbstractConfigProvider
         }
 
         $label = str_replace('{order_number}', $order->getIncrementId(), $label);
-        $label = str_replace('{shop_name}', $order->getIncrementId(), $label);
+        $label = str_replace('{shop_name}', $store->getName(), $label);
 
         $products = $order->getItems();
         if (count($products)) {

--- a/Model/Order/CreditmemoFactory.php
+++ b/Model/Order/CreditmemoFactory.php
@@ -93,11 +93,11 @@ class CreditmemoFactory extends MagentoCreditmemoFactory
     public function initBuckarooFeeData(array $data, $salesModel)
     {
         if (isset($data['extension_attributes']['buckaroo_fee'])) {
-            $salesModel->setBuckarooFee((double)$data['extension_attributes']['buckaroo_fee']);
+            $salesModel->setBuckarooFee((float)$data['extension_attributes']['buckaroo_fee']);
         }
 
         if (isset($data['extension_attributes']['base_buckaroo_fee'])) {
-            $salesModel->setBaseBuckarooFee((double)$data['extension_attributes']['base_buckaroo_fee']);
+            $salesModel->setBaseBuckarooFee((float)$data['extension_attributes']['base_buckaroo_fee']);
         }
     }
 

--- a/Model/Push/DefaultProcessor.php
+++ b/Model/Push/DefaultProcessor.php
@@ -1530,7 +1530,7 @@ class DefaultProcessor implements PushProcessorInterface
      *
      * @throws Exception
      */
-    private function processSucceededPushAuthorization(): void
+    protected function processSucceededPushAuthorization(): void
     {
         $authPpaymentMethods = [
             Afterpay::CODE,

--- a/Model/Push/PaypalProcessor.php
+++ b/Model/Push/PaypalProcessor.php
@@ -119,7 +119,7 @@ class PaypalProcessor extends DefaultProcessor
         }
 
         $this->logger->addDebug(sprintf(
-            '[PUSH - PayPerEmail] | [Webapi] | [%s:%s] - Get New Status | newStatus: %s',
+            '[PUSH - Paypal] | [Webapi] | [%s:%s] - Get New Status | newStatus: %s',
             __METHOD__,
             __LINE__,
             var_export($newStatus, true)

--- a/Model/Push/PushProcessorsFactory.php
+++ b/Model/Push/PushProcessorsFactory.php
@@ -104,10 +104,14 @@ class PushProcessorsFactory
     private function getPushProcessorClass(?PushTransactionType $pushTransactionType)
     {
         // Set Default Push Processor
-        $pushProcessorClass = $this->pushProcessors['default'];
+        $pushProcessorClass = $this->pushProcessors['default'] ?? null;
+
+        if ($pushTransactionType === null) {
+            return $pushProcessorClass;
+        }
 
         // Set Push Processor by Payment Method
-        $paymentMethod = strtolower($pushTransactionType->getPaymentMethod());
+        $paymentMethod = strtolower((string)$pushTransactionType->getPaymentMethod());
         $pushProcessorClass = $this->pushProcessors[$paymentMethod] ?? $pushProcessorClass;
 
         if ($pushTransactionType->isFromPayPerEmail()

--- a/Test/BaseTest.php
+++ b/Test/BaseTest.php
@@ -103,7 +103,6 @@ abstract class BaseTest extends TestCase
     protected function getMethod($method, $instance)
     {
         $method = new \ReflectionMethod($instance, $method);
-        $method->setAccessible(true);
 
         return $method;
     }
@@ -157,7 +156,6 @@ abstract class BaseTest extends TestCase
 
         $reflection = new \ReflectionObject($instance);
         $property = $reflection->getProperty($property);
-        $property->setAccessible(true);
         return $property->getValue($instance);
     }
 
@@ -176,7 +174,6 @@ abstract class BaseTest extends TestCase
 
         $reflection = new \ReflectionObject($instance);
         $property = $reflection->getProperty($property);
-        $property->setAccessible(true);
         $property->setValue($instance, $value);
 
         return $property;
@@ -250,7 +247,7 @@ abstract class BaseTest extends TestCase
     public function assignDataTest($fixture)
     {
         $data = $this->getFakeMock(\Magento\Framework\DataObject::class)->getMock();
-        $infoInterface = $this->getFakeMock(\Magento\Payment\Model\InfoInterface::class)->getMockForAbstractClass();
+        $infoInterface = $this->getFakeMock(\Magento\Payment\Model\InfoInterface::class)->getMock();
 
         foreach ($fixture as $key => $value) {
             $camelCase = preg_replace_callback(

--- a/Test/Unit/Block/AdminInfoTest.php
+++ b/Test/Unit/Block/AdminInfoTest.php
@@ -107,7 +107,6 @@ class AdminInfoTest extends TestCase
     private function invokeSetDataToTransfer(DataObject $transport, string $field, string $value): void
     {
         $method = new \ReflectionMethod(AdminInfo::class, 'setDataToTransfer');
-        $method->setAccessible(true);
         $method->invoke($this->block, $transport, $field, $value);
     }
 }

--- a/Test/Unit/Block/Adminhtml/Config/Support/SupportTabTest.php
+++ b/Test/Unit/Block/Adminhtml/Config/Support/SupportTabTest.php
@@ -22,6 +22,8 @@ declare(strict_types=1);
 
 namespace Buckaroo\Magento2\Test\Unit\Block\Adminhtml\Config\Support;
 
+
+use PHPUnit\Framework\Attributes\DataProvider;
 use Buckaroo\Magento2\Block\Adminhtml\Config\Support\SupportTab;
 use Buckaroo\Magento2\Service\Software\Data;
 use Buckaroo\Magento2\Test\BaseTest;
@@ -50,12 +52,12 @@ class SupportTabTest extends BaseTest
     }
 
     /**
-     * @dataProvider getVersionsDataProvider
      *
      * @param string $version
      * @param string $phpVersions
      * @param int    $returnValue
      */
+    #[DataProvider('getVersionsDataProvider')]
     public function testWithDifferentMagentoVersionsAndPhpVersions(string $version, string $phpVersions, int $returnValue)
     {
         $productMetaDataMock = $this->getFakeMock(ProductMetadataInterface::class)->getMock();
@@ -73,7 +75,7 @@ class SupportTabTest extends BaseTest
     public static function getVersionsDataProvider(): array
     {
         return [
-            ['2.4.5', '8.1, 8.2, 8.3, 8.4', 1],
+            ['2.4.5', '8.1, 8.2, 8.3, 8.4, 8.5', 1],
             ['6.6.6', 'Cannot determine compatible PHP versions', 0]
         ];
     }

--- a/Test/Unit/Block/Adminhtml/Giftcard/EditTest.php
+++ b/Test/Unit/Block/Adminhtml/Giftcard/EditTest.php
@@ -21,6 +21,8 @@
 
 namespace Buckaroo\Magento2\Test\Unit\Block\Adminhtml\Giftcard;
 
+
+use PHPUnit\Framework\Attributes\DataProvider;
 use Magento\Framework\Phrase;
 use Buckaroo\Magento2\Model\Data\BuckarooGiftcardDataInterface;
 use Buckaroo\Magento2\Block\Adminhtml\Giftcard\Edit;
@@ -33,38 +35,33 @@ class EditTest extends \Buckaroo\Magento2\Test\BaseTest
     public static function headerTextProvider()
     {
         return [
-            [
+            'existing giftcard uses escaped label' => [
                 'id' => 45,
-                'label' => 'Card Label',
-                'expectedArgument' => 'Card Label',
-                'expectedText' => "Edit Giftcard '%s'"
+                'label' => 'Card <b>Label</b>',
+                'expectedText' => "Edit Giftcard 'Card &lt;b&gt;Label&lt;/b&gt;'"
             ],
-            [
+            'no id falls back to add title' => [
                 'id' => null,
                 'label' => 'No ID',
-                'expectedArgument' => 'Will not validate this',
                 'expectedText' => 'Add Giftcard'
             ],
-            [
+            'no id and no label falls back to add title' => [
                 'id' => null,
                 'label' => null,
-                'expectedArgument' => null,
                 'expectedText' => 'Add Giftcard'
             ]
         ];
     }
 
-    /**
-     * @param $id
-     * @param $label
-     * @param $expectedArgument
-     * @param $expectedText
-     *
-     * @dataProvider headerTextProvider
-     */
-    public function testGetHeaderText($id, $label, $expectedArgument, $expectedText)
+    #[DataProvider('headerTextProvider')]
+    public function testGetHeaderText($id, $label, $expectedText)
     {
-        $this->markTestSkipped('Requires full Magento ObjectManager bootstrap — use integration tests.');
+        $objectManager = $this->createMock(\Magento\Framework\ObjectManagerInterface::class);
+        $objectManager->method('get')->willReturnCallback(
+            fn (string $type) => $this->getMockBuilder($type)->disableOriginalConstructor()->getMock()
+        );
+        \Magento\Framework\App\ObjectManager::setInstance($objectManager);
+        \Magento\Framework\Phrase::setRenderer(new \Magento\Framework\Phrase\Renderer\Placeholder());
 
         $giftcardModel = $this->getFakeMock(Giftcard::class)->onlyMethods(['getLabel', 'getId'])->getMock();
         $giftcardModel->method('getId')->willReturn($id);
@@ -73,16 +70,24 @@ class EditTest extends \Buckaroo\Magento2\Test\BaseTest
         $buckarooGiftcardData = $this->getFakeMock(BuckarooGiftcardDataInterface::class)->getMock();
         $buckarooGiftcardData->method('getGiftcardModel')->willReturn($giftcardModel);
 
-        $instance = $this->getInstance(['buckarooGiftcardData' => $buckarooGiftcardData]);
+        $buttonList = $this->getFakeMock(\Magento\Backend\Block\Widget\Button\ButtonList::class)->getMock();
+        $urlBuilder = $this->getFakeMock(\Magento\Framework\UrlInterface::class)->getMock();
+        $urlBuilder->method('getUrl')->willReturn('http://admin.test/url');
+
+        $request = $this->getFakeMock(\Magento\Framework\App\RequestInterface::class)->getMock();
+
+        $context = $this->getFakeMock(\Magento\Backend\Block\Widget\Context::class)->getMock();
+        $context->method('getButtonList')->willReturn($buttonList);
+        $context->method('getUrlBuilder')->willReturn($urlBuilder);
+        $context->method('getRequest')->willReturn($request);
+        $context->method('getEscaper')->willReturn(new \Magento\Framework\Escaper());
+
+        $instance = $this->getInstance([
+            'context' => $context,
+            'buckarooGiftcardData' => $buckarooGiftcardData,
+        ]);
         $result = $instance->getHeaderText();
-        $resultArgs = $result->getArguments();
 
-        $this->assertInstanceOf(Phrase::class, $result);
-        $this->assertEquals($expectedText, $result->getText());
-        $this->assertIsArray($resultArgs);
-
-        if (isset($resultArgs[0])) {
-            $this->assertEquals($expectedArgument, $resultArgs[0]);
-        }
+        $this->assertSame($expectedText, $result);
     }
 }

--- a/Test/Unit/Block/Adminhtml/System/Config/Fieldset/PaymentTest.php
+++ b/Test/Unit/Block/Adminhtml/System/Config/Fieldset/PaymentTest.php
@@ -29,9 +29,20 @@ class PaymentTest extends BaseTest
 {
     protected $instanceClass = Payment::class;
 
+    public function setUp(): void
+    {
+        parent::setUp();
+        // Payment's parent (Config Fieldset) pulls SecureHtmlRenderer from the
+        // global ObjectManager because Payment::__construct does not forward it.
+        $objectManager = $this->createMock(\Magento\Framework\ObjectManagerInterface::class);
+        $objectManager->method('get')->willReturnCallback(
+            fn (string $type) => $this->getMockBuilder($type)->disableOriginalConstructor()->getMock()
+        );
+        \Magento\Framework\App\ObjectManager::setInstance($objectManager);
+    }
+
     public function testIsCollapseState()
     {
-        $this->markTestSkipped('Requires full Magento ObjectManager bootstrap — use integration tests.');
 
         $instance = $this->getInstance();
 
@@ -43,7 +54,6 @@ class PaymentTest extends BaseTest
 
     public function testGetHeaderCommentHtml()
     {
-        $this->markTestSkipped('Requires full Magento ObjectManager bootstrap — use integration tests.');
 
         $instance = $this->getInstance();
 

--- a/Test/Unit/Block/Config/Form/Field/FieldsetTest.php
+++ b/Test/Unit/Block/Config/Form/Field/FieldsetTest.php
@@ -21,6 +21,8 @@
 
 namespace Buckaroo\Magento2\Test\Unit\Block\Config\Form\Field;
 
+
+use PHPUnit\Framework\Attributes\DataProvider;
 use Magento\Backend\Block\Context;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Framework\App\RequestInterface;
@@ -58,14 +60,14 @@ class FieldsetTest extends BaseTest
      * @param $configValue
      * @param $expected
      *
-     * @dataProvider getFrontendClassProvider
      */
+    #[DataProvider('getFrontendClassProvider')]
     public function testGetFrontendClass($configValue, $expected)
     {
         $methodId = 'test_method';
         $elementMock = $this->getFakeMock(AbstractElement::class)
             ->onlyMethods(['getData'])
-            ->getMockForAbstractClass();
+            ->getMock();
         $elementMock->expects($this->atLeastOnce())->method('getData')->with('group')->willReturn([
             'id' => $methodId,
             'children' => [
@@ -75,9 +77,9 @@ class FieldsetTest extends BaseTest
             ]
         ]);
 
-        $requestMock = $this->getFakeMock(RequestInterface::class)->getMockForAbstractClass();
+        $requestMock = $this->getFakeMock(RequestInterface::class)->getMock();
 
-        $scopeConfigMock = $this->getFakeMock(ScopeConfigInterface::class)->getMockForAbstractClass();
+        $scopeConfigMock = $this->getFakeMock(ScopeConfigInterface::class)->getMock();
         $scopeConfigMock->method('getValue')->willReturn($configValue);
 
         $contextMock = $this->getFakeMock(Context::class)->onlyMethods(['getScopeConfig', 'getRequest'])->getMock();
@@ -98,12 +100,12 @@ class FieldsetTest extends BaseTest
                 ]
             ]
         ];
-        $elementMock = $this->getFakeMock(AbstractElement::class)->onlyMethods(['getData'])->getMockForAbstractClass();
+        $elementMock = $this->getFakeMock(AbstractElement::class)->onlyMethods(['getData'])->getMock();
         $elementMock->method('getData')->with('group')->willReturn($elementGroupArray);
 
-        $requestMock = $this->getFakeMock(RequestInterface::class)->getMockForAbstractClass();
+        $requestMock = $this->getFakeMock(RequestInterface::class)->getMock();
 
-        $scopeConfigMock = $this->getFakeMock(ScopeConfigInterface::class)->getMockForAbstractClass();
+        $scopeConfigMock = $this->getFakeMock(ScopeConfigInterface::class)->getMock();
         $scopeConfigMock->method('getValue')
             ->with('buckaroo_magento2/config/path', ScopeConfigInterface::SCOPE_TYPE_DEFAULT, null)
             ->willReturn('1');
@@ -146,11 +148,11 @@ class FieldsetTest extends BaseTest
      * @param $website
      * @param $expected
      *
-     * @dataProvider getScopeValueProvider
      */
+    #[DataProvider('getScopeValueProvider')]
     public function testGetScopeValue($store, $website, $expected)
     {
-        $requestMock = $this->getFakeMock(RequestInterface::class)->getMockForAbstractClass();
+        $requestMock = $this->getFakeMock(RequestInterface::class)->getMock();
         $requestMock->method('getParam')
             ->willReturnCallback(function ($param, $default = null) use ($store, $website) {
                 // Use the parameters to avoid PHPMD warnings

--- a/Test/Unit/Block/InfoTest.php
+++ b/Test/Unit/Block/InfoTest.php
@@ -23,6 +23,8 @@ declare(strict_types=1);
 
 namespace Buckaroo\Magento2\Test\Unit\Block;
 
+
+use PHPUnit\Framework\Attributes\DataProvider;
 use Buckaroo\Magento2\Block\Info;
 use Buckaroo\Magento2\Helper\PaymentGroupTransaction;
 use Buckaroo\Magento2\Model\Method\BuckarooAdapter;
@@ -66,10 +68,10 @@ class InfoTest extends TestCase
     }
 
     /**
-     * @dataProvider missingTransactionKeyProvider
      *
      * @param mixed $storedValue
      */
+    #[DataProvider('missingTransactionKeyProvider')]
     public function testGetPaymentTransactionReferenceReturnsNullWhenKeyIsMissing($storedValue): void
     {
         $this->paymentInfoMock->method('getAdditionalInformation')

--- a/Test/Unit/Controller/Adminhtml/Giftcard/EditTest.php
+++ b/Test/Unit/Controller/Adminhtml/Giftcard/EditTest.php
@@ -52,10 +52,9 @@ class EditTest extends BaseTest
         $buckarooGiftcardDataMock->method('setGiftcardModel')->with($giftcardMock)->willReturnSelf();
 
         // Create session mock - use addMethods for getFormData
-        $sessionMock = $this->getMockBuilder(Session::class)
+        $sessionMock = $this->getMockBuilder(\Buckaroo\Magento2\Test\Unit\Stubs\SessionStub::class)
             ->disableOriginalConstructor()
-            ->addMethods(['getFormData'])
-            ->getMock();
+            ->onlyMethods(['getFormData'])->getMock();
         $sessionMock->method('getFormData')->willReturn([]);
 
         // Create message manager mock

--- a/Test/Unit/Controller/Redirect/ProcessTest.php
+++ b/Test/Unit/Controller/Redirect/ProcessTest.php
@@ -49,17 +49,16 @@ class ProcessTest extends BaseTest
      */
     public function testExecute()
     {
-        $response = $this->getFakeMock(ResponseInterface::class)->getMockForAbstractClass();
+        $response = $this->getFakeMock(ResponseInterface::class)->getMock();
 
-        $request = $this->getFakeMock(RequestInterface::class)->onlyMethods(['getParams'])->getMockForAbstractClass();
+        $request = $this->getFakeMock(RequestInterface::class)->getMock();
         $request->method('getParams')->willReturn([]);
 
-        $redirect = $this->getFakeMock(RedirectInterface::class)->onlyMethods(['redirect'])->getMockForAbstractClass();
+        $redirect = $this->getFakeMock(RedirectInterface::class)->getMock();
         $redirect->method('redirect');
 
         $messageManagerMock = $this->getFakeMock(ManagerInterface::class)
-            ->onlyMethods(['addErrorMessage'])
-            ->getMockForAbstractClass();
+            ->getMock();
         $messageManagerMock->method('addErrorMessage');
 
         $contextMock = $this->getFakeMock(Context::class)
@@ -76,10 +75,8 @@ class ProcessTest extends BaseTest
         $redirectFactoryMock->method('create')->willReturn($redirectMock);
 
         // Add RequestPushFactory mock for redirectRequest
-        $pushRequestMock = $this->getMockBuilder(\Buckaroo\Magento2\Api\Data\PushRequestInterface::class)
-            ->addMethods(['getOriginalRequest', 'getData'])
-            ->onlyMethods(['getStatusCode'])
-            ->getMockForAbstractClass();
+        $pushRequestMock = $this->getMockBuilder(\Buckaroo\Magento2\Test\Unit\Stubs\PushRequestInterfaceStub::class)
+            ->getMock();
         $pushRequestMock->method('getOriginalRequest')->willReturn([]);
         $pushRequestMock->method('getData')->willReturn([]);
         $pushRequestMock->method('getStatusCode')->willReturn('');
@@ -112,18 +109,17 @@ class ProcessTest extends BaseTest
             'brq_datarequest' => null
         ];
 
-        $response = $this->getFakeMock(ResponseInterface::class)->getMockForAbstractClass();
+        $response = $this->getFakeMock(ResponseInterface::class)->getMock();
 
-        $request = $this->getFakeMock(RequestInterface::class)->onlyMethods(['getParams'])->getMockForAbstractClass();
+        $request = $this->getFakeMock(RequestInterface::class)->getMock();
 
         $request->method('getParams')->willReturn($params);
 
-        $redirect = $this->getFakeMock(RedirectInterface::class)->getMockForAbstractClass();
+        $redirect = $this->getFakeMock(RedirectInterface::class)->getMock();
         $redirect->expects($this->once())->method('redirect')->with($response, 'failure_url', []);
 
         $messageManagerMock = $this->getFakeMock(ManagerInterface::class)
-            ->onlyMethods(['addErrorMessage'])
-            ->getMockForAbstractClass();
+            ->getMock();
         $messageManagerMock->method('addErrorMessage');
 
         $contextMock = $this->getFakeMock(Context::class)
@@ -146,13 +142,10 @@ class ProcessTest extends BaseTest
 
         $quoteRecreateMock->method('recreate')->willReturn(false);
 
-        $payment = $this->getFakeMock(Payment::class)
-            ->addMethods(['canProcessPostData'])
-            ->onlyMethods(['getMethodInstance'])
-            ->getMock();
+        $payment = $this->getFakeMock(\Buckaroo\Magento2\Test\Unit\Stubs\PaymentStub::class)
+            ->onlyMethods(['getMethodInstance', 'canProcessPostData'])->getMock();
         $methodInstance = $this->getFakeMock(\Magento\Payment\Model\MethodInterface::class)
-            ->onlyMethods(['getCode', 'getConfigData'])
-            ->getMockForAbstractClass();
+            ->getMock();
         $methodInstance->method('getCode')->willReturn('buckaroo_magento2_other');
         $methodInstance->method('getConfigData')->willReturn('0');
         $payment->method('getMethodInstance')->willReturn($methodInstance);
@@ -175,7 +168,7 @@ class ProcessTest extends BaseTest
         $orderMock->method('save')->willReturnSelf();
         $orderMock->method('getPayment')->willReturn($payment);
 
-        $helperMock = $this->getFakeMock(Data::class)->addMethods(['setRestoreQuoteLastOrder'])->getMock();
+        $helperMock = $this->getFakeMock(\Buckaroo\Magento2\Test\Unit\Stubs\DataStub::class)->onlyMethods(['setRestoreQuoteLastOrder'])->getMock();
 
         $orderStatusFactoryMock = $this->getFakeMock(OrderStatusFactory::class)->onlyMethods(['get'])->getMock();
         $orderStatusFactoryMock->method('get')
@@ -189,10 +182,8 @@ class ProcessTest extends BaseTest
         $transactionMock->method('getOrder')->willReturn($orderMock);
 
         // Mock PushRequestInterface for redirectRequest dependency
-        $pushRequestMock = $this->getFakeMock(\Buckaroo\Magento2\Api\Data\PushRequestInterface::class)
-            ->addMethods(['getOriginalRequest', 'getData', 'hasPostData', 'hasAdditionalInformation'])
-            ->onlyMethods(['getStatusCode'])
-            ->getMockForAbstractClass();
+        $pushRequestMock = $this->getFakeMock(\Buckaroo\Magento2\Test\Unit\Stubs\PushRequestInterfaceStub::class)
+            ->getMock();
         $pushRequestMock->method('getOriginalRequest')->willReturn([]);
         $pushRequestMock->method('getData')->willReturn(['test' => 'data']);
         $pushRequestMock->method('getStatusCode')->willReturn('490');
@@ -209,15 +200,8 @@ class ProcessTest extends BaseTest
         $lockManagerMock->method('lockOrder')->willReturn(true);
 
         // Mock CheckoutSession with getters and setters used by controller
-        $checkoutSessionMock = $this->getFakeMock(\Magento\Checkout\Model\Session::class)
-            ->addMethods([
-                'setRestoreQuoteLastOrder',
-                'getLastSuccessQuoteId', 'getLastQuoteId', 'getLastOrderId', 'getLastRealOrderId',
-                'setLastSuccessQuoteId', 'setLastQuoteId', 'setLastOrderId', 'setLastRealOrderId',
-                'setLastOrderStatus'
-            ])
-            ->onlyMethods(['restoreQuote'])
-            ->getMock();
+        $checkoutSessionMock = $this->getFakeMock(\Buckaroo\Magento2\Test\Unit\Stubs\SessionStub2::class)
+            ->onlyMethods(['restoreQuote', 'setRestoreQuoteLastOrder', 'getLastSuccessQuoteId', 'getLastQuoteId', 'getLastOrderId', 'getLastRealOrderId', 'setLastSuccessQuoteId', 'setLastQuoteId', 'setLastOrderId', 'setLastRealOrderId', 'setLastOrderStatus'])->getMock();
         $checkoutSessionMock->method('setRestoreQuoteLastOrder')->willReturnSelf();
         $checkoutSessionMock->method('getLastSuccessQuoteId')->willReturn(null);
         $checkoutSessionMock->method('getLastQuoteId')->willReturn(null);
@@ -263,17 +247,16 @@ class ProcessTest extends BaseTest
             'brq_datarequest' => null
         ];
 
-        $response = $this->getFakeMock(ResponseInterface::class)->getMockForAbstractClass();
+        $response = $this->getFakeMock(ResponseInterface::class)->getMock();
 
-        $request = $this->getFakeMock(RequestInterface::class)->onlyMethods(['getParams'])->getMockForAbstractClass();
+        $request = $this->getFakeMock(RequestInterface::class)->getMock();
         $request->method('getParams')->willReturn($params);
 
-        $redirect = $this->getFakeMock(RedirectInterface::class)->getMockForAbstractClass();
+        $redirect = $this->getFakeMock(RedirectInterface::class)->getMock();
         $redirect->expects($this->once())->method('redirect')->with($response, 'failure_url', []);
 
         $messageManagerMock = $this->getFakeMock(ManagerInterface::class)
-            ->onlyMethods(['addErrorMessage'])
-            ->getMockForAbstractClass();
+            ->getMock();
         $messageManagerMock->method('addErrorMessage');
 
         $contextMock = $this->getFakeMock(Context::class)
@@ -292,13 +275,10 @@ class ProcessTest extends BaseTest
         $configProviderMock->method('getFailureRedirectToCheckout')->willReturn(false);
         $configProviderMock->method('getCancelOnBrowserBack')->willReturn(false);
 
-        $payment = $this->getFakeMock(Payment::class)
-            ->addMethods(['canProcessPostData'])
-            ->onlyMethods(['getMethodInstance'])
-            ->getMock();
+        $payment = $this->getFakeMock(\Buckaroo\Magento2\Test\Unit\Stubs\PaymentStub::class)
+            ->onlyMethods(['getMethodInstance', 'canProcessPostData'])->getMock();
         $methodInstance2 = $this->getFakeMock(\Magento\Payment\Model\MethodInterface::class)
-            ->onlyMethods(['getCode', 'getConfigData'])
-            ->getMockForAbstractClass();
+            ->getMock();
         $methodInstance2->method('getCode')->willReturn('buckaroo_magento2_other');
         $methodInstance2->method('getConfigData')->willReturn('0');
         $payment->method('getMethodInstance')->willReturn($methodInstance2);
@@ -314,7 +294,7 @@ class ProcessTest extends BaseTest
         $orderMock->method('getStore')->willReturnSelf();
         $orderMock->method('getPayment')->willReturn($payment);
 
-        $helperMock = $this->getFakeMock(Data::class)->addMethods(['setRestoreQuoteLastOrder'])->getMock();
+        $helperMock = $this->getFakeMock(\Buckaroo\Magento2\Test\Unit\Stubs\DataStub::class)->onlyMethods(['setRestoreQuoteLastOrder'])->getMock();
 
         $transactionMock = $this->getFakeMock(\Magento\Sales\Model\Order\Payment\Transaction::class)
             ->onlyMethods(['getOrder', 'load'])
@@ -328,10 +308,8 @@ class ProcessTest extends BaseTest
         $redirectFactoryMock->method('create')->willReturn($redirectMock);
 
         // Mock PushRequestInterface for redirectRequest dependency
-        $pushRequestMock = $this->getFakeMock(\Buckaroo\Magento2\Api\Data\PushRequestInterface::class)
-            ->addMethods(['getOriginalRequest', 'getData', 'hasPostData', 'hasAdditionalInformation'])
-            ->onlyMethods(['getStatusCode'])
-            ->getMockForAbstractClass();
+        $pushRequestMock = $this->getFakeMock(\Buckaroo\Magento2\Test\Unit\Stubs\PushRequestInterfaceStub::class)
+            ->getMock();
         $pushRequestMock->method('getOriginalRequest')->willReturn([]);
         $pushRequestMock->method('getData')->willReturn(['test' => 'data']);
         $pushRequestMock->method('getStatusCode')->willReturn('490');
@@ -348,15 +326,8 @@ class ProcessTest extends BaseTest
         $lockManagerMock->method('lockOrder')->willReturn(true);
 
         // Mock CheckoutSession
-        $checkoutSessionMock = $this->getFakeMock(\Magento\Checkout\Model\Session::class)
-            ->addMethods([
-                'setRestoreQuoteLastOrder',
-                'getLastSuccessQuoteId', 'getLastQuoteId', 'getLastOrderId', 'getLastRealOrderId',
-                'setLastSuccessQuoteId', 'setLastQuoteId', 'setLastOrderId', 'setLastRealOrderId',
-                'setLastOrderStatus'
-            ])
-            ->onlyMethods(['restoreQuote'])
-            ->getMock();
+        $checkoutSessionMock = $this->getFakeMock(\Buckaroo\Magento2\Test\Unit\Stubs\SessionStub2::class)
+            ->onlyMethods(['restoreQuote', 'setRestoreQuoteLastOrder', 'getLastSuccessQuoteId', 'getLastQuoteId', 'getLastOrderId', 'getLastRealOrderId', 'setLastSuccessQuoteId', 'setLastQuoteId', 'setLastOrderId', 'setLastRealOrderId', 'setLastOrderStatus'])->getMock();
         $checkoutSessionMock->method('setRestoreQuoteLastOrder')->willReturnSelf();
         $checkoutSessionMock->method('getLastSuccessQuoteId')->willReturn(null);
         $checkoutSessionMock->method('getLastQuoteId')->willReturn(null);
@@ -399,17 +370,16 @@ class ProcessTest extends BaseTest
             'brq_statuscode' => 190,
         ];
 
-        $response = $this->getFakeMock(ResponseInterface::class)->getMockForAbstractClass();
+        $response = $this->getFakeMock(ResponseInterface::class)->getMock();
 
-        $request = $this->getFakeMock(RequestInterface::class)->onlyMethods(['getParams'])->getMockForAbstractClass();
+        $request = $this->getFakeMock(RequestInterface::class)->getMock();
         $request->method('getParams')->willReturn($params);
 
-        $redirect = $this->getFakeMock(RedirectInterface::class)->getMockForAbstractClass();
+        $redirect = $this->getFakeMock(RedirectInterface::class)->getMock();
         $redirect->expects($this->once())->method('redirect')->with($response, 'success_url', []);
 
         $messageManagerMock = $this->getFakeMock(ManagerInterface::class)
-            ->onlyMethods(['addSuccessMessage'])
-            ->getMockForAbstractClass();
+            ->getMock();
         $messageManagerMock->method('addSuccessMessage');
 
         $contextMock = $this->getFakeMock(Context::class)
@@ -425,10 +395,8 @@ class ProcessTest extends BaseTest
             ->getMock();
         $configProviderMock->method('getSuccessRedirect')->willReturn('success_url');
 
-        $payment = $this->getFakeMock(Payment::class)
-            ->addMethods(['canProcessPostData', 'processCustomPostData'])
-            ->onlyMethods(['getMethodInstance'])
-            ->getMock();
+        $payment = $this->getFakeMock(\Buckaroo\Magento2\Test\Unit\Stubs\PaymentStub::class)
+            ->onlyMethods(['getMethodInstance', 'canProcessPostData', 'processCustomPostData'])->getMock();
         $payment->method('getMethodInstance')->willReturnSelf();
         $payment->method('canProcessPostData')->with($payment, $params)->willReturn(true);
         $payment->method('processCustomPostData')->with($payment, $params);
@@ -455,7 +423,7 @@ class ProcessTest extends BaseTest
             ->with($this->anything(), $orderMock)
             ->willReturn('success');
 
-        $helperMock = $this->getFakeMock(Data::class)->addMethods(['setRestoreQuoteLastOrder'])->getMock();
+        $helperMock = $this->getFakeMock(\Buckaroo\Magento2\Test\Unit\Stubs\DataStub::class)->onlyMethods(['setRestoreQuoteLastOrder'])->getMock();
 
         // Add redirectFactory mock for Action controllers
         $redirectMock = $this->createMock(\Magento\Framework\Controller\Result\Redirect::class);
@@ -463,10 +431,8 @@ class ProcessTest extends BaseTest
         $redirectFactoryMock->method('create')->willReturn($redirectMock);
 
         // Mock PushRequestInterface for redirectRequest dependency
-        $pushRequestMock = $this->getFakeMock(\Buckaroo\Magento2\Api\Data\PushRequestInterface::class)
-            ->addMethods(['getOriginalRequest', 'getData', 'hasPostData', 'hasAdditionalInformation'])
-            ->onlyMethods(['getStatusCode', 'getDatarequest'])
-            ->getMockForAbstractClass();
+        $pushRequestMock = $this->getFakeMock(\Buckaroo\Magento2\Test\Unit\Stubs\PushRequestInterfaceStub::class)
+            ->getMock();
         $pushRequestMock->method('getOriginalRequest')->willReturn([]);
         $pushRequestMock->method('getData')->willReturn(['test' => 'data']);
         $pushRequestMock->method('getStatusCode')->willReturn('190');
@@ -484,15 +450,8 @@ class ProcessTest extends BaseTest
         $lockManagerMock->method('lockOrder')->willReturn(true);
 
         // Mock CheckoutSession
-        $checkoutSessionMock = $this->getFakeMock(\Magento\Checkout\Model\Session::class)
-            ->addMethods([
-                'setRestoreQuoteLastOrder',
-                'getLastSuccessQuoteId', 'getLastQuoteId', 'getLastOrderId', 'getLastRealOrderId',
-                'setLastSuccessQuoteId', 'setLastQuoteId', 'setLastOrderId', 'setLastRealOrderId',
-                'setLastOrderStatus'
-            ])
-            ->onlyMethods(['restoreQuote'])
-            ->getMock();
+        $checkoutSessionMock = $this->getFakeMock(\Buckaroo\Magento2\Test\Unit\Stubs\SessionStub2::class)
+            ->onlyMethods(['restoreQuote', 'setRestoreQuoteLastOrder', 'getLastSuccessQuoteId', 'getLastQuoteId', 'getLastOrderId', 'getLastRealOrderId', 'setLastSuccessQuoteId', 'setLastQuoteId', 'setLastOrderId', 'setLastRealOrderId', 'setLastOrderStatus'])->getMock();
         $checkoutSessionMock->method('setRestoreQuoteLastOrder')->willReturnSelf();
         $checkoutSessionMock->method('getLastSuccessQuoteId')->willReturn(null);
         $checkoutSessionMock->method('getLastQuoteId')->willReturn(null);

--- a/Test/Unit/Gateway/Command/GatewayCommandTest.php
+++ b/Test/Unit/Gateway/Command/GatewayCommandTest.php
@@ -628,7 +628,7 @@ class GatewayCommandTest extends BaseTest
         $request = ['invoice' => self::ORDER_INCREMENT_ID];
         $transfer = $this->createMock(TransferInterface::class);
 
-        $this->requestBuilder->method('build')->willReturn($request);
+        $this->requestBuilder->method('build')->with($commandSubject)->willReturn($request);
         $this->transferFactory->method('create')->with($request)->willReturn($transfer);
         $this->client->method('placeRequest')
             ->with($this->identicalTo($transfer))

--- a/Test/Unit/Gateway/Command/GatewayCommandTest.php
+++ b/Test/Unit/Gateway/Command/GatewayCommandTest.php
@@ -1,0 +1,677 @@
+<?php
+/**
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the MIT License
+ * It is available through the world-wide-web at this URL:
+ * https://tldrlegal.com/license/mit-license
+ * If you are unable to obtain it through the world-wide-web, please email
+ * to support@buckaroo.nl, so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade this module to newer
+ * versions in the future. If you wish to customize this module for your
+ * needs please contact support@buckaroo.nl for more information.
+ *
+ * @copyright Copyright (c) Buckaroo B.V.
+ * @license   https://tldrlegal.com/license/mit-license
+ */
+declare(strict_types=1);
+
+namespace Buckaroo\Magento2\Test\Unit\Gateway\Command;
+
+use Buckaroo\Magento2\Gateway\Command\GatewayCommand;
+use Buckaroo\Magento2\Gateway\Command\SkipCommandInterface;
+use Buckaroo\Magento2\Gateway\Http\Client\TransactionPayRemainder;
+use Buckaroo\Magento2\Model\LockManagerWrapper;
+use Buckaroo\Magento2\Model\Method\LimitReachException;
+use Buckaroo\Magento2\Model\Service\CancelOrder;
+use Buckaroo\Magento2\Service\SpamLimitService;
+use Buckaroo\Magento2\Test\BaseTest;
+use Buckaroo\Magento2\Test\Unit\Stubs\OrderAdapterInterfaceStub;
+use Magento\Payment\Gateway\Command\CommandException;
+use Magento\Payment\Gateway\Data\PaymentDataObjectInterface;
+use Magento\Payment\Gateway\ErrorMapper\ErrorMessageMapperInterface;
+use Magento\Payment\Gateway\Http\ClientException;
+use Magento\Payment\Gateway\Http\ClientInterface;
+use Magento\Payment\Gateway\Http\ConverterException;
+use Magento\Payment\Gateway\Http\TransferFactoryInterface;
+use Magento\Payment\Gateway\Http\TransferInterface;
+use Magento\Payment\Gateway\Request\BuilderInterface;
+use Magento\Payment\Gateway\Response\HandlerInterface;
+use Magento\Payment\Gateway\Validator\ResultInterface;
+use Magento\Payment\Gateway\Validator\ValidatorInterface;
+use Magento\Payment\Model\InfoInterface;
+use Magento\Payment\Model\MethodInterface;
+use Magento\Sales\Model\Order;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
+
+/**
+ * Behavioral tests for the gateway command executor.
+ *
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
+class GatewayCommandTest extends BaseTest
+{
+    private const ORDER_INCREMENT_ID = '100000123';
+    private const LOCK_TIMEOUT_SECONDS = 5;
+    private const DEFAULT_DECLINE_MESSAGE = 'Transaction has been declined. Please try again later.';
+
+    /**
+     * @var BuilderInterface|MockObject
+     */
+    private $requestBuilder;
+
+    /**
+     * @var TransferFactoryInterface|MockObject
+     */
+    private $transferFactory;
+
+    /**
+     * @var ClientInterface|MockObject
+     */
+    private $client;
+
+    /**
+     * @var LoggerInterface|MockObject
+     */
+    private $logger;
+
+    /**
+     * @var SpamLimitService|MockObject
+     */
+    private $spamLimitService;
+
+    /**
+     * @var CancelOrder|MockObject
+     */
+    private $cancelOrder;
+
+    /**
+     * @var LockManagerWrapper|MockObject
+     */
+    private $lockManager;
+
+    /**
+     * @var HandlerInterface|MockObject
+     */
+    private $handler;
+
+    /**
+     * @var ValidatorInterface|MockObject
+     */
+    private $validator;
+
+    /**
+     * @var ErrorMessageMapperInterface|MockObject
+     */
+    private $errorMessageMapper;
+
+    /**
+     * @var SkipCommandInterface|MockObject
+     */
+    private $skipCommand;
+
+    /**
+     * @var PaymentDataObjectInterface|MockObject
+     */
+    private $paymentDO;
+
+    /**
+     * @var MethodInterface|MockObject
+     */
+    private $methodInstance;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->requestBuilder = $this->createMock(BuilderInterface::class);
+        $this->transferFactory = $this->createMock(TransferFactoryInterface::class);
+        $this->client = $this->createMock(ClientInterface::class);
+        $this->logger = $this->createMock(LoggerInterface::class);
+        $this->spamLimitService = $this->createMock(SpamLimitService::class);
+        $this->cancelOrder = $this->createMock(CancelOrder::class);
+        $this->lockManager = $this->createMock(LockManagerWrapper::class);
+        $this->handler = $this->createMock(HandlerInterface::class);
+        $this->validator = $this->createMock(ValidatorInterface::class);
+        $this->errorMessageMapper = $this->createMock(ErrorMessageMapperInterface::class);
+        $this->skipCommand = $this->createMock(SkipCommandInterface::class);
+    }
+
+    public function testExecuteHappyPathFlowsExactPayloadsThroughPipeline(): void
+    {
+        $commandSubject = $this->createCommandSubject();
+        $request = ['payment_method' => 'ideal', 'invoice' => self::ORDER_INCREMENT_ID, 'amountDebit' => 10.0];
+        $response = ['object' => 'transaction-response', 'status' => 'success'];
+        $transfer = $this->createMock(TransferInterface::class);
+
+        $this->expectLockAcquiredAndReleased();
+
+        $this->cancelOrder->expects($this->once())
+            ->method('cancelPreviousPendingOrder')
+            ->with($this->identicalTo($this->paymentDO));
+
+        $this->requestBuilder->expects($this->once())
+            ->method('build')
+            ->with($commandSubject)
+            ->willReturn($request);
+
+        $this->transferFactory->expects($this->once())
+            ->method('create')
+            ->with($request)
+            ->willReturn($transfer);
+
+        $this->client->expects($this->once())
+            ->method('placeRequest')
+            ->with($this->identicalTo($transfer))
+            ->willReturn($response);
+
+        $this->validator->expects($this->once())
+            ->method('validate')
+            ->with(array_merge($commandSubject, ['response' => $response]))
+            ->willReturn($this->createValidationResult(true));
+
+        $this->handler->expects($this->once())
+            ->method('handle')
+            ->with($commandSubject, $response);
+
+        $this->errorMessageMapper->expects($this->never())->method('getMessage');
+        $this->spamLimitService->expects($this->never())->method('updateRateLimiterCount');
+
+        $this->createCommand()->execute($commandSubject);
+    }
+
+    public function testExecuteThrowsWhenLockCannotBeAcquired(): void
+    {
+        $commandSubject = $this->createCommandSubject();
+
+        $this->lockManager->expects($this->once())
+            ->method('lockOrder')
+            ->with(self::ORDER_INCREMENT_ID, self::LOCK_TIMEOUT_SECONDS)
+            ->willReturn(false);
+        $this->lockManager->expects($this->never())->method('unlockOrder');
+
+        $this->cancelOrder->expects($this->never())->method('cancelPreviousPendingOrder');
+        $this->requestBuilder->expects($this->never())->method('build');
+        $this->client->expects($this->never())->method('placeRequest');
+
+        $this->expectException(CommandException::class);
+        $this->expectExceptionMessage('Could not acquire payment processing lock. Please try again.');
+
+        $this->createCommand()->execute($commandSubject);
+    }
+
+    public function testExecuteThrowsInvalidArgumentBeforeLockingWhenPaymentIsMissing(): void
+    {
+        $this->lockManager->expects($this->never())->method('lockOrder');
+
+        $this->expectException(\InvalidArgumentException::class);
+
+        $this->createCommand()->execute([]);
+    }
+
+    public function testExecuteSkipsGatewayCallButStillUnlocksWhenSkipCommandMatches(): void
+    {
+        $commandSubject = $this->createCommandSubject();
+
+        $this->expectLockAcquiredAndReleased();
+
+        $this->cancelOrder->expects($this->once())
+            ->method('cancelPreviousPendingOrder')
+            ->with($this->identicalTo($this->paymentDO));
+
+        $this->skipCommand->expects($this->once())
+            ->method('isSkip')
+            ->with($commandSubject)
+            ->willReturn(true);
+
+        $this->requestBuilder->expects($this->never())->method('build');
+        $this->transferFactory->expects($this->never())->method('create');
+        $this->client->expects($this->never())->method('placeRequest');
+        $this->validator->expects($this->never())->method('validate');
+        $this->handler->expects($this->never())->method('handle');
+
+        $this->createCommand(null, true, true, true, true)->execute($commandSubject);
+    }
+
+    public function testExecuteProceedsWhenSkipCommandReturnsFalse(): void
+    {
+        $commandSubject = $this->createCommandSubject();
+
+        $this->expectLockAcquiredAndReleased();
+        $this->skipCommand->expects($this->once())
+            ->method('isSkip')
+            ->with($commandSubject)
+            ->willReturn(false);
+
+        $this->stubSuccessfulGatewayRoundTrip($commandSubject, ['status' => 'success']);
+
+        $this->client->expects($this->once())->method('placeRequest');
+
+        $this->createCommand(null, false, false, false, true)->execute($commandSubject);
+    }
+
+    /**
+     * @param \Exception $clientError
+     * @param string $expectedCommandMessage
+     * @param string $expectedLogMessage
+     */
+    #[DataProvider('clientErrorProvider')]
+    public function testClientErrorsAreWrappedInCommandExceptionAndLogged(
+        \Exception $clientError,
+        string $expectedCommandMessage,
+        string $expectedLogMessage
+    ): void {
+        $commandSubject = $this->createCommandSubject();
+        $request = ['invoice' => self::ORDER_INCREMENT_ID];
+        $transfer = $this->createMock(TransferInterface::class);
+
+        $this->expectLockAcquiredAndReleased();
+        $this->requestBuilder->method('build')->willReturn($request);
+        $this->transferFactory->method('create')->with($request)->willReturn($transfer);
+
+        $this->client->expects($this->once())
+            ->method('placeRequest')
+            ->with($this->identicalTo($transfer))
+            ->willThrowException($clientError);
+
+        $this->logger->expects($this->once())
+            ->method('critical')
+            ->with($expectedLogMessage);
+
+        $this->validator->expects($this->never())->method('validate');
+        $this->handler->expects($this->never())->method('handle');
+
+        try {
+            $this->createCommand()->execute($commandSubject);
+            $this->fail('Expected CommandException was not thrown');
+        } catch (CommandException $exception) {
+            $this->assertSame($expectedCommandMessage, $exception->getMessage());
+        }
+    }
+
+    /**
+     * @return array<string, array{0: \Exception, 1: string, 2: string}>
+     */
+    public static function clientErrorProvider(): array
+    {
+        return [
+            'client exception exposes reason' => [
+                new ClientException(__('Connection timed out')),
+                'Payment processing failed: Connection timed out',
+                'Buckaroo Client Error: Connection timed out',
+            ],
+            'converter exception exposes reason' => [
+                new ConverterException(__('Malformed response body')),
+                'Payment data conversion failed: Malformed response body',
+                'Buckaroo Converter Error: Malformed response body',
+            ],
+            'generic exception hides internal detail' => [
+                new \RuntimeException('internal stack detail'),
+                'Payment processing encountered an unexpected error.',
+                'Unexpected Buckaroo Error: internal stack detail',
+            ],
+        ];
+    }
+
+    public function testGenericRequestBuilderFailureIsWrappedWithoutLeakingDetail(): void
+    {
+        $commandSubject = $this->createCommandSubject();
+
+        $this->expectLockAcquiredAndReleased();
+
+        $this->requestBuilder->expects($this->once())
+            ->method('build')
+            ->willThrowException(new \RuntimeException('db credentials leaked'));
+
+        $this->transferFactory->expects($this->never())->method('create');
+        $this->client->expects($this->never())->method('placeRequest');
+
+        try {
+            $this->createCommand()->execute($commandSubject);
+            $this->fail('Expected CommandException was not thrown');
+        } catch (CommandException $exception) {
+            $this->assertSame('Payment processing encountered an unexpected error.', $exception->getMessage());
+            $this->assertStringNotContainsString('db credentials leaked', $exception->getMessage());
+        }
+    }
+
+    public function testValidationFailureWithErrorCodesConsultsMapperAndThrowsMappedMessages(): void
+    {
+        $commandSubject = $this->createCommandSubject();
+        $this->expectLockAcquiredAndReleased();
+        $this->stubSuccessfulGatewayRoundTrip($commandSubject, ['status' => 'failed']);
+
+        $this->validator->expects($this->once())
+            ->method('validate')
+            ->with(array_merge($commandSubject, ['response' => ['status' => 'failed']]))
+            ->willReturn($this->createValidationResult(false, [], ['491', 'F103']));
+
+        $this->errorMessageMapper->expects($this->exactly(2))
+            ->method('getMessage')
+            ->willReturnCallback(function (string $code) {
+                $mapping = [
+                    '491' => __('Invalid parameter'),
+                    'F103' => __('Invalid bank account number'),
+                ];
+                $this->assertArrayHasKey($code, $mapping, 'Mapper consulted with unexpected code: ' . $code);
+                return $mapping[$code];
+            });
+
+        $this->spamLimitService->expects($this->once())
+            ->method('updateRateLimiterCount')
+            ->with($this->identicalTo($this->methodInstance));
+
+        $this->captureCriticalLogs();
+        $this->handler->expects($this->never())->method('handle');
+
+        try {
+            $this->createCommand()->execute($commandSubject);
+            $this->fail('Expected CommandException was not thrown');
+        } catch (CommandException $exception) {
+            $this->assertSame(
+                'Invalid parameter' . PHP_EOL . 'Invalid bank account number',
+                $exception->getMessage()
+            );
+        }
+
+        $this->assertSame(
+            ['Payment Error: Invalid parameter', 'Payment Error: Invalid bank account number'],
+            $this->capturedLogs
+        );
+    }
+
+    public function testValidationFailureWithUnmappedCodeFallsBackToDefaultMessage(): void
+    {
+        $commandSubject = $this->createCommandSubject();
+        $this->expectLockAcquiredAndReleased();
+        $this->stubSuccessfulGatewayRoundTrip($commandSubject, ['status' => 'failed']);
+
+        $this->validator->method('validate')
+            ->willReturn($this->createValidationResult(false, [], ['490']));
+
+        $this->errorMessageMapper->expects($this->once())
+            ->method('getMessage')
+            ->with('490')
+            ->willReturn(null);
+
+        $this->captureCriticalLogs();
+
+        try {
+            $this->createCommand()->execute($commandSubject);
+            $this->fail('Expected CommandException was not thrown');
+        } catch (CommandException $exception) {
+            $this->assertSame(self::DEFAULT_DECLINE_MESSAGE, $exception->getMessage());
+        }
+
+        $this->assertSame(['Payment Error: 490'], $this->capturedLogs);
+    }
+
+    public function testValidationFailureWithoutConfiguredMapperUsesDefaultMessageAndLogsRawCode(): void
+    {
+        $commandSubject = $this->createCommandSubject();
+        $this->expectLockAcquiredAndReleased();
+        $this->stubSuccessfulGatewayRoundTrip($commandSubject, ['status' => 'failed']);
+
+        $this->validator->method('validate')
+            ->willReturn($this->createValidationResult(false, [], ['123']));
+
+        $this->captureCriticalLogs();
+
+        try {
+            $this->createCommand(null, true, true, false)->execute($commandSubject);
+            $this->fail('Expected CommandException was not thrown');
+        } catch (CommandException $exception) {
+            $this->assertSame(self::DEFAULT_DECLINE_MESSAGE, $exception->getMessage());
+        }
+
+        $this->assertSame(['Payment Error: 123'], $this->capturedLogs);
+    }
+
+    public function testValidationFailureWithFailsDescriptionUsesOnlyFirstDescriptionAndSkipsMapper(): void
+    {
+        $commandSubject = $this->createCommandSubject();
+        $this->expectLockAcquiredAndReleased();
+        $this->stubSuccessfulGatewayRoundTrip($commandSubject, ['status' => 'failed']);
+
+        $this->validator->method('validate')
+            ->willReturn($this->createValidationResult(
+                false,
+                [__('Card declined by issuer'), __('Second failure that is ignored')],
+                ['491']
+            ));
+
+        $this->errorMessageMapper->expects($this->never())->method('getMessage');
+        $this->logger->expects($this->never())->method('critical');
+
+        try {
+            $this->createCommand()->execute($commandSubject);
+            $this->fail('Expected CommandException was not thrown');
+        } catch (CommandException $exception) {
+            $this->assertSame('Card declined by issuer', $exception->getMessage());
+        }
+    }
+
+    public function testValidationFailureWhenSpamLimitReachedSetsFlagsInsteadOfThrowing(): void
+    {
+        $commandSubject = $this->createCommandSubject();
+        $response = ['status' => 'failed'];
+        $this->expectLockAcquiredAndReleased();
+        $this->stubSuccessfulGatewayRoundTrip($commandSubject, $response);
+
+        $this->validator->method('validate')
+            ->willReturn($this->createValidationResult(false, [], ['491']));
+
+        $this->spamLimitService->expects($this->once())
+            ->method('updateRateLimiterCount')
+            ->with($this->identicalTo($this->methodInstance))
+            ->willThrowException(new LimitReachException('Max payment attempts reached'));
+
+        $this->spamLimitService->expects($this->once())
+            ->method('setMaxAttemptsFlags')
+            ->with($this->identicalTo($this->paymentDO), 'Max payment attempts reached');
+
+        $this->errorMessageMapper->expects($this->never())->method('getMessage');
+
+        // Pins current behavior: the response handler still runs after the
+        // spam-limit short-circuit even though validation failed.
+        $this->handler->expects($this->once())
+            ->method('handle')
+            ->with($commandSubject, $response);
+
+        $this->createCommand()->execute($commandSubject);
+    }
+
+    public function testExecuteWithoutValidatorAndHandlerCompletesQuietly(): void
+    {
+        $commandSubject = $this->createCommandSubject();
+        $this->expectLockAcquiredAndReleased();
+        $this->stubSuccessfulGatewayRoundTrip($commandSubject, ['status' => 'success']);
+
+        $this->validator->expects($this->never())->method('validate');
+        $this->handler->expects($this->never())->method('handle');
+
+        $this->createCommand(null, false, false, false)->execute($commandSubject);
+    }
+
+    public function testOrderIsUnlockedEvenWhenValidationThrows(): void
+    {
+        $commandSubject = $this->createCommandSubject();
+        $this->expectLockAcquiredAndReleased();
+        $this->stubSuccessfulGatewayRoundTrip($commandSubject, ['status' => 'failed']);
+
+        $this->validator->method('validate')
+            ->willReturn($this->createValidationResult(false, [__('Declined')], []));
+
+        $this->expectException(CommandException::class);
+
+        $this->createCommand()->execute($commandSubject);
+    }
+
+    public function testPayRemainderClientInjectsServiceActionIntoCommandSubject(): void
+    {
+        $commandSubject = $this->createCommandSubject();
+        $expectedSubjectWithAction = array_merge($commandSubject, ['action' => 'payRemainder']);
+        $request = ['invoice' => self::ORDER_INCREMENT_ID];
+        $response = ['status' => 'success'];
+        $transfer = $this->createMock(TransferInterface::class);
+
+        $payRemainderClient = $this->createMock(TransactionPayRemainder::class);
+        $payRemainderClient->expects($this->once())
+            ->method('setServiceAction')
+            ->with(self::ORDER_INCREMENT_ID)
+            ->willReturn('payRemainder');
+
+        $this->expectLockAcquiredAndReleased();
+
+        $this->requestBuilder->expects($this->once())
+            ->method('build')
+            ->with($expectedSubjectWithAction)
+            ->willReturn($request);
+        $this->transferFactory->method('create')->with($request)->willReturn($transfer);
+
+        $payRemainderClient->expects($this->once())
+            ->method('placeRequest')
+            ->with($this->identicalTo($transfer))
+            ->willReturn($response);
+
+        $this->validator->expects($this->once())
+            ->method('validate')
+            ->with(array_merge($expectedSubjectWithAction, ['response' => $response]))
+            ->willReturn($this->createValidationResult(true));
+
+        $this->handler->expects($this->once())
+            ->method('handle')
+            ->with($expectedSubjectWithAction, $response);
+
+        $this->createCommand($payRemainderClient)->execute($commandSubject);
+    }
+
+    /**
+     * Build the command under test with optional collaborators.
+     */
+    private function createCommand(
+        ?ClientInterface $client = null,
+        bool $withHandler = true,
+        bool $withValidator = true,
+        bool $withErrorMapper = true,
+        bool $withSkipCommand = false
+    ): GatewayCommand {
+        return new GatewayCommand(
+            $this->requestBuilder,
+            $this->transferFactory,
+            $client ?? $this->client,
+            $this->logger,
+            $this->spamLimitService,
+            $this->cancelOrder,
+            $this->lockManager,
+            $withHandler ? $this->handler : null,
+            $withValidator ? $this->validator : null,
+            $withErrorMapper ? $this->errorMessageMapper : null,
+            $withSkipCommand ? $this->skipCommand : null
+        );
+    }
+
+    /**
+     * Build a command subject wired to an order with a known increment id.
+     *
+     * @return array{payment: PaymentDataObjectInterface, amount: float}
+     */
+    private function createCommandSubject(): array
+    {
+        $order = $this->createMock(Order::class);
+        $order->method('getIncrementId')->willReturn(self::ORDER_INCREMENT_ID);
+
+        $orderAdapter = $this->createMock(OrderAdapterInterfaceStub::class);
+        $orderAdapter->method('getOrder')->willReturn($order);
+
+        $this->methodInstance = $this->createMock(MethodInterface::class);
+
+        $payment = $this->createMock(InfoInterface::class);
+        $payment->method('getMethodInstance')->willReturn($this->methodInstance);
+
+        $this->paymentDO = $this->createMock(PaymentDataObjectInterface::class);
+        $this->paymentDO->method('getOrder')->willReturn($orderAdapter);
+        $this->paymentDO->method('getPayment')->willReturn($payment);
+
+        return ['payment' => $this->paymentDO, 'amount' => 10.0];
+    }
+
+    /**
+     * Expect the order lock to be acquired with the fixed timeout and released exactly once.
+     */
+    private function expectLockAcquiredAndReleased(): void
+    {
+        $this->lockManager->expects($this->once())
+            ->method('lockOrder')
+            ->with(self::ORDER_INCREMENT_ID, self::LOCK_TIMEOUT_SECONDS)
+            ->willReturn(true);
+
+        $this->lockManager->expects($this->once())
+            ->method('unlockOrder')
+            ->with(self::ORDER_INCREMENT_ID)
+            ->willReturn(true);
+    }
+
+    /**
+     * Stub builder -> transfer factory -> client so the command reaches validation.
+     *
+     * @param array $commandSubject
+     * @param array $response
+     */
+    private function stubSuccessfulGatewayRoundTrip(array $commandSubject, array $response): void
+    {
+        $request = ['invoice' => self::ORDER_INCREMENT_ID];
+        $transfer = $this->createMock(TransferInterface::class);
+
+        $this->requestBuilder->method('build')->willReturn($request);
+        $this->transferFactory->method('create')->with($request)->willReturn($transfer);
+        $this->client->method('placeRequest')
+            ->with($this->identicalTo($transfer))
+            ->willReturn($response);
+    }
+
+    /**
+     * Create a validator result double with pinned values.
+     *
+     * @param bool $isValid
+     * @param array $failsDescription
+     * @param array $errorCodes
+     *
+     * @return ResultInterface|MockObject
+     */
+    private function createValidationResult(
+        bool $isValid,
+        array $failsDescription = [],
+        array $errorCodes = []
+    ): ResultInterface {
+        $result = $this->createMock(ResultInterface::class);
+        $result->method('isValid')->willReturn($isValid);
+        $result->method('getFailsDescription')->willReturn($failsDescription);
+        $result->method('getErrorCodes')->willReturn($errorCodes);
+
+        return $result;
+    }
+
+    /**
+     * Capture logger->critical() messages into $this->capturedLogs for
+     * post-exception assertions.
+     */
+    private function captureCriticalLogs(): void
+    {
+        $this->capturedLogs = [];
+        $this->logger->method('critical')
+            ->willReturnCallback(function ($message): void {
+                $this->capturedLogs[] = (string)$message;
+            });
+    }
+
+    /**
+     * @var string[]
+     */
+    private $capturedLogs = [];
+}

--- a/Test/Unit/Gateway/ErrorMapper/ErrorMessageMapperTest.php
+++ b/Test/Unit/Gateway/ErrorMapper/ErrorMessageMapperTest.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the MIT License
+ * It is available through the world-wide-web at this URL:
+ * https://tldrlegal.com/license/mit-license
+ * If you are unable to obtain it through the world-wide-web, please email
+ * to support@buckaroo.nl, so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade this module to newer
+ * versions in the future. If you wish to customize this module for your
+ * needs please contact support@buckaroo.nl for more information.
+ *
+ * @copyright Copyright (c) Buckaroo B.V.
+ * @license   https://tldrlegal.com/license/mit-license
+ */
+declare(strict_types=1);
+
+namespace Buckaroo\Magento2\Test\Unit\Gateway\ErrorMapper;
+
+use Buckaroo\Magento2\Gateway\ErrorMapper\ErrorMessageMapper;
+use Buckaroo\Magento2\Test\BaseTest;
+use Magento\Framework\Config\DataInterface;
+use Magento\Framework\Phrase;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\MockObject\MockObject;
+
+class ErrorMessageMapperTest extends BaseTest
+{
+    /**
+     * @var DataInterface|MockObject
+     */
+    private $messageMapping;
+
+    /**
+     * @var ErrorMessageMapper
+     */
+    private $mapper;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->messageMapping = $this->createMock(DataInterface::class);
+        $this->mapper = new ErrorMessageMapper($this->messageMapping);
+    }
+
+    public function testShortCodeIsResolvedThroughConfiguredMapping(): void
+    {
+        $this->messageMapping->expects($this->once())
+            ->method('get')
+            ->with('491')
+            ->willReturn('Invalid parameter supplied');
+
+        $message = $this->mapper->getMessage('491');
+
+        $this->assertInstanceOf(Phrase::class, $message);
+        $this->assertSame('Invalid parameter supplied', (string)$message);
+    }
+
+    public function testCodeLongerThanFourCharactersBypassesMappingAndIsReturnedVerbatim(): void
+    {
+        $this->messageMapping->expects($this->never())->method('get');
+
+        $rawGatewayMessage = 'Card number is invalid';
+
+        $message = $this->mapper->getMessage($rawGatewayMessage);
+
+        $this->assertInstanceOf(Phrase::class, $message);
+        $this->assertSame($rawGatewayMessage, (string)$message);
+    }
+
+    public function testExactlyFourCharacterCodeStillConsultsMapping(): void
+    {
+        $this->messageMapping->expects($this->once())
+            ->method('get')
+            ->with('F103')
+            ->willReturn('Invalid bank account number');
+
+        $this->assertSame('Invalid bank account number', (string)$this->mapper->getMessage('F103'));
+    }
+
+    public function testFiveCharacterCodeBypassesMappingBoundary(): void
+    {
+        $this->messageMapping->expects($this->never())->method('get');
+
+        $this->assertSame('F1035', (string)$this->mapper->getMessage('F1035'));
+    }
+
+    /**
+     * @param mixed $mappingResult
+     */
+    #[DataProvider('unmappedResultProvider')]
+    public function testUnmappedShortCodeReturnsNull($mappingResult): void
+    {
+        $this->messageMapping->expects($this->once())
+            ->method('get')
+            ->with('490')
+            ->willReturn($mappingResult);
+
+        $this->assertNull($this->mapper->getMessage('490'));
+    }
+
+    /**
+     * @return array<string, array{0: mixed}>
+     */
+    public static function unmappedResultProvider(): array
+    {
+        return [
+            'mapping returns null' => [null],
+            'mapping returns empty string' => [''],
+        ];
+    }
+}

--- a/Test/Unit/Gateway/Http/Client/DefaultTransactionTest.php
+++ b/Test/Unit/Gateway/Http/Client/DefaultTransactionTest.php
@@ -1,0 +1,278 @@
+<?php
+/**
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the MIT License
+ * It is available through the world-wide-web at this URL:
+ * https://tldrlegal.com/license/mit-license
+ * If you are unable to obtain it through the world-wide-web, please email
+ * to support@buckaroo.nl, so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade this module to newer
+ * versions in the future. If you wish to customize this module for your
+ * needs please contact support@buckaroo.nl for more information.
+ *
+ * @copyright Copyright (c) Buckaroo B.V.
+ * @license   https://tldrlegal.com/license/mit-license
+ */
+declare(strict_types=1);
+
+namespace Buckaroo\Magento2\Test\Unit\Gateway\Http\Client;
+
+use Buckaroo\Magento2\Gateway\Http\Client\DefaultTransaction;
+use Buckaroo\Magento2\Gateway\Http\Client\TransactionType;
+use Buckaroo\Magento2\Model\Adapter\BuckarooAdapter;
+use Buckaroo\Magento2\Test\BaseTest;
+use Buckaroo\Transaction\Response\TransactionResponse;
+use Magento\Payment\Gateway\Http\ClientException;
+use Magento\Payment\Gateway\Http\TransferInterface;
+use Magento\Payment\Model\Method\Logger as PaymentLogger;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
+use Psr\Log\LoggerInterface;
+
+#[AllowMockObjectsWithoutExpectations]
+class DefaultTransactionTest extends BaseTest
+{
+    protected $instanceClass = DefaultTransaction::class;
+
+    /**
+     * @var LoggerInterface|MockObject
+     */
+    private $loggerMock;
+
+    /**
+     * @var PaymentLogger|MockObject
+     */
+    private $paymentLoggerMock;
+
+    /**
+     * @var BuckarooAdapter|MockObject
+     */
+    private $adapterMock;
+
+    /**
+     * @var TransactionResponse|Stub
+     */
+    private $transactionResponseMock;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->loggerMock = $this->createMock(LoggerInterface::class);
+        $this->paymentLoggerMock = $this->createMock(PaymentLogger::class);
+        $this->adapterMock = $this->createMock(BuckarooAdapter::class);
+        $this->transactionResponseMock = $this->createStub(TransactionResponse::class);
+    }
+
+    private function createClient(string $action = TransactionType::PAY): DefaultTransaction
+    {
+        return new DefaultTransaction(
+            $this->loggerMock,
+            $this->paymentLoggerMock,
+            $this->adapterMock,
+            $action
+        );
+    }
+
+    /**
+     * @param array $body
+     *
+     * @return TransferInterface|Stub
+     */
+    private function createTransfer(array $body)
+    {
+        $transfer = $this->createStub(TransferInterface::class);
+        $transfer->method('getBody')->willReturn($body);
+
+        return $transfer;
+    }
+
+    public function testPlaceRequestStripsPaymentMethodAndForwardsBodyToSdk(): void
+    {
+        $body = [
+            'payment_method' => 'ideal',
+            'currency'       => 'EUR',
+            'amountDebit'    => 10.5,
+            'invoice'        => '100000001',
+        ];
+
+        $this->adapterMock->expects($this->once())
+            ->method('execute')
+            ->with(
+                TransactionType::PAY,
+                'ideal',
+                [
+                    'currency'    => 'EUR',
+                    'amountDebit' => 10.5,
+                    'invoice'     => '100000001',
+                ]
+            )
+            ->willReturn($this->transactionResponseMock);
+
+        $result = $this->createClient()->placeRequest($this->createTransfer($body));
+
+        $this->assertSame(['object' => $this->transactionResponseMock], $result);
+    }
+
+    public function testPlaceRequestUsesConfiguredActionFromConstructor(): void
+    {
+        $body = [
+            'payment_method' => 'creditcards',
+            'amountDebit'    => 99.99,
+        ];
+
+        $this->adapterMock->expects($this->once())
+            ->method('execute')
+            ->with(TransactionType::AUTHORIZE, 'creditcards', ['amountDebit' => 99.99])
+            ->willReturn($this->transactionResponseMock);
+
+        $result = $this->createClient(TransactionType::AUTHORIZE)
+            ->placeRequest($this->createTransfer($body));
+
+        $this->assertSame(['object' => $this->transactionResponseMock], $result);
+    }
+
+    public function testEncryptedCardDataForcesPayEncryptedAction(): void
+    {
+        $body = [
+            'payment_method'    => 'creditcards',
+            'encryptedCardData' => 'ENCRYPTED_BLOB',
+            'amountDebit'       => 25.0,
+        ];
+
+        $this->adapterMock->expects($this->once())
+            ->method('execute')
+            ->with(
+                TransactionType::PAY_ENCRYPTED,
+                'creditcards',
+                [
+                    'encryptedCardData' => 'ENCRYPTED_BLOB',
+                    'amountDebit'       => 25.0,
+                ]
+            )
+            ->willReturn($this->transactionResponseMock);
+
+        $result = $this->createClient()->placeRequest($this->createTransfer($body));
+
+        $this->assertSame(['object' => $this->transactionResponseMock], $result);
+    }
+
+    public function testPlaceRequestLogsRequestAndResponseViaPaymentLogger(): void
+    {
+        $body = [
+            'payment_method' => 'ideal',
+            'currency'       => 'EUR',
+        ];
+
+        $this->adapterMock->method('execute')->willReturn($this->transactionResponseMock);
+
+        $this->paymentLoggerMock->expects($this->once())
+            ->method('debug')
+            ->with($this->callback(function (array $log) use ($body): bool {
+                return $log['request'] === $body
+                    && $log['client'] === DefaultTransaction::class
+                    && array_key_exists('response', $log)
+                    && is_array($log['response']);
+            }));
+
+        $this->createClient()->placeRequest($this->createTransfer($body));
+    }
+
+    public function testRefundBelowMinimumAmountSkipsSdkCall(): void
+    {
+        $body = [
+            'payment_method' => 'giftcards',
+            'amountCredit'   => 0.005,
+        ];
+
+        $this->adapterMock->expects($this->never())->method('execute');
+        $this->paymentLoggerMock->expects($this->never())->method('debug');
+
+        $this->loggerMock->expects($this->once())
+            ->method('debug')
+            ->with(
+                'Skipping refund API call - amount already fully refunded via group transactions (giftcards/vouchers)'
+            );
+
+        $result = $this->createClient(TransactionType::REFUND)
+            ->placeRequest($this->createTransfer($body));
+
+        $this->assertSame(
+            [
+                'object'                            => [],
+                'group_transaction_refund_complete' => true,
+            ],
+            $result
+        );
+    }
+
+    public function testRefundAtMinimumAmountThresholdStillCallsSdk(): void
+    {
+        $body = [
+            'payment_method' => 'giftcards',
+            'amountCredit'   => 0.01,
+        ];
+
+        $this->adapterMock->expects($this->once())
+            ->method('execute')
+            ->with(TransactionType::REFUND, 'giftcards', ['amountCredit' => 0.01])
+            ->willReturn($this->transactionResponseMock);
+
+        $result = $this->createClient(TransactionType::REFUND)
+            ->placeRequest($this->createTransfer($body));
+
+        $this->assertSame(['object' => $this->transactionResponseMock], $result);
+    }
+
+    public function testRefundWithoutAmountCreditIsNotSkipped(): void
+    {
+        $body = ['payment_method' => 'ideal'];
+
+        $this->adapterMock->expects($this->once())
+            ->method('execute')
+            ->with(TransactionType::REFUND, 'ideal', [])
+            ->willReturn($this->transactionResponseMock);
+
+        $result = $this->createClient(TransactionType::REFUND)
+            ->placeRequest($this->createTransfer($body));
+
+        $this->assertSame(['object' => $this->transactionResponseMock], $result);
+    }
+
+    public function testSdkExceptionIsWrappedInClientExceptionAndLogged(): void
+    {
+        $body = ['payment_method' => 'ideal', 'currency' => 'EUR'];
+
+        $this->adapterMock->expects($this->once())
+            ->method('execute')
+            ->willThrowException(new \Exception('SDK failure'));
+
+        $this->loggerMock->expects($this->once())->method('critical');
+        // The finally block must still log the request even when the SDK throws.
+        $this->paymentLoggerMock->expects($this->once())->method('debug');
+
+        $this->expectException(ClientException::class);
+        $this->expectExceptionMessage('SDK failure');
+
+        $this->createClient()->placeRequest($this->createTransfer($body));
+    }
+
+    public function testEmptyExceptionMessageFallsBackToGenericMessage(): void
+    {
+        $body = ['payment_method' => 'ideal'];
+
+        $this->adapterMock->expects($this->once())
+            ->method('execute')
+            ->willThrowException(new \Exception(''));
+
+        $this->expectException(ClientException::class);
+        $this->expectExceptionMessage('Sorry, but something went wrong');
+
+        $this->createClient()->placeRequest($this->createTransfer($body));
+    }
+}

--- a/Test/Unit/Gateway/Http/Client/JsonTest.php
+++ b/Test/Unit/Gateway/Http/Client/JsonTest.php
@@ -1,0 +1,262 @@
+<?php
+/**
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the MIT License
+ * It is available through the world-wide-web at this URL:
+ * https://tldrlegal.com/license/mit-license
+ * If you are unable to obtain it through the world-wide-web, please email
+ * to support@buckaroo.nl, so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade this module to newer
+ * versions in the future. If you wish to customize this module for your
+ * needs please contact support@buckaroo.nl for more information.
+ *
+ * @copyright Copyright (c) Buckaroo B.V.
+ * @license   https://tldrlegal.com/license/mit-license
+ */
+declare(strict_types=1);
+
+namespace Buckaroo\Magento2\Test\Unit\Gateway\Http\Client;
+
+use Buckaroo\Magento2\Gateway\Http\Client\Json;
+use Buckaroo\Magento2\Helper\Data;
+use Buckaroo\Magento2\Logging\BuckarooLoggerInterface;
+use Buckaroo\Magento2\Test\BaseTest;
+use Magento\Framework\HTTP\Client\Curl;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\MockObject\MockObject;
+
+#[AllowMockObjectsWithoutExpectations]
+class JsonTest extends BaseTest
+{
+    protected $instanceClass = Json::class;
+
+    private const TEST_TRANSACTION_URI = 'https://testcheckout.buckaroo.nl/json/Transaction';
+    private const LIVE_TRANSACTION_URI = 'https://checkout.buckaroo.nl/json/Transaction';
+
+    /**
+     * @var Curl|MockObject
+     */
+    private $curlMock;
+
+    /**
+     * @var BuckarooLoggerInterface|MockObject
+     */
+    private $loggerMock;
+
+    /**
+     * @var Json
+     */
+    private $client;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->curlMock = $this->createMock(Curl::class);
+        $this->loggerMock = $this->createMock(BuckarooLoggerInterface::class);
+
+        $this->client = new Json($this->curlMock, $this->loggerMock);
+        $this->client->setWebsiteKey('WEBSITE_KEY');
+        $this->client->setSecretKey('SECRET_KEY');
+    }
+
+    public function testGetOptionsBuildsHmacSignedCurlOptions(): void
+    {
+        $data = ['Currency' => 'EUR', 'AmountDebit' => 10.5];
+        $uri = self::TEST_TRANSACTION_URI;
+        $uri2 = strtolower(rawurlencode('testcheckout.buckaroo.nl/json/Transaction'));
+
+        $options = $this->client->getOptions($uri, $uri2, $data, 'POST');
+
+        $expectedJson = \json_encode($data, JSON_PRETTY_PRINT);
+
+        $this->assertSame($uri, $options[CURLOPT_URL]);
+        $this->assertSame('POST', $options[CURLOPT_CUSTOMREQUEST]);
+        $this->assertSame($expectedJson, $options[CURLOPT_POSTFIELDS]);
+        $this->assertTrue($options[CURLOPT_RETURNTRANSFER]);
+        $this->assertFalse($options[CURLOPT_FOLLOWLOCATION]);
+        $this->assertSame('Magento2', $options[CURLOPT_USERAGENT]);
+
+        $headers = $options[CURLOPT_HTTPHEADER];
+        $this->assertSame('Content-Type: application/json; charset=utf-8', $headers[0]);
+        $this->assertSame('Accept: application/json', $headers[1]);
+        $this->assertMatchesRegularExpression(
+            '#^Authorization: hmac WEBSITE_KEY:[A-Za-z0-9+/]+={0,2}:[A-Za-z0-9]{16}:\d+$#',
+            $headers[2]
+        );
+
+        // Recompute the signature from the header parts to pin the HMAC algorithm.
+        [, $hmac, $nonce, $timestamp] = explode(
+            ':',
+            substr($headers[2], strlen('Authorization: hmac '))
+        );
+
+        // phpcs:ignore Magento2.Security.InsecureFunction
+        $encodedContent = base64_encode(md5($expectedJson, true));
+        $rawData = 'WEBSITE_KEY' . 'POST' . $uri2 . $timestamp . $nonce . $encodedContent;
+        $expectedHmac = base64_encode(hash_hmac('sha256', $rawData, 'SECRET_KEY', true));
+
+        $this->assertSame($expectedHmac, $hmac);
+    }
+
+    public function testDoRequestPostsJsonToTestGateway(): void
+    {
+        $data = ['Currency' => 'EUR', 'AmountDebit' => 10.5];
+
+        $this->curlMock->expects($this->once())
+            ->method('setOptions')
+            ->with($this->callback(function (array $options) use ($data): bool {
+                return $options[CURLOPT_URL] === self::TEST_TRANSACTION_URI
+                    && $options[CURLOPT_CUSTOMREQUEST] === 'POST'
+                    && $options[CURLOPT_POSTFIELDS] === \json_encode($data, JSON_PRETTY_PRINT);
+            }));
+
+        $this->curlMock->expects($this->once())
+            ->method('post')
+            ->with(self::TEST_TRANSACTION_URI, $data);
+
+        $this->curlMock->expects($this->never())->method('get');
+        $this->curlMock->method('getBody')->willReturn('{"Key":"TRX-1","Status":{"Code":{"Code":190}}}');
+        $this->curlMock->method('getStatus')->willReturn(200);
+
+        $result = $this->client->doRequest($data, Data::MODE_TEST);
+
+        $this->assertSame(
+            ['Key' => 'TRX-1', 'Status' => ['Code' => ['Code' => 190]]],
+            $result
+        );
+    }
+
+    public function testDoRequestUsesLiveGatewayForLiveMode(): void
+    {
+        $data = ['Currency' => 'EUR'];
+
+        $this->curlMock->expects($this->once())
+            ->method('setOptions')
+            ->with($this->callback(function (array $options): bool {
+                return $options[CURLOPT_URL] === self::LIVE_TRANSACTION_URI;
+            }));
+
+        $this->curlMock->expects($this->once())
+            ->method('post')
+            ->with(self::LIVE_TRANSACTION_URI, $data);
+
+        $this->curlMock->method('getBody')->willReturn('{"Key":"TRX-2"}');
+
+        $result = $this->client->doRequest($data, Data::MODE_LIVE);
+
+        $this->assertSame(['Key' => 'TRX-2'], $result);
+    }
+
+    public function testDoStatusRequestSendsGetToStatusEndpoint(): void
+    {
+        $expectedUri = self::TEST_TRANSACTION_URI . '/status/TRX123';
+
+        $this->curlMock->expects($this->once())
+            ->method('setOptions')
+            ->with($this->callback(function (array $options) use ($expectedUri): bool {
+                return $options[CURLOPT_URL] === $expectedUri
+                    && $options[CURLOPT_CUSTOMREQUEST] === 'GET';
+            }));
+
+        $this->curlMock->expects($this->once())
+            ->method('get')
+            ->with($expectedUri);
+
+        $this->curlMock->expects($this->never())->method('post');
+        $this->curlMock->method('getBody')->willReturn('{"Status":{"Code":{"Code":190}}}');
+
+        $result = $this->client->doStatusRequest('TRX123', Data::MODE_TEST);
+
+        $this->assertSame(['Status' => ['Code' => ['Code' => 190]]], $result);
+    }
+
+    public function testDoCancelRequestSetsKeysAndSendsGetToCancelEndpoint(): void
+    {
+        $expectedUri = self::TEST_TRANSACTION_URI . '/cancel/KEY123';
+
+        $this->curlMock->expects($this->once())
+            ->method('setOptions')
+            ->with($this->callback(function (array $options) use ($expectedUri): bool {
+                $authorizationHeader = $options[CURLOPT_HTTPHEADER][2];
+
+                return $options[CURLOPT_URL] === $expectedUri
+                    && $options[CURLOPT_CUSTOMREQUEST] === 'GET'
+                    && strpos($authorizationHeader, 'Authorization: hmac CANCEL_WEBSITE_KEY:') === 0;
+            }));
+
+        $this->curlMock->expects($this->once())
+            ->method('get')
+            ->with($expectedUri);
+
+        $this->curlMock->method('getBody')->willReturn('{"IsCancelled":true}');
+
+        $result = $this->client->doCancelRequest(
+            'KEY123',
+            Data::MODE_TEST,
+            'CANCEL_SECRET_KEY',
+            'CANCEL_WEBSITE_KEY'
+        );
+
+        $this->assertSame(['IsCancelled' => true], $result);
+    }
+
+    public function testGetResponseReturnsFalseAndLogsErrorWhenClientThrows(): void
+    {
+        $this->curlMock->expects($this->once())
+            ->method('get')
+            ->willThrowException(new \Exception('Connection timed out'));
+
+        $this->loggerMock->expects($this->once())
+            ->method('addError')
+            ->with($this->callback(function (string $message): bool {
+                return strpos($message, 'Connection timed out') !== false;
+            }))
+            ->willReturn(true);
+
+        $this->assertFalse($this->client->getResponse(self::TEST_TRANSACTION_URI));
+    }
+
+    public function testGetResponsePostsWhenDataIsProvided(): void
+    {
+        $data = ['Currency' => 'EUR'];
+
+        $this->curlMock->expects($this->once())
+            ->method('post')
+            ->with(self::TEST_TRANSACTION_URI, $data);
+
+        $this->curlMock->expects($this->never())->method('get');
+        $this->curlMock->method('getBody')->willReturn('{"Key":"TRX-3"}');
+
+        $result = $this->client->getResponse(self::TEST_TRANSACTION_URI, $data);
+
+        $this->assertSame(['Key' => 'TRX-3'], $result);
+    }
+
+    public function testGetResponseUsesGetWhenNoDataIsProvided(): void
+    {
+        $this->curlMock->expects($this->once())
+            ->method('get')
+            ->with(self::TEST_TRANSACTION_URI);
+
+        $this->curlMock->expects($this->never())->method('post');
+        $this->curlMock->method('getBody')->willReturn('{"Key":"TRX-4"}');
+
+        $result = $this->client->getResponse(self::TEST_TRANSACTION_URI);
+
+        $this->assertSame(['Key' => 'TRX-4'], $result);
+    }
+
+    public function testGetStatusDelegatesToCurlClient(): void
+    {
+        $this->curlMock->expects($this->once())
+            ->method('getStatus')
+            ->willReturn(200);
+
+        $this->assertSame(200, $this->client->getStatus());
+    }
+}

--- a/Test/Unit/Gateway/Http/Client/JsonTest.php
+++ b/Test/Unit/Gateway/Http/Client/JsonTest.php
@@ -90,10 +90,15 @@ class JsonTest extends BaseTest
         );
 
         // Recompute the signature from the header parts to pin the HMAC algorithm.
-        [, $hmac, $nonce, $timestamp] = explode(
+        // Indexed access instead of list destructuring: PDepend in the CI mess
+        // detector cannot parse a skipped slot ("[, $a] =").
+        $authParts = explode(
             ':',
             substr($headers[2], strlen('Authorization: hmac '))
         );
+        $hmac = $authParts[1];
+        $nonce = $authParts[2];
+        $timestamp = $authParts[3];
 
         // phpcs:ignore Magento2.Security.InsecureFunction
         $encodedContent = base64_encode(md5($expectedJson, true));

--- a/Test/Unit/Gateway/Http/Client/TransactionIdealPayOrFastCheckoutTest.php
+++ b/Test/Unit/Gateway/Http/Client/TransactionIdealPayOrFastCheckoutTest.php
@@ -1,0 +1,196 @@
+<?php
+/**
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the MIT License
+ * It is available through the world-wide-web at this URL:
+ * https://tldrlegal.com/license/mit-license
+ * If you are unable to obtain it through the world-wide-web, please email
+ * to support@buckaroo.nl, so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade this module to newer
+ * versions in the future. If you wish to customize this module for your
+ * needs please contact support@buckaroo.nl for more information.
+ *
+ * @copyright Copyright (c) Buckaroo B.V.
+ * @license   https://tldrlegal.com/license/mit-license
+ */
+declare(strict_types=1);
+
+namespace Buckaroo\Magento2\Test\Unit\Gateway\Http\Client;
+
+use Buckaroo\Magento2\Gateway\Http\Client\TransactionIdealPayOrFastCheckout;
+use Buckaroo\Magento2\Gateway\Http\Client\TransactionType;
+use Buckaroo\Magento2\Model\Adapter\BuckarooAdapter;
+use Buckaroo\Magento2\Service\PayReminderService;
+use Buckaroo\Magento2\Test\BaseTest;
+use Buckaroo\Transaction\Response\TransactionResponse;
+use Magento\Payment\Gateway\Http\TransferInterface;
+use Magento\Payment\Model\Method\Logger as PaymentLogger;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
+use Psr\Log\LoggerInterface;
+
+class TransactionIdealPayOrFastCheckoutTest extends BaseTest
+{
+    protected $instanceClass = TransactionIdealPayOrFastCheckout::class;
+
+    /**
+     * @var BuckarooAdapter|MockObject
+     */
+    private $adapterMock;
+
+    /**
+     * @var PayReminderService|MockObject
+     */
+    private $payReminderServiceMock;
+
+    /**
+     * @var TransactionResponse|Stub
+     */
+    private $transactionResponseMock;
+
+    /**
+     * @var TransactionIdealPayOrFastCheckout
+     */
+    private $client;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->adapterMock = $this->createMock(BuckarooAdapter::class);
+        $this->payReminderServiceMock = $this->createMock(PayReminderService::class);
+        $this->transactionResponseMock = $this->createStub(TransactionResponse::class);
+
+        $this->client = new TransactionIdealPayOrFastCheckout(
+            $this->createStub(LoggerInterface::class),
+            $this->createStub(PaymentLogger::class),
+            $this->adapterMock,
+            $this->payReminderServiceMock
+        );
+    }
+
+    /**
+     * @param array $body
+     *
+     * @return TransferInterface|Stub
+     */
+    private function createTransfer(array $body)
+    {
+        $transfer = $this->createStub(TransferInterface::class);
+        $transfer->method('getBody')->willReturn($body);
+
+        return $transfer;
+    }
+
+    public function testFastCheckoutIssuerUsesPayFastCheckoutActionWithoutIssuer(): void
+    {
+        $body = [
+            'payment_method' => 'ideal',
+            'issuer'         => TransactionIdealPayOrFastCheckout::FAST_CHECKOUT_ISSUER,
+            'amountDebit'    => 25.0,
+            'invoice'        => '100000010',
+        ];
+
+        $this->payReminderServiceMock->expects($this->never())->method('getServiceAction');
+
+        $this->adapterMock->expects($this->once())
+            ->method('execute')
+            ->with(
+                TransactionType::PAY_FAST_CHECKOUT,
+                'ideal',
+                [
+                    'amountDebit' => 25.0,
+                    'invoice'     => '100000010',
+                ]
+            )
+            ->willReturn($this->transactionResponseMock);
+
+        $result = $this->client->placeRequest($this->createTransfer($body));
+
+        $this->assertSame(['object' => $this->transactionResponseMock], $result);
+    }
+
+    public function testRegularIssuerKeepsIssuerAndUsesPayRemainderFlow(): void
+    {
+        $body = [
+            'payment_method' => 'ideal',
+            'issuer'         => 'ABNANL2A',
+            'amountDebit'    => 25.0,
+            'invoice'        => '100000010',
+        ];
+
+        $this->payReminderServiceMock->expects($this->once())
+            ->method('getServiceAction')
+            ->with('100000010', TransactionType::PAY, TransactionType::PAY_REMAINDER)
+            ->willReturn(TransactionType::PAY);
+
+        $this->adapterMock->expects($this->once())
+            ->method('execute')
+            ->with(
+                TransactionType::PAY,
+                'ideal',
+                [
+                    'issuer'      => 'ABNANL2A',
+                    'amountDebit' => 25.0,
+                    'invoice'     => '100000010',
+                ]
+            )
+            ->willReturn($this->transactionResponseMock);
+
+        $result = $this->client->placeRequest($this->createTransfer($body));
+
+        $this->assertSame(['object' => $this->transactionResponseMock], $result);
+    }
+
+    public function testRegularIssuerUsesPayRemainderWhenOrderIsPartiallyPaid(): void
+    {
+        $body = [
+            'payment_method' => 'ideal',
+            'issuer'         => 'INGBNL2A',
+            'invoice'        => '100000011',
+        ];
+
+        $this->payReminderServiceMock->expects($this->once())
+            ->method('getServiceAction')
+            ->with('100000011', TransactionType::PAY, TransactionType::PAY_REMAINDER)
+            ->willReturn(TransactionType::PAY_REMAINDER);
+
+        $this->adapterMock->expects($this->once())
+            ->method('execute')
+            ->with(
+                TransactionType::PAY_REMAINDER,
+                'ideal',
+                [
+                    'issuer'  => 'INGBNL2A',
+                    'invoice' => '100000011',
+                ]
+            )
+            ->willReturn($this->transactionResponseMock);
+
+        $this->client->placeRequest($this->createTransfer($body));
+    }
+
+    public function testMissingIssuerFallsBackToPayRemainderFlow(): void
+    {
+        $body = [
+            'payment_method' => 'ideal',
+            'invoice'        => '100000012',
+        ];
+
+        $this->payReminderServiceMock->expects($this->once())
+            ->method('getServiceAction')
+            ->with('100000012', TransactionType::PAY, TransactionType::PAY_REMAINDER)
+            ->willReturn(TransactionType::PAY);
+
+        $this->adapterMock->expects($this->once())
+            ->method('execute')
+            ->with(TransactionType::PAY, 'ideal', ['invoice' => '100000012'])
+            ->willReturn($this->transactionResponseMock);
+
+        $this->client->placeRequest($this->createTransfer($body));
+    }
+}

--- a/Test/Unit/Gateway/Http/Client/TransactionPayOrInInstallmentsTest.php
+++ b/Test/Unit/Gateway/Http/Client/TransactionPayOrInInstallmentsTest.php
@@ -1,0 +1,164 @@
+<?php
+/**
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the MIT License
+ * It is available through the world-wide-web at this URL:
+ * https://tldrlegal.com/license/mit-license
+ * If you are unable to obtain it through the world-wide-web, please email
+ * to support@buckaroo.nl, so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade this module to newer
+ * versions in the future. If you wish to customize this module for your
+ * needs please contact support@buckaroo.nl for more information.
+ *
+ * @copyright Copyright (c) Buckaroo B.V.
+ * @license   https://tldrlegal.com/license/mit-license
+ */
+declare(strict_types=1);
+
+namespace Buckaroo\Magento2\Test\Unit\Gateway\Http\Client;
+
+use Buckaroo\Magento2\Gateway\Http\Client\TransactionPayOrInInstallments;
+use Buckaroo\Magento2\Gateway\Http\Client\TransactionType;
+use Buckaroo\Magento2\Model\Adapter\BuckarooAdapter;
+use Buckaroo\Magento2\Test\BaseTest;
+use Buckaroo\Transaction\Response\TransactionResponse;
+use Magento\Payment\Gateway\Http\TransferInterface;
+use Magento\Payment\Model\Method\Logger as PaymentLogger;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
+use Psr\Log\LoggerInterface;
+
+class TransactionPayOrInInstallmentsTest extends BaseTest
+{
+    protected $instanceClass = TransactionPayOrInInstallments::class;
+
+    /**
+     * @var BuckarooAdapter|MockObject
+     */
+    private $adapterMock;
+
+    /**
+     * @var TransactionResponse|Stub
+     */
+    private $transactionResponseMock;
+
+    /**
+     * @var TransactionPayOrInInstallments
+     */
+    private $client;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->adapterMock = $this->createMock(BuckarooAdapter::class);
+        $this->transactionResponseMock = $this->createStub(TransactionResponse::class);
+
+        $this->client = new TransactionPayOrInInstallments(
+            $this->createStub(LoggerInterface::class),
+            $this->createStub(PaymentLogger::class),
+            $this->adapterMock
+        );
+    }
+
+    /**
+     * @param array $body
+     *
+     * @return TransferInterface|Stub
+     */
+    private function createTransfer(array $body)
+    {
+        $transfer = $this->createStub(TransferInterface::class);
+        $transfer->method('getBody')->willReturn($body);
+
+        return $transfer;
+    }
+
+    public static function serviceActionProvider(): array
+    {
+        return [
+            'pay action from magento uses pay' => [
+                TransactionType::PAY,
+                TransactionType::PAY,
+            ],
+            'payInInstallments action keeps installments' => [
+                TransactionType::PAY_IN_INSTALLMENTS,
+                TransactionType::PAY_IN_INSTALLMENTS,
+            ],
+            'any other action falls back to installments' => [
+                'authorize',
+                TransactionType::PAY_IN_INSTALLMENTS,
+            ],
+            'empty action falls back to installments' => [
+                '',
+                TransactionType::PAY_IN_INSTALLMENTS,
+            ],
+        ];
+    }
+
+    #[DataProvider('serviceActionProvider')]
+    public function testActionIsSelectedFromServiceActionFromMagento(
+        string $serviceActionFromMagento,
+        string $expectedSdkAction
+    ): void {
+        $body = [
+            'payment_method'       => 'in3',
+            'amountDebit'          => 150.0,
+            'additionalParameters' => [
+                'service_action_from_magento' => $serviceActionFromMagento,
+            ],
+        ];
+
+        $this->adapterMock->expects($this->once())
+            ->method('execute')
+            ->with(
+                $expectedSdkAction,
+                'in3',
+                [
+                    'amountDebit'          => 150.0,
+                    'additionalParameters' => [
+                        'service_action_from_magento' => $serviceActionFromMagento,
+                    ],
+                ]
+            )
+            ->willReturn($this->transactionResponseMock);
+
+        $result = $this->client->placeRequest($this->createTransfer($body));
+
+        $this->assertSame(['object' => $this->transactionResponseMock], $result);
+    }
+
+    public function testAdditionalParametersAreForwardedUnchangedToSdk(): void
+    {
+        $body = [
+            'payment_method'       => 'capayable',
+            'invoice'              => '100000042',
+            'additionalParameters' => [
+                'service_action_from_magento' => TransactionType::PAY_IN_INSTALLMENTS,
+                'customParameter'             => 'customValue',
+            ],
+        ];
+
+        $this->adapterMock->expects($this->once())
+            ->method('execute')
+            ->with(
+                TransactionType::PAY_IN_INSTALLMENTS,
+                'capayable',
+                [
+                    'invoice'              => '100000042',
+                    'additionalParameters' => [
+                        'service_action_from_magento' => TransactionType::PAY_IN_INSTALLMENTS,
+                        'customParameter'             => 'customValue',
+                    ],
+                ]
+            )
+            ->willReturn($this->transactionResponseMock);
+
+        $this->client->placeRequest($this->createTransfer($body));
+    }
+}

--- a/Test/Unit/Gateway/Http/Client/TransactionPayRemainderTest.php
+++ b/Test/Unit/Gateway/Http/Client/TransactionPayRemainderTest.php
@@ -1,0 +1,203 @@
+<?php
+/**
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the MIT License
+ * It is available through the world-wide-web at this URL:
+ * https://tldrlegal.com/license/mit-license
+ * If you are unable to obtain it through the world-wide-web, please email
+ * to support@buckaroo.nl, so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade this module to newer
+ * versions in the future. If you wish to customize this module for your
+ * needs please contact support@buckaroo.nl for more information.
+ *
+ * @copyright Copyright (c) Buckaroo B.V.
+ * @license   https://tldrlegal.com/license/mit-license
+ */
+declare(strict_types=1);
+
+namespace Buckaroo\Magento2\Test\Unit\Gateway\Http\Client;
+
+use Buckaroo\Magento2\Gateway\Http\Client\TransactionPayRemainder;
+use Buckaroo\Magento2\Gateway\Http\Client\TransactionType;
+use Buckaroo\Magento2\Model\Adapter\BuckarooAdapter;
+use Buckaroo\Magento2\Service\PayReminderService;
+use Buckaroo\Magento2\Test\BaseTest;
+use Buckaroo\Transaction\Response\TransactionResponse;
+use Magento\Payment\Gateway\Http\TransferInterface;
+use Magento\Payment\Model\Method\Logger as PaymentLogger;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
+use Psr\Log\LoggerInterface;
+
+class TransactionPayRemainderTest extends BaseTest
+{
+    protected $instanceClass = TransactionPayRemainder::class;
+
+    /**
+     * @var BuckarooAdapter|MockObject
+     */
+    private $adapterMock;
+
+    /**
+     * @var PayReminderService|MockObject
+     */
+    private $payReminderServiceMock;
+
+    /**
+     * @var TransactionResponse|Stub
+     */
+    private $transactionResponseMock;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->adapterMock = $this->createMock(BuckarooAdapter::class);
+        $this->payReminderServiceMock = $this->createMock(PayReminderService::class);
+        $this->transactionResponseMock = $this->createStub(TransactionResponse::class);
+    }
+
+    private function createClient(
+        string $serviceAction = TransactionType::PAY,
+        string $newServiceAction = TransactionType::PAY_REMAINDER
+    ): TransactionPayRemainder {
+        return new TransactionPayRemainder(
+            $this->createStub(LoggerInterface::class),
+            $this->createStub(PaymentLogger::class),
+            $this->adapterMock,
+            $this->payReminderServiceMock,
+            $serviceAction,
+            $newServiceAction
+        );
+    }
+
+    /**
+     * @param array $body
+     *
+     * @return TransferInterface|Stub
+     */
+    private function createTransfer(array $body)
+    {
+        $transfer = $this->createStub(TransferInterface::class);
+        $transfer->method('getBody')->willReturn($body);
+
+        return $transfer;
+    }
+
+    public function testProcessResolvesServiceActionFromInvoiceIncrementId(): void
+    {
+        $body = [
+            'payment_method' => 'ideal',
+            'invoice'        => '100000123',
+            'order'          => '100000999',
+            'amountDebit'    => 15.0,
+        ];
+
+        $this->payReminderServiceMock->expects($this->once())
+            ->method('getServiceAction')
+            ->with('100000123', TransactionType::PAY, TransactionType::PAY_REMAINDER)
+            ->willReturn(TransactionType::PAY_REMAINDER);
+
+        $this->adapterMock->expects($this->once())
+            ->method('execute')
+            ->with(
+                TransactionType::PAY_REMAINDER,
+                'ideal',
+                [
+                    'invoice'     => '100000123',
+                    'order'       => '100000999',
+                    'amountDebit' => 15.0,
+                ]
+            )
+            ->willReturn($this->transactionResponseMock);
+
+        $result = $this->createClient()->placeRequest($this->createTransfer($body));
+
+        $this->assertSame(['object' => $this->transactionResponseMock], $result);
+    }
+
+    public function testProcessFallsBackToOrderIncrementIdWhenInvoiceIsMissing(): void
+    {
+        $body = [
+            'payment_method' => 'ideal',
+            'order'          => '100000456',
+        ];
+
+        $this->payReminderServiceMock->expects($this->once())
+            ->method('getServiceAction')
+            ->with('100000456', TransactionType::PAY, TransactionType::PAY_REMAINDER)
+            ->willReturn(TransactionType::PAY);
+
+        $this->adapterMock->expects($this->once())
+            ->method('execute')
+            ->with(TransactionType::PAY, 'ideal', ['order' => '100000456'])
+            ->willReturn($this->transactionResponseMock);
+
+        $this->createClient()->placeRequest($this->createTransfer($body));
+    }
+
+    public function testProcessPassesEmptyIncrementIdWhenNoOrderReferenceExists(): void
+    {
+        $body = ['payment_method' => 'ideal', 'amountDebit' => 5.0];
+
+        $this->payReminderServiceMock->expects($this->once())
+            ->method('getServiceAction')
+            ->with('', TransactionType::PAY, TransactionType::PAY_REMAINDER)
+            ->willReturn(TransactionType::PAY);
+
+        $this->adapterMock->expects($this->once())
+            ->method('execute')
+            ->with(TransactionType::PAY, 'ideal', ['amountDebit' => 5.0])
+            ->willReturn($this->transactionResponseMock);
+
+        $this->createClient()->placeRequest($this->createTransfer($body));
+    }
+
+    public function testCustomConstructorActionsAreForwardedToPayReminderService(): void
+    {
+        $body = [
+            'payment_method' => 'creditcards',
+            'invoice'        => '100000001',
+        ];
+
+        $this->payReminderServiceMock->expects($this->once())
+            ->method('getServiceAction')
+            ->with(
+                '100000001',
+                TransactionType::AUTHORIZE,
+                TransactionType::PAY_REMAINDER_ENCRYPTED
+            )
+            ->willReturn(TransactionType::AUTHORIZE);
+
+        $this->adapterMock->expects($this->once())
+            ->method('execute')
+            ->with(TransactionType::AUTHORIZE, 'creditcards', ['invoice' => '100000001'])
+            ->willReturn($this->transactionResponseMock);
+
+        $client = $this->createClient(
+            TransactionType::AUTHORIZE,
+            TransactionType::PAY_REMAINDER_ENCRYPTED
+        );
+
+        $client->placeRequest($this->createTransfer($body));
+    }
+
+    public function testSetServiceActionDelegatesToPayReminderService(): void
+    {
+        $this->adapterMock->expects($this->never())->method('execute');
+
+        $this->payReminderServiceMock->expects($this->once())
+            ->method('getServiceAction')
+            ->with('100000777', TransactionType::PAY, TransactionType::PAY_REMAINDER)
+            ->willReturn(TransactionType::PAY_REMAINDER);
+
+        $this->assertSame(
+            TransactionType::PAY_REMAINDER,
+            $this->createClient()->setServiceAction('100000777')
+        );
+    }
+}

--- a/Test/Unit/Gateway/Http/SDKTransferFactoryTest.php
+++ b/Test/Unit/Gateway/Http/SDKTransferFactoryTest.php
@@ -1,0 +1,83 @@
+<?php
+/**
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the MIT License
+ * It is available through the world-wide-web at this URL:
+ * https://tldrlegal.com/license/mit-license
+ * If you are unable to obtain it through the world-wide-web, please email
+ * to support@buckaroo.nl, so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade this module to newer
+ * versions in the future. If you wish to customize this module for your
+ * needs please contact support@buckaroo.nl for more information.
+ *
+ * @copyright Copyright (c) Buckaroo B.V.
+ * @license   https://tldrlegal.com/license/mit-license
+ */
+declare(strict_types=1);
+
+namespace Buckaroo\Magento2\Test\Unit\Gateway\Http;
+
+use Buckaroo\Magento2\Gateway\Http\SDKTransferFactory;
+use Buckaroo\Magento2\Test\BaseTest;
+use Magento\Payment\Gateway\Http\TransferBuilder;
+use Magento\Payment\Gateway\Http\TransferInterface;
+
+class SDKTransferFactoryTest extends BaseTest
+{
+    public function testCreateBuildsPostTransferCarryingTheExactRequestBody(): void
+    {
+        $request = [
+            'payment_method' => 'ideal',
+            'invoice' => '100000123',
+            'amountDebit' => 10.5,
+            'clientIP' => ['address' => '127.0.0.1', 'type' => 4],
+        ];
+
+        $factory = new SDKTransferFactory(new TransferBuilder());
+
+        $transfer = $factory->create($request);
+
+        $this->assertInstanceOf(TransferInterface::class, $transfer);
+        $this->assertSame($request, $transfer->getBody());
+        $this->assertSame('POST', $transfer->getMethod());
+        $this->assertSame([], $transfer->getHeaders());
+        $this->assertSame('', $transfer->getUri());
+    }
+
+    public function testCreateWithEmptyRequestStillProducesPostTransferWithEmptyBody(): void
+    {
+        $factory = new SDKTransferFactory(new TransferBuilder());
+
+        $transfer = $factory->create([]);
+
+        $this->assertSame([], $transfer->getBody());
+        $this->assertSame('POST', $transfer->getMethod());
+    }
+
+    public function testCreateDelegatesBodyAndMethodToInjectedBuilder(): void
+    {
+        $request = ['order' => '100000999'];
+        $expectedTransfer = $this->createMock(TransferInterface::class);
+
+        $transferBuilder = $this->createMock(TransferBuilder::class);
+        $transferBuilder->expects($this->once())
+            ->method('setBody')
+            ->with($request)
+            ->willReturnSelf();
+        $transferBuilder->expects($this->once())
+            ->method('setMethod')
+            ->with('POST')
+            ->willReturnSelf();
+        $transferBuilder->expects($this->once())
+            ->method('build')
+            ->willReturn($expectedTransfer);
+
+        $factory = new SDKTransferFactory($transferBuilder);
+
+        $this->assertSame($expectedTransfer, $factory->create($request));
+    }
+}

--- a/Test/Unit/Gateway/Request/AdditionalInformation/IssuerDataBuilderTest.php
+++ b/Test/Unit/Gateway/Request/AdditionalInformation/IssuerDataBuilderTest.php
@@ -21,6 +21,8 @@ declare(strict_types=1);
 
 namespace Buckaroo\Magento2\Test\Unit\Gateway\Request\AdditionalInformation;
 
+
+use PHPUnit\Framework\Attributes\DataProvider;
 use Buckaroo\Magento2\Gateway\Request\AdditionalInformation\IssuerDataBuilder;
 use Magento\Payment\Gateway\Data\PaymentDataObjectInterface;
 use Magento\Payment\Model\InfoInterface;
@@ -42,10 +44,10 @@ class IssuerDataBuilderTest extends TestCase
     }
 
     /**
-     * @dataProvider buildDataProvider
      *
      * @param array $expectedResult
      */
+    #[DataProvider('buildDataProvider')]
     public function testBuild(array $expectedResult): void
     {
         $paymentDOMock = $this->createMock(PaymentDataObjectInterface::class);

--- a/Test/Unit/Gateway/Request/Address/AfterpayBillingAddressDataBuilderTest.php
+++ b/Test/Unit/Gateway/Request/Address/AfterpayBillingAddressDataBuilderTest.php
@@ -21,6 +21,8 @@ declare(strict_types=1);
 
 namespace Buckaroo\Magento2\Test\Unit\Gateway\Request\Address;
 
+
+use PHPUnit\Framework\Attributes\DataProvider;
 use Buckaroo\Magento2\Gateway\Request\Address\AfterpayBillingAddressDataBuilder;
 use Buckaroo\Magento2\Test\Unit\Gateway\Request\AbstractDataBuilderTest;
 use Magento\Sales\Model\Order\Address;
@@ -50,12 +52,12 @@ class AfterpayBillingAddressDataBuilderTest extends AbstractDataBuilderTest
     }
 
     /**
-     * @dataProvider dachStreetDataProvider
      *
      * @param string $countryId
      * @param array  $street
      * @param string $expectedStreet
      */
+    #[DataProvider('dachStreetDataProvider')]
     public function testDachStreetUsesOnlyFirstLine(string $countryId, array $street, string $expectedStreet): void
     {
         $this->addressMock->method('getStreet')->willReturn($street);
@@ -75,7 +77,7 @@ class AfterpayBillingAddressDataBuilderTest extends AbstractDataBuilderTest
     /**
      * @return array[]
      */
-    public function dachStreetDataProvider(): array
+    public static function dachStreetDataProvider(): array
     {
         return [
             'dach uses only street line 1' => [

--- a/Test/Unit/Gateway/Request/Articles/ArticlesHandler/KlarnaKpHandlerTest.php
+++ b/Test/Unit/Gateway/Request/Articles/ArticlesHandler/KlarnaKpHandlerTest.php
@@ -317,18 +317,15 @@ class KlarnaKpHandlerTest extends TestCase
 
         // Quote mock — getGiftCardsAmount / getRewardCurrencyAmount are Adobe Commerce methods
         // absent on CE, so they must be added via addMethods().
-        $quote = $this->getMockBuilder(Quote::class)
+        $quote = $this->getMockBuilder(\Buckaroo\Magento2\Test\Unit\Stubs\QuoteStub::class)
             ->disableOriginalConstructor()
-            ->addMethods(['getGiftCardsAmount', 'getRewardCurrencyAmount'])
-            ->getMock();
+            ->onlyMethods(['getGiftCardsAmount', 'getRewardCurrencyAmount'])->getMock();
         $quote->method('getGiftCardsAmount')->willReturn($giftCardAmount);
         $quote->method('getRewardCurrencyAmount')->willReturn(0.0);
 
-        $quoteProxy = $this->getMockBuilder(Quote::class)
+        $quoteProxy = $this->getMockBuilder(\Buckaroo\Magento2\Test\Unit\Stubs\QuoteStub::class)
             ->disableOriginalConstructor()
-            ->onlyMethods(['load'])
-            ->addMethods(['getGiftCardsAmount', 'getRewardCurrencyAmount'])
-            ->getMock();
+            ->onlyMethods(['load', 'getGiftCardsAmount', 'getRewardCurrencyAmount'])->getMock();
         $quoteProxy->method('load')->willReturn($quote);
         $quoteProxy->method('getGiftCardsAmount')->willReturn($giftCardAmount);
         $quoteProxy->method('getRewardCurrencyAmount')->willReturn(0.0);
@@ -339,8 +336,7 @@ class KlarnaKpHandlerTest extends TestCase
         $this->scopeConfig->method('getValue')->willReturn(false);
 
         // Tax / shipping (shipping = 0 in these tests so shipping line is skipped).
-        $rateRequest = $this->getMockBuilder(\stdClass::class)
-            ->addMethods(['setProductClassId'])
+        $rateRequest = $this->getMockBuilder(\Buckaroo\Magento2\Test\Unit\Stubs\StdObjectStub::class)
             ->getMock();
         $rateRequest->method('setProductClassId')->willReturnSelf();
         $this->taxCalculation->method('getRateRequest')->willReturn($rateRequest);
@@ -369,11 +365,9 @@ class KlarnaKpHandlerTest extends TestCase
     {
         // getBuckarooFeeInclTax / getBuckarooFee are Buckaroo extension attributes absent
         // from the base Invoice class, so they must be added via addMethods().
-        $invoice = $this->getMockBuilder(Invoice::class)
+        $invoice = $this->getMockBuilder(\Buckaroo\Magento2\Test\Unit\Stubs\InvoiceStub::class)
             ->disableOriginalConstructor()
-            ->onlyMethods(['getAllItems', 'getGrandTotal', 'getTaxAmount', 'getShippingInclTax'])
-            ->addMethods(['getBuckarooFeeInclTax', 'getBuckarooFee'])
-            ->getMock();
+            ->onlyMethods(['getAllItems', 'getGrandTotal', 'getTaxAmount', 'getShippingInclTax', 'getBuckarooFeeInclTax', 'getBuckarooFee'])->getMock();
         $invoice->method('getAllItems')->willReturn($this->stagedItems);
         $invoice->method('getGrandTotal')->willReturn($this->stagedGrandTotal);
         $invoice->method('getTaxAmount')->willReturn(0.0);
@@ -399,10 +393,9 @@ class KlarnaKpHandlerTest extends TestCase
         $orderItem = $this->createMock(Order\Item::class);
         $orderItem->method('getTaxPercent')->willReturn(0.0);
 
-        $item = $this->getMockBuilder(Invoice\Item::class)
+        $item = $this->getMockBuilder(\Buckaroo\Magento2\Test\Unit\Stubs\InvoiceItemStub::class)
             ->disableOriginalConstructor()
-            ->onlyMethods(['getRowTotalInclTax', 'getOrderItem', 'getName', 'getSku', 'getQty', 'getDiscountAmount', 'getPriceInclTax', 'getPrice', 'getTaxAmount'])
-            ->addMethods(['hasParentItemId', 'getWeeeTaxAppliedAmount'])
+            ->onlyMethods(['getRowTotalInclTax', 'getOrderItem', 'getName', 'getSku', 'getQty', 'getDiscountAmount', 'getPriceInclTax', 'getPrice', 'getTaxAmount', 'hasParentItemId', 'getWeeeTaxAppliedAmount'])
             ->getMock();
 
         $item->method('getRowTotalInclTax')->willReturn($price);

--- a/Test/Unit/Gateway/Request/BasicParameter/AmountCreditDataBuilderTest.php
+++ b/Test/Unit/Gateway/Request/BasicParameter/AmountCreditDataBuilderTest.php
@@ -21,6 +21,8 @@ declare(strict_types=1);
 
 namespace Buckaroo\Magento2\Test\Unit\Gateway\Request\BasicParameter;
 
+
+use PHPUnit\Framework\Attributes\DataProvider;
 use Buckaroo\Magento2\Gateway\Data\Order\OrderAdapter;
 use Buckaroo\Magento2\Gateway\Request\BasicParameter\AmountCreditDataBuilder;
 use Buckaroo\Magento2\Service\RefundGroupTransactionService;
@@ -65,7 +67,6 @@ class AmountCreditDataBuilderTest extends AbstractDataBuilderTest
     }
 
     /**
-     * @dataProvider buildDataProvider
      *
      * @param float $amount
      * @param float $amountLeftToRefund
@@ -74,6 +75,7 @@ class AmountCreditDataBuilderTest extends AbstractDataBuilderTest
      * @throws ClientException
      * @throws ConverterException
      */
+    #[DataProvider('buildDataProvider')]
     public function testBuild(float $amount, float $amountLeftToRefund, float $expectedResult): void
     {
         $this->orderMock->method('getBaseGrandTotal')->willReturn($amount);

--- a/Test/Unit/Gateway/Request/BasicParameter/AmountDebitDataBuilderTest.php
+++ b/Test/Unit/Gateway/Request/BasicParameter/AmountDebitDataBuilderTest.php
@@ -21,6 +21,8 @@ declare(strict_types=1);
 
 namespace Buckaroo\Magento2\Test\Unit\Gateway\Request\BasicParameter;
 
+
+use PHPUnit\Framework\Attributes\DataProvider;
 use Buckaroo\Magento2\Gateway\Request\BasicParameter\AmountDebitDataBuilder;
 use Buckaroo\Magento2\Test\Unit\Gateway\Request\AbstractDataBuilderTest;
 
@@ -42,13 +44,13 @@ class AmountDebitDataBuilderTest extends AbstractDataBuilderTest
     }
 
     /**
-     * @dataProvider amountDataProvider
      *
      * @param float|null $grandTotal
      * @param float      $expectedAmount
      *
      * @throws \Exception
      */
+    #[DataProvider('amountDataProvider')]
     public function testBuild(?float $grandTotal, float $expectedAmount)
     {
         $this->orderMock->method('getGrandTotal')

--- a/Test/Unit/Gateway/Request/BasicParameter/ClientIPDataBuilderTest.php
+++ b/Test/Unit/Gateway/Request/BasicParameter/ClientIPDataBuilderTest.php
@@ -21,6 +21,8 @@ declare(strict_types=1);
 
 namespace Buckaroo\Magento2\Test\Unit\Gateway\Request\BasicParameter;
 
+
+use PHPUnit\Framework\Attributes\DataProvider;
 use Buckaroo\Magento2\Gateway\Request\BasicParameter\ClientIPDataBuilder;
 use Buckaroo\Magento2\Model\ConfigProvider\Account;
 use Buckaroo\Magento2\Test\Unit\Gateway\Request\AbstractDataBuilderTest;
@@ -64,11 +66,11 @@ class ClientIPDataBuilderTest extends AbstractDataBuilderTest
     }
 
     /**
-     * @dataProvider getBuildDataProvider
      *
      * @param string $expectedAddress
      * @param int    $expectedType
      */
+    #[DataProvider('getBuildDataProvider')]
     public function testBuild(string $expectedAddress, int $expectedType): void
     {
         $this->createOrderMock(
@@ -114,7 +116,7 @@ class ClientIPDataBuilderTest extends AbstractDataBuilderTest
         $store = $this->createMock(Store::class);
         $this->orderMock->method('getRemoteIp')->willReturn($remoteIp);
         $this->orderMock->method('getStore')->willReturn($store);
-        $orderPaymentMock = $this->getMockForAbstractClass(
+        $orderPaymentMock = $this->createMock(
             OrderPaymentInterface::class,
             [],
             '',
@@ -132,11 +134,11 @@ class ClientIPDataBuilderTest extends AbstractDataBuilderTest
     }
 
     /**
-     * @dataProvider isIpPrivateDataProvider
      *
      * @param string $ip
      * @param bool   $expectedResult
      */
+    #[DataProvider('isIpPrivateDataProvider')]
     public function testIsIpPrivate(string $ip, bool $expectedResult): void
     {
         $isIpPrivate = $this->invokeIsIpPrivateMethod($this->clientIPDataBuilder, $ip);
@@ -174,7 +176,6 @@ class ClientIPDataBuilderTest extends AbstractDataBuilderTest
     {
         $reflection = new \ReflectionClass(ClientIPDataBuilder::class);
         $method = $reflection->getMethod('isIpPrivate');
-        $method->setAccessible(true);
 
         return $method->invokeArgs($clientIPDataBuilder, [$ip]);
     }

--- a/Test/Unit/Gateway/Request/BasicParameter/ClientIPDataBuilderTest.php
+++ b/Test/Unit/Gateway/Request/BasicParameter/ClientIPDataBuilderTest.php
@@ -116,15 +116,7 @@ class ClientIPDataBuilderTest extends AbstractDataBuilderTest
         $store = $this->createMock(Store::class);
         $this->orderMock->method('getRemoteIp')->willReturn($remoteIp);
         $this->orderMock->method('getStore')->willReturn($store);
-        $orderPaymentMock = $this->createMock(
-            OrderPaymentInterface::class,
-            [],
-            '',
-            false,
-            false,
-            true,
-            []
-        );
+        $orderPaymentMock = $this->createMock(OrderPaymentInterface::class);
         $orderPaymentMock->method('getMethod')
             ->willReturn($paymentMethod);
         $this->orderMock->method('getPayment')->willReturn($orderPaymentMock);

--- a/Test/Unit/Gateway/Request/BasicParameter/CurrencyDataBuilderTest.php
+++ b/Test/Unit/Gateway/Request/BasicParameter/CurrencyDataBuilderTest.php
@@ -21,6 +21,8 @@ declare(strict_types=1);
 
 namespace Buckaroo\Magento2\Test\Unit\Gateway\Request\BasicParameter;
 
+
+use PHPUnit\Framework\Attributes\DataProvider;
 use Buckaroo\Magento2\Gateway\Request\BasicParameter\CurrencyDataBuilder;
 use Buckaroo\Magento2\Model\ConfigProvider\Method\ConfigProviderInterface;
 use Buckaroo\Magento2\Model\ConfigProvider\Factory;
@@ -55,7 +57,6 @@ class CurrencyDataBuilderTest extends BaseTest
     }
 
     /**
-     * @dataProvider currencyDataProvider
      *
      * @param mixed $orderCurrencyCode
      * @param mixed $baseCurrencyCode
@@ -63,6 +64,7 @@ class CurrencyDataBuilderTest extends BaseTest
      * @param mixed $allowedCurrencies
      * @param mixed $expectedResult
      */
+    #[DataProvider('currencyDataProvider')]
     public function testBuild(
         $orderCurrencyCode,
         $baseCurrencyCode,
@@ -80,7 +82,7 @@ class CurrencyDataBuilderTest extends BaseTest
         $configProviderMock = $this->getMockBuilder(AbstractConfigProvider::class)
             ->disableOriginalConstructor()
             ->onlyMethods(['getAllowedCurrencies'])
-            ->getMockForAbstractClass();
+            ->getMock();
         $configProviderMock->method('getAllowedCurrencies')->willReturn($allowedCurrencies);
 
         $this->configProviderMethodFactoryMock->expects($this->atMost(1))
@@ -108,9 +110,8 @@ class CurrencyDataBuilderTest extends BaseTest
     private function getPaymentDOMock()
     {
         // Use the already prepared order mock so currency codes are available
-        $orderAdapterMock = $this->getMockBuilder(\Magento\Payment\Gateway\Data\OrderAdapterInterface::class)
-            ->addMethods(['getOrder'])
-            ->getMockForAbstractClass();
+        $orderAdapterMock = $this->getMockBuilder(\Buckaroo\Magento2\Test\Unit\Stubs\OrderAdapterInterfaceStub::class)
+            ->getMock();
         $orderAdapterMock->method('getOrder')->willReturn($this->orderMock);
 
         $paymentMock = $this->createMock(\Magento\Payment\Model\InfoInterface::class);

--- a/Test/Unit/Gateway/Request/BasicParameter/PaymentMethodDataBuilderTest.php
+++ b/Test/Unit/Gateway/Request/BasicParameter/PaymentMethodDataBuilderTest.php
@@ -21,6 +21,8 @@ declare(strict_types=1);
 
 namespace Buckaroo\Magento2\Test\Unit\Gateway\Request\BasicParameter;
 
+
+use PHPUnit\Framework\Attributes\DataProvider;
 use Buckaroo\Magento2\Gateway\Request\BasicParameter\PaymentMethodDataBuilder;
 use Buckaroo\Magento2\Helper\PaymentGroupTransaction;
 use Buckaroo\Magento2\Test\Unit\Gateway\Request\AbstractDataBuilderTest;
@@ -49,11 +51,11 @@ class PaymentMethodDataBuilderTest extends AbstractDataBuilderTest
     }
 
     /**
-     * @dataProvider buildDataProvider
      *
      * @param string $payment_method
      * @param string $expectedResult
      */
+    #[DataProvider('buildDataProvider')]
     public function testBuild(string $payment_method, string $expectedResult): void
     {
         $this->paymentMethodInstanceMock->method('getCode')->willReturn($payment_method);

--- a/Test/Unit/Gateway/Request/PayLinkDataBuilderTest.php
+++ b/Test/Unit/Gateway/Request/PayLinkDataBuilderTest.php
@@ -21,6 +21,8 @@ declare(strict_types=1);
 
 namespace Buckaroo\Magento2\Test\Unit\Gateway\Request;
 
+
+use PHPUnit\Framework\Attributes\DataProvider;
 use Buckaroo\Magento2\Gateway\Request\PayLinkDataBuilder;
 use Buckaroo\Magento2\Model\ConfigProvider\Method\Giftcards;
 use Buckaroo\Magento2\Model\ConfigProvider\Method\PayLink;
@@ -57,12 +59,12 @@ class PayLinkDataBuilderTest extends AbstractDataBuilderTest
     }
 
     /**
-     * @dataProvider buildDataProvider
      *
      * @param string      $configuredMethods
      * @param string|null $activeGiftcards
      * @param string      $expectedMethods
      */
+    #[DataProvider('buildDataProvider')]
     public function testBuild(
         string $configuredMethods,
         ?string $activeGiftcards,

--- a/Test/Unit/Gateway/Request/PayReminder/AmountDataBuilderTest.php
+++ b/Test/Unit/Gateway/Request/PayReminder/AmountDataBuilderTest.php
@@ -21,6 +21,8 @@ declare(strict_types=1);
 
 namespace Buckaroo\Magento2\Test\Unit\Gateway\Request\PayReminder;
 
+
+use PHPUnit\Framework\Attributes\DataProvider;
 use Buckaroo\Magento2\Gateway\Request\PayReminder\AmountDataBuilder;
 use Buckaroo\Magento2\Service\PayReminderService;
 use Buckaroo\Magento2\Test\Unit\Gateway\Request\AbstractDataBuilderTest;
@@ -51,12 +53,12 @@ class AmountDataBuilderTest extends AbstractDataBuilderTest
     }
 
     /**
-     * @dataProvider buildDataProvider
      *
      * @param string $serviceAction
      * @param float  $payRemainder
      * @param array  $expectedResult
      */
+    #[DataProvider('buildDataProvider')]
     public function testBuild(string $serviceAction, float $payRemainder, array $expectedResult): void
     {
         $incrementId = '100000001';

--- a/Test/Unit/Gateway/Request/PayReminder/OriginalTransactionKeyDataBuilderTest.php
+++ b/Test/Unit/Gateway/Request/PayReminder/OriginalTransactionKeyDataBuilderTest.php
@@ -21,6 +21,8 @@ declare(strict_types=1);
 
 namespace Buckaroo\Magento2\Test\Unit\Gateway\Request\PayReminder;
 
+
+use PHPUnit\Framework\Attributes\DataProvider;
 use Buckaroo\Magento2\Gateway\Request\PayReminder\OriginalTransactionKeyDataBuilder;
 use Buckaroo\Magento2\Service\PayReminderService;
 use Buckaroo\Magento2\Test\Unit\Gateway\Request\AbstractDataBuilderTest;
@@ -51,12 +53,12 @@ class OriginalTransactionKeyDataBuilderTest extends AbstractDataBuilderTest
     }
 
     /**
-     * @dataProvider buildDataProvider
      *
      * @param string $serviceAction
      * @param string $originalTransactionKey
      * @param array  $expectedResult
      */
+    #[DataProvider('buildDataProvider')]
     public function testBuild(string $serviceAction, string $originalTransactionKey, array $expectedResult): void
     {
         $incrementId = '100000001';

--- a/Test/Unit/Gateway/Request/Recipient/AfterpayDataBuilderTest.php
+++ b/Test/Unit/Gateway/Request/Recipient/AfterpayDataBuilderTest.php
@@ -21,6 +21,8 @@ declare(strict_types=1);
 
 namespace Buckaroo\Magento2\Test\Unit\Gateway\Request\Recipient;
 
+
+use PHPUnit\Framework\Attributes\DataProvider;
 use Buckaroo\Magento2\Gateway\Request\Recipient\AfterpayDataBuilder;
 use Buckaroo\Magento2\Test\Unit\Gateway\Request\AbstractDataBuilderTest;
 use Magento\Framework\App\Config\ScopeConfigInterface;
@@ -52,12 +54,12 @@ class AfterpayDataBuilderTest extends AbstractDataBuilderTest
     }
 
     /**
-     * @dataProvider careOfDataProvider
      *
      * @param string      $countryId
      * @param array       $street
      * @param string|null $expectedCareOf
      */
+    #[DataProvider('careOfDataProvider')]
     public function testBuildCareOfMapping(string $countryId, array $street, ?string $expectedCareOf): void
     {
         $this->addressMock->method('getStreet')->willReturn($street);
@@ -83,7 +85,7 @@ class AfterpayDataBuilderTest extends AbstractDataBuilderTest
     /**
      * @return array[]
      */
-    public function careOfDataProvider(): array
+    public static function careOfDataProvider(): array
     {
         $exactlyFiftyCharacters = str_repeat('A', 50);
         $longerThanFiftyCharacters = str_repeat('B', 60);

--- a/Test/Unit/Gateway/Request/Recipient/KlarnaDataBuilderTest.php
+++ b/Test/Unit/Gateway/Request/Recipient/KlarnaDataBuilderTest.php
@@ -21,6 +21,8 @@ declare(strict_types=1);
 
 namespace Buckaroo\Magento2\Test\Unit\Gateway\Request\Recipient;
 
+
+use PHPUnit\Framework\Attributes\DataProvider;
 use Buckaroo\Magento2\Gateway\Data\Order\OrderAdapter;
 use Buckaroo\Magento2\Gateway\Request\Recipient\KlarnaDataBuilder;
 use Buckaroo\Magento2\Test\Unit\Gateway\Request\AbstractDataBuilderTest;
@@ -63,10 +65,10 @@ class KlarnaDataBuilderTest extends AbstractDataBuilderTest
      * parameter must always be sent as "unknown" regardless of any legacy
      * customer_gender value that might still be present on the payment.
      *
-     * @dataProvider customerGenderProvider
      *
      * @param string|null $customerGender
      */
+    #[DataProvider('customerGenderProvider')]
     public function testGenderIsAlwaysUnknown(?string $customerGender): void
     {
         $this->paymentMock = $this->createMock(InfoInterface::class);
@@ -86,7 +88,7 @@ class KlarnaDataBuilderTest extends AbstractDataBuilderTest
     /**
      * @return array<string, array{0: string|null}>
      */
-    public function customerGenderProvider(): array
+    public static function customerGenderProvider(): array
     {
         return [
             'legacy male value' => ['1'],

--- a/Test/Unit/Gateway/Response/CancelHandlerTest.php
+++ b/Test/Unit/Gateway/Response/CancelHandlerTest.php
@@ -41,6 +41,7 @@ class CancelHandlerTest extends AbstractResponseHandlerTest
     public function testHandle(): void
     {
         $this->orderPaymentMock
+            ->expects($this->once())
             ->method('setAdditionalInformation')
             ->with('voided_by_buckaroo', true);
 

--- a/Test/Unit/Gateway/Response/ConsumerMessageHandlerTest.php
+++ b/Test/Unit/Gateway/Response/ConsumerMessageHandlerTest.php
@@ -21,6 +21,8 @@ declare(strict_types=1);
 
 namespace Buckaroo\Magento2\Test\Unit\Gateway\Response;
 
+
+use PHPUnit\Framework\Attributes\DataProvider;
 use Buckaroo\Magento2\Gateway\Response\CancelHandler;
 use Buckaroo\Magento2\Gateway\Response\ConsumerMessageHandler;
 use Magento\Framework\Message\ManagerInterface as MessageManager;
@@ -48,11 +50,11 @@ class ConsumerMessageHandlerTest extends AbstractResponseHandlerTest
     }
 
     /**
-     * @dataProvider messageDataProvider
      *
      * @param array $consumerMessage
      * @param int   $expectedMessageCalls
      */
+    #[DataProvider('messageDataProvider')]
     public function testHandle(array $consumerMessage, int $expectedMessageCalls): void
     {
         $this->transactionResponse

--- a/Test/Unit/Gateway/Response/CreditManagementOrderHandlerTest.php
+++ b/Test/Unit/Gateway/Response/CreditManagementOrderHandlerTest.php
@@ -39,10 +39,12 @@ class CreditManagementOrderHandlerTest extends AbstractResponseHandlerTest
     public function testHandle(): void
     {
         $invoiceKey = 'test_invoice_key';
-        $this->orderPaymentMock->method('setAdditionalInformation')
+        $this->orderPaymentMock->expects($this->once())
+            ->method('setAdditionalInformation')
             ->with(CreditManagementOrderHandler::INVOICE_KEY, $invoiceKey);
 
-        $this->transactionResponse->method('data')
+        $this->transactionResponse->expects($this->once())
+            ->method('data')
             ->with('Services')
             ->willReturn([
                 [
@@ -67,7 +69,6 @@ class CreditManagementOrderHandlerTest extends AbstractResponseHandlerTest
         ];
 
         $method = new \ReflectionMethod(CreditManagementOrderHandler::class, 'getCreditManagementService');
-        $method->setAccessible(true);
         $result = $method->invoke($this->creditManagementOrderHandler, $services);
 
         $this->assertEquals($services[0], $result);
@@ -83,7 +84,6 @@ class CreditManagementOrderHandlerTest extends AbstractResponseHandlerTest
         ];
 
         $method = new \ReflectionMethod(CreditManagementOrderHandler::class, 'getInvoiceKey');
-        $method->setAccessible(true);
         $result = $method->invoke($this->creditManagementOrderHandler, $service);
 
         $this->assertEquals($service['Parameters'][0]['Value'], $result);

--- a/Test/Unit/Gateway/Response/PaymentDetailsHandlerTest.php
+++ b/Test/Unit/Gateway/Response/PaymentDetailsHandlerTest.php
@@ -54,18 +54,28 @@ class PaymentDetailsHandlerTest extends AbstractResponseHandlerTest
     public function testHandle(): void
     {
         $arrayResponse = ['some_key' => 'some_value'];
-        $this->transactionResponse->method('toArray')
+        $rawInfo = ['normalized_key' => 'normalized_value'];
+
+        $this->transactionResponse->expects($this->once())
+            ->method('toArray')
             ->willReturn($arrayResponse);
 
-        $this->helper->method('getTransactionAdditionalInfo')
+        $this->helper->expects($this->once())
+            ->method('getTransactionAdditionalInfo')
             ->with($arrayResponse)
-            ->willReturn($arrayResponse);
+            ->willReturn($rawInfo);
 
-        $this->orderPaymentMock->method('setTransactionAdditionalInfo')
+        $this->orderPaymentMock->expects($this->once())
+            ->method('setTransactionAdditionalInfo')
             ->with(
                 \Magento\Sales\Model\Order\Payment\Transaction::RAW_DETAILS,
-                json_encode($arrayResponse)
+                json_encode($rawInfo)
             );
+
+        // The handler must register the raw transaction response for later use.
+        $this->registry->expects($this->once())
+            ->method('setResponse')
+            ->with($this->transactionResponse);
 
         $this->paymentDetailsHandler->handle(['payment' => $this->getPaymentDOMock()], $this->getTransactionResponse());
     }
@@ -73,18 +83,34 @@ class PaymentDetailsHandlerTest extends AbstractResponseHandlerTest
     public function testGetTransactionAdditionalInfo(): void
     {
         $array = ['some_key' => 'some_value'];
-        $this->helper->method('getTransactionAdditionalInfo')
+        $normalized = ['normalized_key' => 'normalized_value'];
+
+        $this->helper->expects($this->once())
+            ->method('getTransactionAdditionalInfo')
             ->with($array)
-            ->willReturn($array);
+            ->willReturn($normalized);
 
         $result = $this->paymentDetailsHandler->getTransactionAdditionalInfo($array);
-        $this->assertEquals($array, $result);
+
+        // Must return exactly what the helper produced, proving delegation (not an echo of the input).
+        $this->assertSame($normalized, $result);
     }
 
-    public function testAddToRegistry(): void
+    public function testHandleSkipsWhenGroupTransactionRefundComplete(): void
     {
-        // Test method may not exist - skip reflection test since the interface
-        // doesn't have a register method
-        $this->assertTrue(true); // Basic assertion to complete test
+        // When a group transaction refund has already completed, the handler must be a no-op:
+        // it must not touch the payment or register a response.
+        $this->transactionResponse->expects($this->never())->method('toArray');
+        $this->helper->expects($this->never())->method('getTransactionAdditionalInfo');
+        $this->orderPaymentMock->expects($this->never())->method('setTransactionAdditionalInfo');
+        $this->registry->expects($this->never())->method('setResponse');
+
+        $response = $this->getTransactionResponse();
+        $response['group_transaction_refund_complete'] = true;
+
+        $this->paymentDetailsHandler->handle(
+            ['payment' => $this->getPaymentDOMock()],
+            $response
+        );
     }
 }

--- a/Test/Unit/Gateway/Response/PaymentInTransitHandlerTest.php
+++ b/Test/Unit/Gateway/Response/PaymentInTransitHandlerTest.php
@@ -21,6 +21,8 @@ declare(strict_types=1);
 
 namespace Buckaroo\Magento2\Test\Unit\Gateway\Response;
 
+
+use PHPUnit\Framework\Attributes\DataProvider;
 use Buckaroo\Magento2\Gateway\Response\PaymentInTransitHandler;
 
 class PaymentInTransitHandlerTest extends AbstractResponseHandlerTest
@@ -37,11 +39,11 @@ class PaymentInTransitHandlerTest extends AbstractResponseHandlerTest
     }
 
     /**
-     * @dataProvider handleDataProvider
      *
      * @param bool $hasRedirect
      * @param bool $inTransit
      */
+    #[DataProvider('handleDataProvider')]
     public function testHandle(bool $hasRedirect, bool $inTransit)
     {
         $this->transactionResponse

--- a/Test/Unit/Gateway/Response/ReservationNumberHandlerTest.php
+++ b/Test/Unit/Gateway/Response/ReservationNumberHandlerTest.php
@@ -21,6 +21,8 @@ declare(strict_types=1);
 
 namespace Buckaroo\Magento2\Test\Unit\Gateway\Response;
 
+
+use PHPUnit\Framework\Attributes\DataProvider;
 use Buckaroo\Magento2\Gateway\Response\ReservationNumberHandler;
 use Buckaroo\Magento2\Logging\BuckarooLoggerInterface;
 use Buckaroo\Transaction\Response\TransactionResponse;
@@ -43,7 +45,6 @@ class ReservationNumberHandlerTest extends AbstractResponseHandlerTest
     }
 
     /**
-     * @dataProvider reservationNumberDataProvider
      *
      * @param string     $paymentMethod
      * @param bool       $hasReservationNumber
@@ -51,6 +52,7 @@ class ReservationNumberHandlerTest extends AbstractResponseHandlerTest
      *
      * @throws \Exception
      */
+    #[DataProvider('reservationNumberDataProvider')]
     public function testHandle(
         string $paymentMethod,
         bool $hasReservationNumber,
@@ -61,11 +63,9 @@ class ReservationNumberHandlerTest extends AbstractResponseHandlerTest
             ->willReturn($paymentMethod);
 
         if ($paymentMethod == 'buckaroo_magento2_klarnakp') {
-            $orderMock = $this->getMockBuilder(Order::class)
+            $orderMock = $this->getMockBuilder(\Buckaroo\Magento2\Test\Unit\Stubs\OrderStub::class)
                 ->disableOriginalConstructor()
-                ->addMethods(['getBuckarooReservationNumber', 'setBuckarooReservationNumber'])
-                ->onlyMethods(['save'])
-                ->getMock();
+                ->onlyMethods(['save', 'getBuckarooReservationNumber', 'setBuckarooReservationNumber'])->getMock();
 
             $orderMock
                 ->method('getBuckarooReservationNumber')

--- a/Test/Unit/Gateway/Response/SkipPushHandlerTest.php
+++ b/Test/Unit/Gateway/Response/SkipPushHandlerTest.php
@@ -21,6 +21,8 @@ declare(strict_types=1);
 
 namespace Buckaroo\Magento2\Test\Unit\Gateway\Response;
 
+
+use PHPUnit\Framework\Attributes\DataProvider;
 use Buckaroo\Magento2\Gateway\Response\SkipPushHandler;
 
 class SkipPushHandlerTest extends AbstractResponseHandlerTest
@@ -37,29 +39,29 @@ class SkipPushHandlerTest extends AbstractResponseHandlerTest
     }
 
     /**
-     * @dataProvider skipPushDataProvider
      *
      * @param $skipPush
      *
      * @throws \Exception
      */
+    #[DataProvider('skipPushDataProvider')]
     public function testHandle($skipPush): void
     {
         $this->orderPaymentMock
-            ->expects($this->any())
+            ->expects($this->once())
             ->method('getAdditionalInformation')
             ->with('skip_push')
             ->willReturn($skipPush);
 
         if ($skipPush > 0) {
             $this->orderPaymentMock
+                ->expects($this->once())
                 ->method('setAdditionalInformation')
                 ->with('skip_push', $skipPush - 1);
         } else {
             $this->orderPaymentMock
                 ->expects($this->never())
-                ->method('setAdditionalInformation')
-                ->with('skip_push', $skipPush);
+                ->method('setAdditionalInformation');
         }
 
         $this->skipPushHandler->handle(['payment' => $this->getPaymentDOMock()], $this->getTransactionResponse());

--- a/Test/Unit/Gateway/Response/TransactionIdHandlerTest.php
+++ b/Test/Unit/Gateway/Response/TransactionIdHandlerTest.php
@@ -41,22 +41,27 @@ class TransactionIdHandlerTest extends AbstractResponseHandlerTest
     {
         $transactionKey = 'test_transaction_key';
 
-        $this->transactionResponse->method('getTransactionKey')
+        $this->transactionResponse->expects($this->once())
+            ->method('getTransactionKey')
             ->willReturn($transactionKey);
 
         $this->orderPaymentMock
+            ->expects($this->once())
             ->method('setTransactionId')
             ->with($transactionKey);
 
         $this->orderPaymentMock
+            ->expects($this->once())
             ->method('setAdditionalInformation')
             ->with(TransactionIdHandler::BUCKAROO_ORIGINAL_TRANSACTION_KEY_KEY, $transactionKey);
 
         $this->orderPaymentMock
+            ->expects($this->once())
             ->method('setIsTransactionClosed')
             ->with(true);
 
         $this->orderPaymentMock
+            ->expects($this->once())
             ->method('setShouldCloseParentTransaction')
             ->with(true);
 

--- a/Test/Unit/Gateway/Skip/KlarnaCancelVoidSkipTest.php
+++ b/Test/Unit/Gateway/Skip/KlarnaCancelVoidSkipTest.php
@@ -151,11 +151,9 @@ class KlarnaCancelVoidSkipTest extends TestCase
      */
     private function createOrderMock(?string $dataRequestKey = null, ?string $reservationNumber = null)
     {
-        $orderMock = $this->getMockBuilder(Order::class)
+        $orderMock = $this->getMockBuilder(\Buckaroo\Magento2\Test\Unit\Stubs\OrderStub::class)
             ->disableOriginalConstructor()
-            ->addMethods(['getBuckarooDatarequestKey', 'getBuckarooReservationNumber'])
-            ->onlyMethods(['getIncrementId'])
-            ->getMock();
+            ->onlyMethods(['getIncrementId', 'getBuckarooDatarequestKey', 'getBuckarooReservationNumber'])->getMock();
 
         $orderMock->method('getBuckarooDatarequestKey')->willReturn($dataRequestKey);
         $orderMock->method('getBuckarooReservationNumber')->willReturn($reservationNumber);

--- a/Test/Unit/Gateway/Validator/ActiveAccountValidatorTest.php
+++ b/Test/Unit/Gateway/Validator/ActiveAccountValidatorTest.php
@@ -2,6 +2,8 @@
 
 namespace Buckaroo\Magento2\Test\Unit\Gateway\Validator;
 
+
+use PHPUnit\Framework\Attributes\DataProvider;
 use Buckaroo\Magento2\Gateway\Validator\ActiveAccountValidator;
 use Buckaroo\Magento2\Model\ConfigProvider\Account;
 use Buckaroo\Magento2\Model\ConfigProvider\Factory as ConfigProviderFactory;
@@ -39,11 +41,11 @@ class ActiveAccountValidatorTest extends TestCase
     }
 
     /**
-     * @dataProvider accountActiveProvider
      *
      * @param mixed $accountActive
      * @param bool  $isValid
      */
+    #[DataProvider('accountActiveProvider')]
     public function testValidate($accountActive, bool $isValid)
     {
         // Create mock quote

--- a/Test/Unit/Gateway/Validator/AreaCodeValidatorTest.php
+++ b/Test/Unit/Gateway/Validator/AreaCodeValidatorTest.php
@@ -2,6 +2,8 @@
 
 namespace Buckaroo\Magento2\Test\Unit\Gateway\Validator;
 
+
+use PHPUnit\Framework\Attributes\DataProvider;
 use Buckaroo\Magento2\Gateway\Validator\AreaCodeValidator;
 use Buckaroo\Magento2\Model\ConfigProvider\Method\Factory as MethodConfigProviderFactory;
 use Buckaroo\Magento2\Model\ConfigProvider\Method\ConfigProviderInterface;
@@ -45,9 +47,7 @@ class AreaCodeValidatorTest extends TestCase
         );
     }
 
-    /**
-     * @dataProvider validateDataProvider
-     */
+    #[DataProvider('validateDataProvider')]
     public function testValidate(
         string $areaCode,
         ?string $availableInBackend,

--- a/Test/Unit/Gateway/Validator/AvailableBasedOnAmountValidatorTest.php
+++ b/Test/Unit/Gateway/Validator/AvailableBasedOnAmountValidatorTest.php
@@ -2,6 +2,8 @@
 
 namespace Buckaroo\Magento2\Test\Unit\Gateway\Validator;
 
+
+use PHPUnit\Framework\Attributes\DataProvider;
 use Buckaroo\Magento2\Gateway\Validator\AvailableBasedOnAmountValidator;
 use Magento\Payment\Gateway\Validator\ResultInterface;
 use Magento\Payment\Gateway\Validator\ResultInterfaceFactory;
@@ -30,13 +32,13 @@ class AvailableBasedOnAmountValidatorTest extends TestCase
     }
 
     /**
-     * @dataProvider availableBasedOnAmountValidatorDataProvider
      *
      * @param mixed $maximum
      * @param mixed $minimum
      * @param mixed $grandTotal
      * @param mixed $isValid
      */
+    #[DataProvider('availableBasedOnAmountValidatorDataProvider')]
     public function testValidate($maximum, $minimum, $grandTotal, $isValid)
     {
         $paymentMethodInstanceMock = $this->createMock(MethodInterface::class);
@@ -48,11 +50,9 @@ class AvailableBasedOnAmountValidatorTest extends TestCase
             ]);
 
         // Create a more robust Quote mock that doesn't trigger internal factory calls
-        $quoteMock = $this->getMockBuilder(\Magento\Quote\Model\Quote::class)
+        $quoteMock = $this->getMockBuilder(\Buckaroo\Magento2\Test\Unit\Stubs\QuoteStub::class)
             ->disableOriginalConstructor()
-            ->onlyMethods(['getStoreId', 'getShippingAddress', 'getBillingAddress'])
-            ->addMethods(['getGrandTotal'])
-            ->getMock();
+            ->onlyMethods(['getStoreId', 'getShippingAddress', 'getBillingAddress', 'getGrandTotal'])->getMock();
         $quoteMock->method('getGrandTotal')
             ->willReturn($grandTotal);
         $quoteMock->method('getStoreId')

--- a/Test/Unit/Gateway/Validator/AvailableBasedOnCurrencyValidatorTest.php
+++ b/Test/Unit/Gateway/Validator/AvailableBasedOnCurrencyValidatorTest.php
@@ -2,6 +2,8 @@
 
 namespace Buckaroo\Magento2\Test\Unit\Gateway\Validator;
 
+
+use PHPUnit\Framework\Attributes\DataProvider;
 use Buckaroo\Magento2\Gateway\Validator\AvailableBasedOnCurrencyValidator;
 use Buckaroo\Magento2\Service\TransactionCurrencyResolver;
 use Magento\Payment\Gateway\Validator\ResultInterface;
@@ -38,12 +40,12 @@ class AvailableBasedOnCurrencyValidatorTest extends TestCase
     }
 
     /**
-     * @dataProvider dataProviderTestValidate
      *
      * @param string $quoteCurrency
      * @param bool   $currencyAllowed
      * @param bool   $expectedResult
      */
+    #[DataProvider('dataProviderTestValidate')]
     public function testValidate(
         string $quoteCurrency,
         bool $currencyAllowed,

--- a/Test/Unit/Gateway/Validator/IssuerValidatorTest.php
+++ b/Test/Unit/Gateway/Validator/IssuerValidatorTest.php
@@ -2,6 +2,8 @@
 
 namespace Buckaroo\Magento2\Test\Unit\Gateway\Validator;
 
+
+use PHPUnit\Framework\Attributes\DataProvider;
 use Buckaroo\Magento2\Gateway\Validator\IssuerValidator;
 use Buckaroo\Magento2\Model\ConfigProvider\Method\AbstractConfigProvider;
 use Buckaroo\Magento2\Model\ConfigProvider\Factory as ConfigProviderMethodFactory;
@@ -50,13 +52,13 @@ class IssuerValidatorTest extends TestCase
     }
 
     /**
-     * @dataProvider issuerValidatorDataProvider
      *
      * @param mixed $chosenIssuer
      * @param mixed $paymentMethodCode
      * @param mixed $isValid
      * @param mixed $failMessage
      */
+    #[DataProvider('issuerValidatorDataProvider')]
     public function testValidate($chosenIssuer, $paymentMethodCode, $isValid, $failMessage)
     {
         $paymentDataObjectInterface = $this->createMock(PaymentDataObjectInterface::class);

--- a/Test/Unit/Model/AbstractCommandBasedTest.php
+++ b/Test/Unit/Model/AbstractCommandBasedTest.php
@@ -79,11 +79,9 @@ abstract class AbstractCommandBasedTest extends TestCase
 
         // Build a Quote double that explicitly allows stubbing getPayment()
         // and (optionally) getGrandTotal().
-        $this->quoteMock = $this->getMockBuilder(Quote::class)
-            ->disableOriginalConstructor()
-            ->onlyMethods(['getPayment'])   // make getPayment stub-able
-            ->addMethods(['getGrandTotal']) // add if your Magento version lacks it
-            ->getMock();
+        $this->quoteMock = $this->getMockBuilder(\Buckaroo\Magento2\Test\Unit\Stubs\QuoteStub::class)
+            ->disableOriginalConstructor()   // make getPayment stub-able // add if your Magento version lacks it
+            ->onlyMethods(['getPayment', 'getGrandTotal'])->getMock();
 
         // Payment: allow chaining setAdditionalInformation()
         $this->paymentMock = $this->getMockBuilder(Payment::class)

--- a/Test/Unit/Model/Config/Backend/AllowedCurrenciesTest.php
+++ b/Test/Unit/Model/Config/Backend/AllowedCurrenciesTest.php
@@ -36,9 +36,8 @@ class AllowedCurrenciesTest extends \Buckaroo\Magento2\Test\BaseTest
      */
     public function testSaveNoValue()
     {
-        $resourceMock = $this->getFakeMock(AbstractResource::class)
-            ->addMethods(['save'])
-            ->getMockForAbstractClass();
+        $resourceMock = $this->getFakeMock(\Buckaroo\Magento2\Test\Unit\Stubs\AbstractResourceStub::class)
+            ->onlyMethods(['save'])->getMock();
         $resourceMock->method('save');
 
         $instance = $this->getInstance(['resource' => $resourceMock]);
@@ -57,9 +56,8 @@ class AllowedCurrenciesTest extends \Buckaroo\Magento2\Test\BaseTest
             ->getMock();
         $configProviderMock->method('getAllowedCurrencies')->willReturn(['EUR', 'USD']);
 
-        $resourceMock = $this->getFakeMock(AbstractResource::class)
-            ->addMethods(['save'])
-            ->getMockForAbstractClass();
+        $resourceMock = $this->getFakeMock(\Buckaroo\Magento2\Test\Unit\Stubs\AbstractResourceStub::class)
+            ->onlyMethods(['save'])->getMock();
         $resourceMock->method('save');
 
         $instance = $this->getInstance(['configProvider' => $configProviderMock, 'resource' => $resourceMock]);
@@ -87,7 +85,7 @@ class AllowedCurrenciesTest extends \Buckaroo\Magento2\Test\BaseTest
             ]
         ]);
 
-        $localeResolverMock = $this->getFakeMock(\Magento\Framework\Locale\ResolverInterface::class)->getMockForAbstractClass();
+        $localeResolverMock = $this->getFakeMock(\Magento\Framework\Locale\ResolverInterface::class)->getMock();
         $localeResolverMock->method('getLocale')->willReturn('en_US');
 
         $instance = $this->getInstance([

--- a/Test/Unit/Model/Config/Backend/NumberTest.php
+++ b/Test/Unit/Model/Config/Backend/NumberTest.php
@@ -34,9 +34,8 @@ class NumberTest extends \Buckaroo\Magento2\Test\BaseTest
      */
     public function testEmptyValue()
     {
-        $resourceMock = $this->getFakeMock(AbstractResource::class)
-            ->addMethods(['save'])
-            ->getMockForAbstractClass();
+        $resourceMock = $this->getFakeMock(\Buckaroo\Magento2\Test\Unit\Stubs\AbstractResourceStub::class)
+            ->onlyMethods(['save'])->getMock();
         $resourceMock->method('save');
 
         $instance = $this->getInstance(['resource' => $resourceMock]);
@@ -50,9 +49,8 @@ class NumberTest extends \Buckaroo\Magento2\Test\BaseTest
      */
     public function testValidValue()
     {
-        $resourceMock = $this->getFakeMock(AbstractResource::class)
-            ->addMethods(['save'])
-            ->getMockForAbstractClass();
+        $resourceMock = $this->getFakeMock(\Buckaroo\Magento2\Test\Unit\Stubs\AbstractResourceStub::class)
+            ->onlyMethods(['save'])->getMock();
         $resourceMock->method('save');
 
         $instance = $this->getInstance(['resource' => $resourceMock]);

--- a/Test/Unit/Model/Config/Backend/PriceTest.php
+++ b/Test/Unit/Model/Config/Backend/PriceTest.php
@@ -34,9 +34,8 @@ class PriceTest extends \Buckaroo\Magento2\Test\BaseTest
      */
     public function testEmptyValue()
     {
-        $resourceMock = $this->getFakeMock(AbstractResource::class)
-            ->addMethods(['save'])
-            ->getMockForAbstractClass();
+        $resourceMock = $this->getFakeMock(\Buckaroo\Magento2\Test\Unit\Stubs\AbstractResourceStub::class)
+            ->onlyMethods(['save'])->getMock();
         $resourceMock->method('save');
 
         $instance = $this->getInstance(['resource' => $resourceMock]);
@@ -53,9 +52,8 @@ class PriceTest extends \Buckaroo\Magento2\Test\BaseTest
      */
     public function testValidValue()
     {
-        $resourceMock = $this->getFakeMock(AbstractResource::class)
-            ->addMethods(['save'])
-            ->getMockForAbstractClass();
+        $resourceMock = $this->getFakeMock(\Buckaroo\Magento2\Test\Unit\Stubs\AbstractResourceStub::class)
+            ->onlyMethods(['save'])->getMock();
         $resourceMock->method('save');
 
         $instance = $this->getInstance(['resource' => $resourceMock]);

--- a/Test/Unit/Model/Config/Source/Afterpay2PaymentMethods.php
+++ b/Test/Unit/Model/Config/Source/Afterpay2PaymentMethods.php
@@ -21,6 +21,8 @@
 
 namespace Buckaroo\Magento2\Test\Unit\Model\Config\Source;
 
+
+use PHPUnit\Framework\Attributes\DataProvider;
 use Buckaroo\Magento2\Model\Config\Source\Afterpay2PaymentMethods;
 use Buckaroo\Magento2\Test\BaseTest;
 
@@ -46,8 +48,8 @@ class Afterpay2PaymentMethodsTest extends BaseTest
     /**
      * @param $paymentOption
      *
-     * @dataProvider toOptionArrayProvider
      */
+    #[DataProvider('toOptionArrayProvider')]
     public function testToOptionArray($paymentOption)
     {
         $instance = $this->getInstance();

--- a/Test/Unit/Model/Config/Source/AfterpayPaymentMethodsTest.php
+++ b/Test/Unit/Model/Config/Source/AfterpayPaymentMethodsTest.php
@@ -21,6 +21,8 @@
 
 namespace Buckaroo\Magento2\Test\Unit\Model\Config\Source;
 
+
+use PHPUnit\Framework\Attributes\DataProvider;
 use Buckaroo\Magento2\Model\Config\Source\AfterpayPaymentMethods;
 use Buckaroo\Magento2\Test\BaseTest;
 
@@ -46,8 +48,8 @@ class AfterpayPaymentMethodsTest extends BaseTest
     /**
      * @param $paymentOption
      *
-     * @dataProvider toOptionArrayProvider
      */
+    #[DataProvider('toOptionArrayProvider')]
     public function testToOptionArray($paymentOption)
     {
         $instance = $this->getInstance();

--- a/Test/Unit/Model/Config/Source/Display/TypeTest.php
+++ b/Test/Unit/Model/Config/Source/Display/TypeTest.php
@@ -21,6 +21,8 @@
 
 namespace Buckaroo\Magento2\Test\Unit\Model\Config\Source\Display;
 
+
+use PHPUnit\Framework\Attributes\DataProvider;
 use Buckaroo\Magento2\Model\Config\Source\Display\Type;
 use Buckaroo\Magento2\Test\BaseTest;
 
@@ -49,8 +51,8 @@ class TypeTest extends BaseTest
     /**
      * @param $paymentOption
      *
-     * @dataProvider toOptionArrayProvider
      */
+    #[DataProvider('toOptionArrayProvider')]
     public function testToOptionArray($paymentOption)
     {
         $instance = $this->getInstance();

--- a/Test/Unit/Model/Config/Source/FeePercentageModeTest.php
+++ b/Test/Unit/Model/Config/Source/FeePercentageModeTest.php
@@ -21,6 +21,8 @@
 
 namespace Buckaroo\Magento2\Test\Unit\Model\Config\Source;
 
+
+use PHPUnit\Framework\Attributes\DataProvider;
 use Buckaroo\Magento2\Model\Config\Source\FeePercentageMode;
 use Buckaroo\Magento2\Test\BaseTest;
 use Magento\Framework\Phrase;
@@ -47,8 +49,8 @@ class FeePercentageModeTest extends BaseTest
     /**
      * @param $paymentOption
      *
-     * @dataProvider toOptionArrayProvider
      */
+    #[DataProvider('toOptionArrayProvider')]
     public function testToOptionArray($paymentOption)
     {
         $instance = $this->getInstance();

--- a/Test/Unit/Model/Config/Source/GiftcardsTest.php
+++ b/Test/Unit/Model/Config/Source/GiftcardsTest.php
@@ -20,6 +20,8 @@
  */
 namespace Buckaroo\Magento2\Test\Unit\Model\Config\Source;
 
+
+use PHPUnit\Framework\Attributes\DataProvider;
 use Buckaroo\Magento2\Model\Config\Source\Giftcards;
 use Buckaroo\Magento2\Test\BaseTest;
 
@@ -93,8 +95,8 @@ class GiftcardsTest extends BaseTest
      * @param $giftcardData
      * @param $expected
      *
-     * @dataProvider toOptionArrayProvider
      */
+    #[DataProvider('toOptionArrayProvider')]
     public function testToOptionArray($giftcardData, $expected)
     {
         $sortOrderBuilderMock = $this->getFakeMock(\Magento\Framework\Api\SortOrderBuilder::class)

--- a/Test/Unit/Model/Config/Source/PaymentFlowTest.php
+++ b/Test/Unit/Model/Config/Source/PaymentFlowTest.php
@@ -7,6 +7,8 @@
 
 namespace Buckaroo\Magento2\Test\Unit\Model\Config\Source;
 
+
+use PHPUnit\Framework\Attributes\DataProvider;
 use Buckaroo\Magento2\Model\Config\Source\PaymentFlow;
 use Buckaroo\Magento2\Test\BaseTest;
 
@@ -23,10 +25,10 @@ class PaymentFlowTest extends BaseTest
     }
 
     /**
-     * @dataProvider toOptionArrayProvider
      *
      * @param array $expected
      */
+    #[DataProvider('toOptionArrayProvider')]
     public function testToOptionArray(array $expected)
     {
         $instance = $this->getInstance();

--- a/Test/Unit/Model/Config/Source/PaymentMethods/AfterExpiryTest.php
+++ b/Test/Unit/Model/Config/Source/PaymentMethods/AfterExpiryTest.php
@@ -5,6 +5,8 @@
  */
 namespace Buckaroo\Magento2\Test\Unit\Model\Config\Source\PaymentMethods;
 
+
+use PHPUnit\Framework\Attributes\DataProvider;
 use Buckaroo\Magento2\Model\Config\Source\PaymentMethods\AfterExpiry;
 use Buckaroo\Magento2\Test\BaseTest;
 
@@ -35,8 +37,8 @@ class AfterExpiryTest extends BaseTest
     /**
      * @param array $paymentOption
      *
-     * @dataProvider toOptionArrayProvider
      */
+    #[DataProvider('toOptionArrayProvider')]
     public function testToOptionArray($paymentOption)
     {
         $instance = $this->getInstance();

--- a/Test/Unit/Model/Config/Source/PaymentMethods/PayPerEmailTest.php
+++ b/Test/Unit/Model/Config/Source/PaymentMethods/PayPerEmailTest.php
@@ -21,6 +21,8 @@
 
 namespace Buckaroo\Magento2\Test\Unit\Model\Config\Source\PayPerEmail;
 
+
+use PHPUnit\Framework\Attributes\DataProvider;
 use Buckaroo\Magento2\Model\Config\Source\PaymentMethods\PayPerEmail;
 use Buckaroo\Magento2\Test\BaseTest;
 
@@ -76,8 +78,8 @@ class PayPerEmailTest extends BaseTest
     /**
      * @param $paymentOption
      *
-     * @dataProvider toOptionArrayProvider
      */
+    #[DataProvider('toOptionArrayProvider')]
     public function testToOptionArray($paymentOption)
     {
         $instance = $this->getInstance();

--- a/Test/Unit/Model/Config/Source/TaxClass/CalculationTest.php
+++ b/Test/Unit/Model/Config/Source/TaxClass/CalculationTest.php
@@ -21,6 +21,8 @@
 
 namespace Buckaroo\Magento2\Test\Unit\Model\Config\Source\TaxClass;
 
+
+use PHPUnit\Framework\Attributes\DataProvider;
 use Buckaroo\Magento2\Model\Config\Source\TaxClass\Calculation;
 use Buckaroo\Magento2\Test\BaseTest;
 
@@ -39,8 +41,8 @@ class CalculationTest extends BaseTest
     /**
      * @param array $paymentOption
      *
-     * @dataProvider toOptionArrayProvider
      */
+    #[DataProvider('toOptionArrayProvider')]
     public function testToOptionArray($paymentOption)
     {
         $instance = $this->getInstance();

--- a/Test/Unit/Model/Config/Source/VisibleFrontBackTest.php
+++ b/Test/Unit/Model/Config/Source/VisibleFrontBackTest.php
@@ -21,6 +21,8 @@
 
 namespace Buckaroo\Magento2\Test\Unit\Model\Config\Source;
 
+
+use PHPUnit\Framework\Attributes\DataProvider;
 use Buckaroo\Magento2\Model\Config\Source\VisibleFrontBack;
 use Buckaroo\Magento2\Test\BaseTest;
 
@@ -49,8 +51,8 @@ class VisibleFrontBackTest extends BaseTest
     /**
      * @param $visibleFrontBack
      *
-     * @dataProvider toOptionArrayProvider
      */
+    #[DataProvider('toOptionArrayProvider')]
     public function testToOptionArray($visibleFrontBack)
     {
         $instance = $this->getInstance();
@@ -81,8 +83,8 @@ class VisibleFrontBackTest extends BaseTest
     /**
      * @param $visibleFrontBack
      *
-     * @dataProvider toArrayProvider
      */
+    #[DataProvider('toArrayProvider')]
     public function testToArray($visibleFrontBack)
     {
         $instance = $this->getInstance();

--- a/Test/Unit/Model/ConfigProvider/AccountTest.php
+++ b/Test/Unit/Model/ConfigProvider/AccountTest.php
@@ -90,6 +90,42 @@ class AccountTest extends BaseTest
         ->willReturn(
             'Order {order_number} shop: {shop_name} product: {product_name}'
         );
-        $this->assertEquals("Order {$orderNumber} shop: {$orderNumber} product: {$productName}", $account->getParsedLabel($storeMock, $orderMock));
+
+        $result = $account->getParsedLabel($storeMock, $orderMock);
+
+        $this->assertSame(
+            "Order {$orderNumber} shop: {$shopName} product: {$productName}",
+            $result
+        );
+
+        // Every placeholder must have been substituted.
+        $this->assertStringNotContainsString('{order_number}', $result);
+        $this->assertStringNotContainsString('{shop_name}', $result);
+        $this->assertStringNotContainsString('{product_name}', $result);
+    }
+
+    public function testGetParsedLabelReturnsStoreNameWhenNoLabelIsConfigured()
+    {
+        $shopName = 'Shop Name';
+
+        $storeMock = $this->getFakeMock(Store::class)
+            ->onlyMethods(['getName'])
+            ->getMock();
+        $storeMock->expects($this->once())->method('getName')->willReturn($shopName);
+
+        $orderMock = $this->getFakeMock(Order::class)
+            ->onlyMethods(['getIncrementId', 'getItems'])
+            ->getMock();
+        $orderMock->expects($this->never())->method('getIncrementId');
+        $orderMock->expects($this->never())->method('getItems');
+
+        $account = $this->getFakeMock(Account::class)
+            ->onlyMethods(['getTransactionLabel'])
+            ->getMock();
+        $account->method('getTransactionLabel')
+            ->with($storeMock)
+            ->willReturn(null);
+
+        $this->assertSame($shopName, $account->getParsedLabel($storeMock, $orderMock));
     }
 }

--- a/Test/Unit/Model/ConfigProvider/Method/Afterpay20Test.php
+++ b/Test/Unit/Model/ConfigProvider/Method/Afterpay20Test.php
@@ -20,6 +20,8 @@
  */
 namespace Buckaroo\Magento2\Test\Unit\Model\ConfigProvider\Method;
 
+
+use PHPUnit\Framework\Attributes\DataProvider;
 use Buckaroo\Magento2\Model\ConfigProvider\Method\AbstractConfigProvider;
 use Magento\Store\Model\ScopeInterface;
 use Buckaroo\Magento2\Helper\PaymentFee;
@@ -60,13 +62,12 @@ class Afterpay20Test extends BaseTest
      * @param $active
      * @param $expected
      *
-     * @dataProvider getConfigProvider
      */
+    #[DataProvider('getConfigProvider')]
     public function testGetConfig($active, $expected)
     {
         $scopeConfigMock = $this->getFakeMock(ScopeConfigInterface::class)
-            ->onlyMethods(['getValue'])
-            ->getMockForAbstractClass();
+            ->getMock();
         // PHPUnit 10: use a value map instead of withConsecutive()
         $valueMap = [
             [
@@ -147,13 +148,12 @@ class Afterpay20Test extends BaseTest
      * @param $value
      * @param $expected
      *
-     * @dataProvider getPaymentFeeProvider
      */
+    #[DataProvider('getPaymentFeeProvider')]
     public function testGetPaymentFee($value, $expected)
     {
         $scopeConfigMock = $this->getFakeMock(ScopeConfigInterface::class)
-            ->onlyMethods(['getValue'])
-            ->getMockForAbstractClass();
+            ->getMock();
         $scopeConfigMock->method('getValue')
             ->with(
                 $this->getPaymentMethodConfigPath(Afterpay20::CODE, AbstractConfigProvider::PAYMENT_FEE),

--- a/Test/Unit/Model/ConfigProvider/Method/ApplepayTest.php
+++ b/Test/Unit/Model/ConfigProvider/Method/ApplepayTest.php
@@ -26,11 +26,11 @@ class ApplepayTest extends BaseTest
     }
 
     /**
-     * @dataProvider configProvider
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      *
      * @param bool $active
      */
+    #[DataProvider('configProvider')]
     public function testGetConfig(bool $active): void
     {
         // 1) Scope config
@@ -97,10 +97,9 @@ class ApplepayTest extends BaseTest
         }
 
         // 4) Account (merchant GUID) — some envs may not use it; just stub the method without asserting calls
-        $account = $this->getMockBuilder(\Buckaroo\Magento2\Model\ConfigProvider\Account::class)
+        $account = $this->getMockBuilder(\Buckaroo\Magento2\Test\Unit\Stubs\AccountStub::class)
             ->disableOriginalConstructor()
-            ->addMethods(['getMerchantGuid'])
-            ->getMock();
+            ->onlyMethods(['getMerchantGuid'])->getMock();
         $account->method('getMerchantGuid')->willReturn('GUID12345');
 
         // Instance under test

--- a/Test/Unit/Model/ConfigProvider/Method/BelfiusTest.php
+++ b/Test/Unit/Model/ConfigProvider/Method/BelfiusTest.php
@@ -21,6 +21,8 @@
 
 namespace Buckaroo\Magento2\Test\Unit\Model\ConfigProvider\Method;
 
+
+use PHPUnit\Framework\Attributes\DataProvider;
 use Buckaroo\Magento2\Model\ConfigProvider\Method\AbstractConfigProvider;
 use Buckaroo\Magento2\Model\ConfigProvider\Method\Applepay;
 use Magento\Store\Model\ScopeInterface;
@@ -56,15 +58,14 @@ class BelfiusTest extends BaseTest
      * @param $active
      * @param $expected
      *
-     * @dataProvider getConfigProvider
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
+    #[DataProvider('getConfigProvider')]
     public function testGetConfig($active, $expected)
     {
         $scopeConfigMock = $this->getFakeMock(ScopeConfigInterface::class)
-            ->onlyMethods(['getValue'])
-            ->getMockForAbstractClass();
+            ->getMock();
 
         $valueMap = [
             [
@@ -142,13 +143,12 @@ class BelfiusTest extends BaseTest
      *
      * @covers ::getPaymentFee
      *
-     * @dataProvider getPaymentFeeProvider
      */
+    #[DataProvider('getPaymentFeeProvider')]
     public function testGetPaymentFee($value, $expected)
     {
         $scopeConfigMock = $this->getFakeMock(ScopeConfigInterface::class)
-            ->onlyMethods(['getValue'])
-            ->getMockForAbstractClass();
+            ->getMock();
 
         $scopeConfigMock->method('getValue')
             ->with(

--- a/Test/Unit/Model/ConfigProvider/Method/CapayableIn3Test.php
+++ b/Test/Unit/Model/ConfigProvider/Method/CapayableIn3Test.php
@@ -21,6 +21,8 @@
 
 namespace Buckaroo\Magento2\Test\Unit\Model\ConfigProvider\Method;
 
+
+use PHPUnit\Framework\Attributes\DataProvider;
 use Buckaroo\Magento2\Model\ConfigProvider\Method\AbstractConfigProvider;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Store\Model\ScopeInterface;
@@ -113,8 +115,8 @@ class CapayableIn3Test extends BaseTest
      * @param $fee
      * @param $expected
      *
-     * @dataProvider getPaymentFeeProvider
      */
+    #[DataProvider('getPaymentFeeProvider')]
     public function testGetPaymentFee($fee, $expected)
     {
         $scopeConfigMock = $this->getMockBuilder(ScopeConfigInterface::class)->getMock();

--- a/Test/Unit/Model/ConfigProvider/Method/CapayablePostpayTest.php
+++ b/Test/Unit/Model/ConfigProvider/Method/CapayablePostpayTest.php
@@ -21,6 +21,8 @@
 
 namespace Buckaroo\Magento2\Test\Unit\Model\ConfigProvider\Method;
 
+
+use PHPUnit\Framework\Attributes\DataProvider;
 use Buckaroo\Magento2\Model\ConfigProvider\Method\AbstractConfigProvider;
 use Buckaroo\Magento2\Model\ConfigProvider\Method\CapayableIn3;
 use Magento\Framework\App\Config\ScopeConfigInterface;
@@ -50,8 +52,7 @@ class CapayablePostpayTest extends BaseTest
     public function testGetConfig()
     {
         $scopeConfigMock = $this->getFakeMock(ScopeConfigInterface::class)
-            ->onlyMethods(['getValue'])
-            ->getMockForAbstractClass();
+            ->getMock();
         $scopeConfigMock->method('getValue')
             ->willReturnCallback(function ($path, $scope = null, $scopeId = null) {
                 // Use parameters to avoid PHPMD warnings
@@ -109,8 +110,8 @@ class CapayablePostpayTest extends BaseTest
      * @param $fee
      * @param $expected
      *
-     * @dataProvider getPaymentFeeProvider
      */
+    #[DataProvider('getPaymentFeeProvider')]
     public function testGetPaymentFee($fee, $expected)
     {
         $scopeConfigMock = $this->getMockBuilder(ScopeConfigInterface::class)->getMock();

--- a/Test/Unit/Model/ConfigProvider/Method/ClicktopayTest.php
+++ b/Test/Unit/Model/ConfigProvider/Method/ClicktopayTest.php
@@ -22,6 +22,8 @@ declare(strict_types=1);
 
 namespace Buckaroo\Magento2\Test\Unit\Model\ConfigProvider\Method;
 
+
+use PHPUnit\Framework\Attributes\DataProvider;
 use Buckaroo\Magento2\Model\ConfigProvider\Method\AbstractConfigProvider;
 use Buckaroo\Magento2\Model\ConfigProvider\Method\Clicktopay;
 use Buckaroo\Magento2\Test\BaseTest;
@@ -42,9 +44,7 @@ class ClicktopayTest extends BaseTest
         ];
     }
 
-    /**
-     * @dataProvider configProvider
-     */
+    #[DataProvider('configProvider')]
     public function testGetConfig(bool $active): void
     {
         $scopeConfig    = $this->createScopeConfigMock($active);

--- a/Test/Unit/Model/ConfigProvider/Method/CreditcardTest.php
+++ b/Test/Unit/Model/ConfigProvider/Method/CreditcardTest.php
@@ -37,8 +37,7 @@ class CreditcardTest extends BaseTest
         $allowedCurrencies = 'USD,EUR';
 
         $scopeConfigMock = $this->getFakeMock(ScopeConfigInterface::class)
-            ->onlyMethods(['getValue'])
-            ->getMockForAbstractClass();
+            ->getMock();
 
         // Mock the getValue calls for different config paths
         $scopeConfigMock->method('getValue')->willReturnMap([
@@ -82,8 +81,7 @@ class CreditcardTest extends BaseTest
     public function testGetActive()
     {
         $scopeConfigMock = $this->getFakeMock(ScopeConfigInterface::class)
-            ->onlyMethods(['getValue'])
-            ->getMockForAbstractClass();
+            ->getMock();
         $scopeConfigMock->method('getValue')
             ->with(
                 $this->getPaymentMethodConfigPath(Creditcard::CODE, AbstractConfigProvider::ACTIVE),

--- a/Test/Unit/Model/ConfigProvider/Method/CreditcardsTest.php
+++ b/Test/Unit/Model/ConfigProvider/Method/CreditcardsTest.php
@@ -20,6 +20,8 @@
  */
 namespace Buckaroo\Magento2\Test\Unit\Model\ConfigProvider\Method;
 
+
+use PHPUnit\Framework\Attributes\DataProvider;
 use Buckaroo\Magento2\Model\ConfigProvider\Method\AbstractConfigProvider;
 use Magento\Store\Model\ScopeInterface;
 use Buckaroo\Magento2\Helper\PaymentFee;
@@ -52,13 +54,12 @@ class CreditcardsTest extends BaseTest
     /**
      * @param $expected
      *
-     * @dataProvider getConfigProvider
      */
+    #[DataProvider('getConfigProvider')]
     public function testGetConfig($expected)
     {
         $scopeConfigMock = $this->getFakeMock(ScopeConfigInterface::class)
-            ->onlyMethods(['getValue'])
-            ->getMockForAbstractClass();
+            ->getMock();
         $scopeConfigMock->method('getValue')
             ->willReturnMap([
                 [
@@ -159,13 +160,12 @@ class CreditcardsTest extends BaseTest
      * @param $value
      * @param $expected
      *
-     * @dataProvider getPaymentFeeProvider
      */
+    #[DataProvider('getPaymentFeeProvider')]
     public function testGetPaymentFee($value, $expected)
     {
         $scopeConfigMock = $this->getFakeMock(ScopeConfigInterface::class)
-            ->onlyMethods(['getValue'])
-            ->getMockForAbstractClass();
+            ->getMock();
         $scopeConfigMock->method('getValue')
             ->with(
                 Creditcards::XPATH_CREDITCARDS_PAYMENT_FEE,

--- a/Test/Unit/Model/ConfigProvider/Method/EpsTest.php
+++ b/Test/Unit/Model/ConfigProvider/Method/EpsTest.php
@@ -18,6 +18,8 @@
 
 namespace Buckaroo\Magento2\Test\Unit\Model\ConfigProvider\Method;
 
+
+use PHPUnit\Framework\Attributes\DataProvider;
 use Buckaroo\Magento2\Helper\PaymentFee;
 use Buckaroo\Magento2\Model\ConfigProvider\Method\AbstractConfigProvider;
 use Buckaroo\Magento2\Model\ConfigProvider\Method\Eps;
@@ -59,16 +61,15 @@ class EpsTest extends BaseTest
      * @param bool  $active
      * @param array $expected
      *
-     * @dataProvider getConfigProvider
      */
+    #[DataProvider('getConfigProvider')]
     public function testGetConfig($active, $expected): void
     {
         // $expected parameter is from data provider but not used in this test implementation
         unset($expected);
 
         $scopeConfigMock = $this->getFakeMock(ScopeConfigInterface::class)
-            ->onlyMethods(['getValue'])
-            ->getMockForAbstractClass();
+            ->getMock();
 
         $scopeConfigMock->method('getValue')
             ->willReturnCallback(function ($path, $scope = null, $storeId = null) use ($active) {
@@ -144,13 +145,12 @@ class EpsTest extends BaseTest
      * @param mixed $value
      * @param mixed $expected
      *
-     * @dataProvider getPaymentFeeProvider
      */
+    #[DataProvider('getPaymentFeeProvider')]
     public function testGetPaymentFee($value, $expected): void
     {
         $scopeConfigMock = $this->getFakeMock(ScopeConfigInterface::class)
-            ->onlyMethods(['getValue'])
-            ->getMockForAbstractClass();
+            ->getMock();
 
         $scopeConfigMock->method('getValue')
             ->with(

--- a/Test/Unit/Model/ConfigProvider/Method/FactoryTest.php
+++ b/Test/Unit/Model/ConfigProvider/Method/FactoryTest.php
@@ -38,9 +38,9 @@ class FactoryTest extends BaseTest
         $model = 'model1';
         $providers = [['type' => 'model1', 'model' => 'model1']];
 
-        $configProviderMock = $this->getFakeMock(ConfigProviderInterface::class)->getMockForAbstractClass();
+        $configProviderMock = $this->getFakeMock(ConfigProviderInterface::class)->getMock();
 
-        $objectManagerMock = $this->getFakeMock(ObjectManagerInterface::class)->onlyMethods(['get'])->getMockForAbstractClass();
+        $objectManagerMock = $this->getFakeMock(ObjectManagerInterface::class)->getMock();
         $objectManagerMock->method('get')->with($model)->willReturn($configProviderMock);
 
         $instance = $this->getInstance(['configProviders' => $providers, 'objectManager' => $objectManagerMock]);
@@ -75,7 +75,7 @@ class FactoryTest extends BaseTest
         // Mock an object that doesn't implement the expected BuckarooConfigProviderInterface
         $invalidConfigProvider = new \stdClass(); // This won't implement BuckarooConfigProviderInterface
 
-        $objectManagerMock = $this->getFakeMock(ObjectManagerInterface::class)->onlyMethods(['get'])->getMockForAbstractClass();
+        $objectManagerMock = $this->getFakeMock(ObjectManagerInterface::class)->getMock();
         $objectManagerMock->method('get')->with('InvalidTestClass')->willReturn($invalidConfigProvider);
 
         $instance = $this->getInstance(['configProviders' => $providers, 'objectManager' => $objectManagerMock]);

--- a/Test/Unit/Model/ConfigProvider/Method/GiftcardsTest.php
+++ b/Test/Unit/Model/ConfigProvider/Method/GiftcardsTest.php
@@ -35,8 +35,7 @@ class GiftcardsTest extends BaseTest
     public function testGetConfig()
     {
         $scopeConfigMock = $this->getFakeMock(ScopeConfigInterface::class)
-            ->onlyMethods(['getValue'])
-            ->getMockForAbstractClass();
+            ->getMock();
         $scopeConfigMock->method('getValue')->willReturnMap([
             // Make the giftcards method active
             [
@@ -93,8 +92,7 @@ class GiftcardsTest extends BaseTest
     public function testGetPaymentFee()
     {
         $scopeConfigMock = $this->getFakeMock(ScopeConfigInterface::class)
-            ->onlyMethods(['getValue'])
-            ->getMockForAbstractClass();
+            ->getMock();
         $scopeConfigMock->method('getValue')
             ->with('payment/buckaroo_magento2_giftcards/active', ScopeInterface::SCOPE_STORE)
             ->willReturn(false);

--- a/Test/Unit/Model/ConfigProvider/Method/IdealTest.php
+++ b/Test/Unit/Model/ConfigProvider/Method/IdealTest.php
@@ -37,8 +37,7 @@ class IdealTest extends BaseTest
     public function testInactive()
     {
         $scopeConfigMock = $this->getFakeMock(ScopeConfigInterface::class)
-            ->onlyMethods(['getValue'])
-            ->getMockForAbstractClass();
+            ->getMock();
         $scopeConfigMock->method('getValue')
             ->with(
                 $this->getPaymentMethodConfigPath(Ideal::CODE, AbstractConfigProvider::ACTIVE),
@@ -58,8 +57,7 @@ class IdealTest extends BaseTest
     public function testGetConfig()
     {
         $scopeConfigMock = $this->getFakeMock(ScopeConfigInterface::class)
-            ->onlyMethods(['getValue'])
-            ->getMockForAbstractClass();
+            ->getMock();
         $scopeConfigMock->method('getValue')->willReturnMap([
             // Make the ideal method active
             [
@@ -110,8 +108,7 @@ class IdealTest extends BaseTest
     public function testGetPaymentFee()
     {
         $scopeConfigMock = $this->getFakeMock(ScopeConfigInterface::class)
-            ->onlyMethods(['getValue'])
-            ->getMockForAbstractClass();
+            ->getMock();
         $scopeConfigMock->method('getValue')
             ->with(
                 $this->getPaymentMethodConfigPath(Ideal::CODE, AbstractConfigProvider::PAYMENT_FEE),
@@ -131,8 +128,7 @@ class IdealTest extends BaseTest
     public function testGetPaymentFeeReturnNumber()
     {
         $scopeConfigMock = $this->getFakeMock(ScopeConfigInterface::class)
-            ->onlyMethods(['getValue'])
-            ->getMockForAbstractClass();
+            ->getMock();
         $scopeConfigMock->method('getValue')
             ->with(
                 $this->getPaymentMethodConfigPath(Ideal::CODE, AbstractConfigProvider::PAYMENT_FEE),
@@ -152,8 +148,7 @@ class IdealTest extends BaseTest
     public function testGetActive()
     {
         $scopeConfigMock = $this->getFakeMock(ScopeConfigInterface::class)
-            ->onlyMethods(['getValue'])
-            ->getMockForAbstractClass();
+            ->getMock();
         $scopeConfigMock->method('getValue')
             ->with(
                 $this->getPaymentMethodConfigPath(Ideal::CODE, AbstractConfigProvider::ACTIVE),

--- a/Test/Unit/Model/ConfigProvider/Method/KbcTest.php
+++ b/Test/Unit/Model/ConfigProvider/Method/KbcTest.php
@@ -21,6 +21,8 @@
 
 namespace Buckaroo\Magento2\Test\Unit\Model\ConfigProvider\Method;
 
+
+use PHPUnit\Framework\Attributes\DataProvider;
 use Buckaroo\Magento2\Model\ConfigProvider\Method\AbstractConfigProvider;
 use Magento\Store\Model\ScopeInterface;
 use Buckaroo\Magento2\Helper\PaymentFee;
@@ -50,15 +52,14 @@ class KbcTest extends BaseTest
      * @param $active
      * @param $expected
      *
-     * @dataProvider getConfigProvider
      *
      * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
+    #[DataProvider('getConfigProvider')]
     public function testGetConfig($active, $expected)
     {
         $scopeConfigMock = $this->getFakeMock(ScopeConfigInterface::class)
-            ->onlyMethods(['getValue'])
-            ->getMockForAbstractClass();
+            ->getMock();
 
         $scopeConfigMock->method('getValue')->willReturnMap([
             [
@@ -140,13 +141,12 @@ class KbcTest extends BaseTest
      * @param $value
      * @param $expected
      *
-     * @dataProvider getPaymentFeeProvider
      */
+    #[DataProvider('getPaymentFeeProvider')]
     public function testGetPaymentFee($value, $expected)
     {
         $scopeConfigMock = $this->getFakeMock(ScopeConfigInterface::class)
-            ->onlyMethods(['getValue'])
-            ->getMockForAbstractClass();
+            ->getMock();
         $scopeConfigMock->method('getValue')
             ->with(
                 $this->getPaymentMethodConfigPath(Kbc::CODE, AbstractConfigProvider::PAYMENT_FEE),

--- a/Test/Unit/Model/ConfigProvider/Method/KlarnaTest.php
+++ b/Test/Unit/Model/ConfigProvider/Method/KlarnaTest.php
@@ -20,6 +20,8 @@
  */
 namespace Buckaroo\Magento2\Test\Unit\Model\ConfigProvider\Method;
 
+
+use PHPUnit\Framework\Attributes\DataProvider;
 use Buckaroo\Magento2\Model\ConfigProvider\Method\AbstractConfigProvider;
 use Magento\Store\Model\ScopeInterface;
 use Buckaroo\Magento2\Helper\PaymentFee;
@@ -63,13 +65,12 @@ class KlarnaTest extends BaseTest
      * @param $active
      * @param $expected
      *
-     * @dataProvider getConfigProvider
      */
+    #[DataProvider('getConfigProvider')]
     public function testGetConfig($active, $expected)
     {
         $scopeConfigMock = $this->getFakeMock(ScopeConfigInterface::class)
-            ->onlyMethods(['getValue'])
-            ->getMockForAbstractClass();
+            ->getMock();
 
         if ($active) {
             $scopeConfigMock->method('getValue')
@@ -141,13 +142,12 @@ class KlarnaTest extends BaseTest
      * @param $value
      * @param $expected
      *
-     * @dataProvider getPaymentFeeProvider
      */
+    #[DataProvider('getPaymentFeeProvider')]
     public function testGetPaymentFee($value, $expected)
     {
         $scopeConfigMock = $this->getFakeMock(ScopeConfigInterface::class)
-            ->onlyMethods(['getValue'])
-            ->getMockForAbstractClass();
+            ->getMock();
         $scopeConfigMock->method('getValue')
             ->with(
                 $this->getPaymentMethodConfigPath(Klarnakp::CODE, AbstractConfigProvider::PAYMENT_FEE),

--- a/Test/Unit/Model/ConfigProvider/Method/MrcashTest.php
+++ b/Test/Unit/Model/ConfigProvider/Method/MrcashTest.php
@@ -20,6 +20,8 @@
  */
 namespace Buckaroo\Magento2\Test\Unit\Model\ConfigProvider\Method;
 
+
+use PHPUnit\Framework\Attributes\DataProvider;
 use Buckaroo\Magento2\Model\ConfigProvider\Method\AbstractConfigProvider;
 use Magento\Store\Model\ScopeInterface;
 use Buckaroo\Magento2\Helper\PaymentFee;
@@ -60,13 +62,12 @@ class MrcashTest extends BaseTest
      * @param $active
      * @param $expected
      *
-     * @dataProvider getConfigProvider
      */
+    #[DataProvider('getConfigProvider')]
     public function testGetConfig($active, $expected)
     {
         $scopeConfigMock = $this->getFakeMock(ScopeConfigInterface::class)
-            ->onlyMethods(['getValue'])
-            ->getMockForAbstractClass();
+            ->getMock();
         $scopeConfigMock->method('getValue')->willReturnMap([
             // Set active state
             [
@@ -164,13 +165,12 @@ class MrcashTest extends BaseTest
      * @param $value
      * @param $expected
      *
-     * @dataProvider getPaymentFeeProvider
      */
+    #[DataProvider('getPaymentFeeProvider')]
     public function testGetPaymentFee($value, $expected)
     {
         $scopeConfigMock = $this->getFakeMock(ScopeConfigInterface::class)
-            ->onlyMethods(['getValue'])
-            ->getMockForAbstractClass();
+            ->getMock();
         $scopeConfigMock->method('getValue')
             ->with(
                 $this->getPaymentMethodConfigPath(Mrcash::CODE, AbstractConfigProvider::PAYMENT_FEE),

--- a/Test/Unit/Model/ConfigProvider/Method/PayPerEmailTest.php
+++ b/Test/Unit/Model/ConfigProvider/Method/PayPerEmailTest.php
@@ -21,6 +21,8 @@
 
 namespace Buckaroo\Magento2\Test\Unit\Model\ConfigProvider\Method;
 
+
+use PHPUnit\Framework\Attributes\DataProvider;
 use Buckaroo\Magento2\Model\ConfigProvider\Method\AbstractConfigProvider;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Store\Model\ScopeInterface;
@@ -100,8 +102,8 @@ class PayPerEmailTest extends BaseTest
      * @param $fee
      * @param $expected
      *
-     * @dataProvider getPaymentFeeProvider
      */
+    #[DataProvider('getPaymentFeeProvider')]
     public function testGetPaymentFee($fee, $expected)
     {
         $scopeConfigMock = $this->getMockBuilder(ScopeConfigInterface::class)->getMock();
@@ -139,8 +141,8 @@ class PayPerEmailTest extends BaseTest
      * @param $option
      * @param $expected
      *
-     * @dataProvider getSendMailProvider
      */
+    #[DataProvider('getSendMailProvider')]
     public function testHasSendMail($option, $expected)
     {
         $scopeConfigMock = $this->getMockBuilder(ScopeConfigInterface::class)->getMock();
@@ -175,8 +177,8 @@ class PayPerEmailTest extends BaseTest
      * @param $areaCode
      * @param $expected
      *
-     * @dataProvider isVisibleForAreaCodeProvider
      */
+    #[DataProvider('isVisibleForAreaCodeProvider')]
     public function testIsVisibleForAreaCode($visibleFrontBack, $areaCode, $expected)
     {
         $scopeConfigMock = $this->getMockBuilder(ScopeConfigInterface::class)->getMock();

--- a/Test/Unit/Model/ConfigProvider/Method/PaypalTest.php
+++ b/Test/Unit/Model/ConfigProvider/Method/PaypalTest.php
@@ -6,6 +6,8 @@
  */
 namespace Buckaroo\Magento2\Test\Unit\Model\ConfigProvider\Method;
 
+
+use PHPUnit\Framework\Attributes\DataProvider;
 use Buckaroo\Magento2\Model\ConfigProvider\Method\AbstractConfigProvider;
 use Magento\Store\Model\ScopeInterface;
 use Buckaroo\Magento2\Helper\PaymentFee;
@@ -38,13 +40,12 @@ class PaypalTest extends BaseTest
     /**
      * @param array $expected
      *
-     * @dataProvider getConfigProvider
      */
+    #[DataProvider('getConfigProvider')]
     public function testGetConfig($expected)
     {
         $scopeConfigMock = $this->getFakeMock(ScopeConfigInterface::class)
-            ->onlyMethods(['getValue'])
-            ->getMockForAbstractClass();
+            ->getMock();
 
         // Make the method active and return EUR for allowed_currencies; null for anything else.
         $scopeConfigMock->method('getValue')
@@ -131,13 +132,12 @@ class PaypalTest extends BaseTest
      * @param mixed $value
      * @param mixed $expected
      *
-     * @dataProvider getPaymentFeeProvider
      */
+    #[DataProvider('getPaymentFeeProvider')]
     public function testGetPaymentFee($value, $expected)
     {
         $scopeConfigMock = $this->getFakeMock(ScopeConfigInterface::class)
-            ->onlyMethods(['getValue'])
-            ->getMockForAbstractClass();
+            ->getMock();
 
         // Stub exactly how the live model queries the fee:
         $scopeConfigMock->method('getValue')

--- a/Test/Unit/Model/ConfigProvider/Method/SepaDirectDebitTest.php
+++ b/Test/Unit/Model/ConfigProvider/Method/SepaDirectDebitTest.php
@@ -20,6 +20,8 @@
  */
 namespace Buckaroo\Magento2\Test\Unit\Model\ConfigProvider\Method;
 
+
+use PHPUnit\Framework\Attributes\DataProvider;
 use Buckaroo\Magento2\Model\ConfigProvider\Method\AbstractConfigProvider;
 use Magento\Store\Model\ScopeInterface;
 use Buckaroo\Magento2\Helper\PaymentFee;
@@ -59,13 +61,12 @@ class SepaDirectDebitTest extends BaseTest
     /**
      * @param $expected
      *
-     * @dataProvider getConfigProvider
      */
+    #[DataProvider('getConfigProvider')]
     public function testGetConfig($expected)
     {
         $scopeConfigMock = $this->getFakeMock(ScopeConfigInterface::class)
-            ->onlyMethods(['getValue'])
-            ->getMockForAbstractClass();
+            ->getMock();
         $scopeConfigMock->method('getValue')
             ->willReturnCallback(function($path, $scope = null, $scopeId = null) {
                 // Use parameters to avoid PHPMD warnings
@@ -130,13 +131,12 @@ class SepaDirectDebitTest extends BaseTest
      * @param $value
      * @param $expected
      *
-     * @dataProvider getPaymentFeeProvider
      */
+    #[DataProvider('getPaymentFeeProvider')]
     public function testGetPaymentFee($value, $expected)
     {
         $scopeConfigMock = $this->getFakeMock(ScopeConfigInterface::class)
-            ->onlyMethods(['getValue'])
-            ->getMockForAbstractClass();
+            ->getMock();
         $scopeConfigMock->method('getValue')
             ->with(
                 $this->getPaymentMethodConfigPath(SepaDirectDebit::CODE, AbstractConfigProvider::PAYMENT_FEE),

--- a/Test/Unit/Model/ConfigProvider/Method/TransferTest.php
+++ b/Test/Unit/Model/ConfigProvider/Method/TransferTest.php
@@ -21,6 +21,8 @@
 
 namespace Buckaroo\Magento2\Test\Unit\Model\ConfigProvider\Method;
 
+
+use PHPUnit\Framework\Attributes\DataProvider;
 use Buckaroo\Magento2\Model\ConfigProvider\Method\AbstractConfigProvider;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Store\Model\ScopeInterface;
@@ -40,8 +42,7 @@ class TransferTest extends \Buckaroo\Magento2\Test\BaseTest
     protected function paymentFeeConfig($value)
     {
         $scopeConfigMock = $this->getFakeMock(ScopeConfigInterface::class)
-            ->onlyMethods(['getValue'])
-            ->getMockForAbstractClass();
+            ->getMock();
         $scopeConfigMock->method('getValue')
             ->willReturnCallback(function ($path, $scope = null, $scopeId = null) use ($value) {
                 // Use parameters to avoid PHPMD warnings
@@ -62,8 +63,7 @@ class TransferTest extends \Buckaroo\Magento2\Test\BaseTest
     public function testInactive()
     {
         $scopeConfigMock = $this->getFakeMock(ScopeConfigInterface::class)
-            ->onlyMethods(['getValue'])
-            ->getMockForAbstractClass();
+            ->getMock();
         $scopeConfigMock->method('getValue')
             ->with(
                 $this->getPaymentMethodConfigPath(Transfer::CODE, AbstractConfigProvider::ACTIVE),
@@ -85,8 +85,7 @@ class TransferTest extends \Buckaroo\Magento2\Test\BaseTest
         $sendEmail = '1';
 
         $scopeConfigMock = $this->getFakeMock(ScopeConfigInterface::class)
-            ->onlyMethods(['getValue'])
-            ->getMockForAbstractClass();
+            ->getMock();
         $scopeConfigMock->method('getValue')->willReturnCallback(function ($path = null) {
             // Return active = 1 for the payment method to ensure it's enabled
             if (strpos($path, '/active') !== false) {
@@ -130,8 +129,8 @@ class TransferTest extends \Buckaroo\Magento2\Test\BaseTest
      * @param $value
      * @param $expected
      *
-     * @dataProvider getSendMailProvider
      */
+    #[DataProvider('getSendMailProvider')]
     public function testHasSendMail($value, $expected)
     {
         $scopeConfigMock = $this->getMockBuilder(ScopeConfigInterface::class)->getMock();

--- a/Test/Unit/Model/ConfigProvider/RefundTest.php
+++ b/Test/Unit/Model/ConfigProvider/RefundTest.php
@@ -35,8 +35,7 @@ class RefundTest extends \Buckaroo\Magento2\Test\BaseTest
     public function testGetConfig()
     {
         $scopeConfigMock = $this->getFakeMock(ScopeConfigInterface::class)
-            ->onlyMethods(['getValue'])
-            ->getMockForAbstractClass();
+            ->getMock();
         $scopeConfigMock->method('getValue')->willReturn(null)
             ->willReturn(false);
 
@@ -53,8 +52,7 @@ class RefundTest extends \Buckaroo\Magento2\Test\BaseTest
     public function testGetConfigWithStoreId()
     {
         $scopeConfigMock = $this->getFakeMock(ScopeConfigInterface::class)
-            ->onlyMethods(['getValue'])
-            ->getMockForAbstractClass();
+            ->getMock();
         $scopeConfigMock->method('getValue')->willReturn(null)
             ->willReturn(false);
 

--- a/Test/Unit/Model/ConfigProvider/SecondChanceTest.php
+++ b/Test/Unit/Model/ConfigProvider/SecondChanceTest.php
@@ -20,6 +20,8 @@
 
 namespace Buckaroo\Magento2\Test\Unit\Model\ConfigProvider;
 
+
+use PHPUnit\Framework\Attributes\DataProvider;
 use Buckaroo\Magento2\Model\ConfigProvider\SecondChance;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Store\Model\ScopeInterface;
@@ -57,8 +59,8 @@ class SecondChanceTest extends \Buckaroo\Magento2\Test\BaseTest
      * @param mixed $configValue
      * @param bool  $expected
      *
-     * @dataProvider isSecondChanceEnabledProvider
      */
+    #[DataProvider('isSecondChanceEnabledProvider')]
     public function testIsSecondChanceEnabled($configValue, $expected)
     {
         $store = $this->getFakeMock(Store::class)->getMock();
@@ -93,8 +95,8 @@ class SecondChanceTest extends \Buckaroo\Magento2\Test\BaseTest
      * @param mixed $configValue
      * @param bool  $expected
      *
-     * @dataProvider isFirstEmailEnabledProvider
      */
+    #[DataProvider('isFirstEmailEnabledProvider')]
     public function testIsFirstEmailEnabled($configValue, $expected)
     {
         $store = $this->getFakeMock(Store::class)->getMock();
@@ -129,8 +131,8 @@ class SecondChanceTest extends \Buckaroo\Magento2\Test\BaseTest
      * @param mixed $configValue
      * @param bool  $expected
      *
-     * @dataProvider isSecondEmailEnabledProvider
      */
+    #[DataProvider('isSecondEmailEnabledProvider')]
     public function testIsSecondEmailEnabled($configValue, $expected)
     {
         $store = $this->getFakeMock(Store::class)->getMock();
@@ -165,8 +167,8 @@ class SecondChanceTest extends \Buckaroo\Magento2\Test\BaseTest
      * @param mixed  $configValue
      * @param string $expected
      *
-     * @dataProvider getFirstEmailTemplateProvider
      */
+    #[DataProvider('getFirstEmailTemplateProvider')]
     public function testGetFirstEmailTemplate($configValue, $expected)
     {
         // $expected parameter is from data provider but not used in this test implementation
@@ -203,8 +205,8 @@ class SecondChanceTest extends \Buckaroo\Magento2\Test\BaseTest
      * @param mixed  $configValue
      * @param string $expected
      *
-     * @dataProvider getSecondEmailTemplateProvider
      */
+    #[DataProvider('getSecondEmailTemplateProvider')]
     public function testGetSecondEmailTemplate($configValue, $expected)
     {
         // $expected parameter is from data provider but not used in this test implementation
@@ -243,8 +245,8 @@ class SecondChanceTest extends \Buckaroo\Magento2\Test\BaseTest
      * @param mixed $configValue
      * @param int   $expected
      *
-     * @dataProvider getFirstEmailTimingProvider
      */
+    #[DataProvider('getFirstEmailTimingProvider')]
     public function testGetFirstEmailTiming($configValue, $expected)
     {
         $store = $this->getFakeMock(Store::class)->getMock();
@@ -281,8 +283,8 @@ class SecondChanceTest extends \Buckaroo\Magento2\Test\BaseTest
      * @param mixed $configValue
      * @param int   $expected
      *
-     * @dataProvider getSecondEmailTimingProvider
      */
+    #[DataProvider('getSecondEmailTimingProvider')]
     public function testGetSecondEmailTiming($configValue, $expected)
     {
         $store = $this->getFakeMock(Store::class)->getMock();
@@ -318,8 +320,8 @@ class SecondChanceTest extends \Buckaroo\Magento2\Test\BaseTest
      * @param mixed $configValue
      * @param bool  $expected
      *
-     * @dataProvider shouldSkipOutOfStockProvider
      */
+    #[DataProvider('shouldSkipOutOfStockProvider')]
     public function testShouldSkipOutOfStock($configValue, $expected)
     {
         $store = $this->getFakeMock(Store::class)->getMock();
@@ -356,8 +358,8 @@ class SecondChanceTest extends \Buckaroo\Magento2\Test\BaseTest
      * @param mixed $configValue
      * @param int   $expected
      *
-     * @dataProvider getPruneDaysProvider
      */
+    #[DataProvider('getPruneDaysProvider')]
     public function testGetPruneDays($configValue, $expected)
     {
         $store = $this->getFakeMock(Store::class)->getMock();
@@ -393,8 +395,8 @@ class SecondChanceTest extends \Buckaroo\Magento2\Test\BaseTest
      * @param mixed $configValue
      * @param bool  $expected
      *
-     * @dataProvider canSendMultipleEmailsProvider
      */
+    #[DataProvider('canSendMultipleEmailsProvider')]
     public function testCanSendMultipleEmails($configValue, $expected)
     {
         $store = $this->getFakeMock(Store::class)->getMock();

--- a/Test/Unit/Model/GiftcardTest.php
+++ b/Test/Unit/Model/GiftcardTest.php
@@ -21,6 +21,8 @@
 
 namespace Buckaroo\Magento2\Test\Unit\Model;
 
+
+use PHPUnit\Framework\Attributes\DataProvider;
 use Buckaroo\Magento2\Model\Giftcard;
 
 class GiftcardTest extends \Buckaroo\Magento2\Test\BaseTest
@@ -52,8 +54,8 @@ class GiftcardTest extends \Buckaroo\Magento2\Test\BaseTest
      * @param $servicecode
      * @param $expected
      *
-     * @dataProvider servicecodeProvider
      */
+    #[DataProvider('servicecodeProvider')]
     public function testShouldBeAbleToSetAndGetServicecode($servicecode, $expected)
     {
         $instance = $this->getInstance();
@@ -87,8 +89,8 @@ class GiftcardTest extends \Buckaroo\Magento2\Test\BaseTest
      * @param $label
      * @param $expected
      *
-     * @dataProvider labelProvider
      */
+    #[DataProvider('labelProvider')]
     public function testShouldBeAbleToSetAndGetLabel($label, $expected)
     {
         $instance = $this->getInstance();

--- a/Test/Unit/Model/PaypalExpress/OrderCreateTest.php
+++ b/Test/Unit/Model/PaypalExpress/OrderCreateTest.php
@@ -65,12 +65,12 @@ class OrderCreateTest extends BaseTest
     {
         $defaults = [
             'responseFactory'        => $this->getFakeMock(OrderCreateResponseInterfaceFactory::class)->getMock(),
-            'quoteManagement'        => $this->getFakeMock(CartManagementInterface::class)->getMockForAbstractClass(),
+            'quoteManagement'        => $this->getFakeMock(CartManagementInterface::class)->getMock(),
             'maskedQuoteIdToQuoteId' => $this->getFakeMock(MaskedQuoteIdToQuoteId::class)->getMock(),
             'customerSession'        => $this->getFakeMock(CustomerSession::class)->getMock(),
             'checkoutSession'        => $this->getFakeMock(CheckoutSession::class)->getMock(),
-            'quoteRepository'        => $this->getFakeMock(CartRepositoryInterface::class)->getMockForAbstractClass(),
-            'orderRepository'        => $this->getFakeMock(OrderRepositoryInterface::class)->getMockForAbstractClass(),
+            'quoteRepository'        => $this->getFakeMock(CartRepositoryInterface::class)->getMock(),
+            'orderRepository'        => $this->getFakeMock(OrderRepositoryInterface::class)->getMock(),
             'orderUpdateFactory'     => $this->getFakeMock(OrderUpdateFactory::class)->getMock(),
             'logger'                 => $this->getFakeMock(Log::class)->getMock(),
         ];
@@ -82,7 +82,6 @@ class OrderCreateTest extends BaseTest
     private function callMethod(object $object, string $method, array $args = []): mixed
     {
         $ref = new \ReflectionMethod($object, $method);
-        $ref->setAccessible(true);
         return $ref->invokeArgs($object, $args);
     }
 
@@ -100,10 +99,8 @@ class OrderCreateTest extends BaseTest
         QuoteAddress $billingAddress,
         string $customerEmail = 'pending@paypal.customer'
     ): Quote {
-        $quoteMock = $this->getFakeMock(Quote::class)
-            ->onlyMethods(['getShippingAddress', 'getBillingAddress', 'getCustomer', 'getId'])
-            ->addMethods(['getCustomerEmail', 'setCustomerEmail'])
-            ->getMock();
+        $quoteMock = $this->getFakeMock(\Buckaroo\Magento2\Test\Unit\Stubs\QuoteStub::class)
+            ->onlyMethods(['getShippingAddress', 'getBillingAddress', 'getCustomer', 'getId', 'getCustomerEmail', 'setCustomerEmail'])->getMock();
 
         $quoteMock->method('getShippingAddress')->willReturn($shippingAddress);
         $quoteMock->method('getBillingAddress')->willReturn($billingAddress);
@@ -123,16 +120,8 @@ class OrderCreateTest extends BaseTest
      */
     private function makeAddressWithPlaceholders(): QuoteAddress
     {
-        $address = $this->getFakeMock(QuoteAddress::class)
-            ->onlyMethods([
-                'getFirstname', 'setFirstname',
-                'getLastname',  'setLastname',
-                'getStreet',    'setStreet',
-                'getTelephone', 'setTelephone',
-                'getEmail',     'setEmail',
-            ])
-            ->addMethods(['setShouldIgnoreValidation']) // magic __call, not a real PHP method
-            ->getMock();
+        $address = $this->getFakeMock(\Buckaroo\Magento2\Test\Unit\Stubs\AddressStub::class) // magic __call, not a real PHP method
+            ->onlyMethods(['getFirstname', 'setFirstname', 'getLastname', 'setLastname', 'getStreet', 'setStreet', 'getTelephone', 'setTelephone', 'getEmail', 'setEmail', 'setShouldIgnoreValidation'])->getMock();
 
         $address->method('getFirstname')->willReturn('PayPal');
         $address->method('getLastname')->willReturn('Customer');
@@ -193,8 +182,7 @@ class OrderCreateTest extends BaseTest
         $sessionMock->method('getCustomerId')->willReturn(42); // int from session
 
         $customerMock = $this->getFakeMock(CustomerInterface::class)
-            ->onlyMethods(['getId'])
-            ->getMockForAbstractClass();
+            ->getMock();
         $customerMock->method('getId')->willReturn('42'); // string from DB
 
         $quoteMock = $this->getFakeMock(Quote::class)
@@ -216,8 +204,7 @@ class OrderCreateTest extends BaseTest
         $sessionMock->method('getCustomerId')->willReturn(7);
 
         $customerMock = $this->getFakeMock(CustomerInterface::class)
-            ->onlyMethods(['getId'])
-            ->getMockForAbstractClass();
+            ->getMock();
         $customerMock->method('getId')->willReturn(7);
 
         $quoteMock = $this->getFakeMock(Quote::class)
@@ -241,8 +228,7 @@ class OrderCreateTest extends BaseTest
         $sessionMock->method('getCustomerId')->willReturn(1);
 
         $customerMock = $this->getFakeMock(CustomerInterface::class)
-            ->onlyMethods(['getId'])
-            ->getMockForAbstractClass();
+            ->getMock();
         $customerMock->method('getId')->willReturn('2');
 
         $quoteMock = $this->getFakeMock(Quote::class)
@@ -274,8 +260,7 @@ class OrderCreateTest extends BaseTest
         $quoteMock = $this->makeQuoteMock($shippingAddress, $billingAddress);
         $quoteMock->expects($this->once())->method('setCustomerEmail')->with('');
 
-        $repoMock = $this->getFakeMock(CartRepositoryInterface::class)
-            ->onlyMethods(['save'])->getMockForAbstractClass();
+        $repoMock = $this->getFakeMock(CartRepositoryInterface::class)->getMock();
         $repoMock->expects($this->once())->method('save')->with($quoteMock);
 
         $instance = $this->makeOrderCreate(['quoteRepository' => $repoMock]);
@@ -295,8 +280,7 @@ class OrderCreateTest extends BaseTest
         $quoteMock = $this->makeQuoteMock($address, $address, 'jane@example.com');
         $quoteMock->expects($this->never())->method('setCustomerEmail');
 
-        $repoMock = $this->getFakeMock(CartRepositoryInterface::class)
-            ->onlyMethods(['save'])->getMockForAbstractClass();
+        $repoMock = $this->getFakeMock(CartRepositoryInterface::class)->getMock();
         $repoMock->expects($this->once())->method('save');
 
         $instance = $this->makeOrderCreate(['quoteRepository' => $repoMock]);
@@ -308,8 +292,7 @@ class OrderCreateTest extends BaseTest
         $address  = $this->makeAddressWithPlaceholders();
         $quoteMock = $this->makeQuoteMock($address, $address);
 
-        $repoMock = $this->getFakeMock(CartRepositoryInterface::class)
-            ->onlyMethods(['save'])->getMockForAbstractClass();
+        $repoMock = $this->getFakeMock(CartRepositoryInterface::class)->getMock();
         $repoMock->method('save')->willThrowException(new \RuntimeException('DB error'));
 
         $instance = $this->makeOrderCreate(['quoteRepository' => $repoMock]);
@@ -338,15 +321,11 @@ class OrderCreateTest extends BaseTest
             ->onlyMethods(['setAdditionalInformation', 'setMethod'])
             ->getMock();
 
-        $customerMock = $this->getFakeMock(CustomerInterface::class)
-            ->onlyMethods(['getId'])->getMockForAbstractClass();
+        $customerMock = $this->getFakeMock(CustomerInterface::class)->getMock();
         $customerMock->method('getId')->willReturn(null);
 
-        $quoteMock = $this->getFakeMock(Quote::class)
-            ->onlyMethods(['getShippingAddress', 'getBillingAddress', 'getPayment',
-                           'getCustomer', 'reserveOrderId', 'getId'])
-            ->addMethods(['getCustomerEmail', 'setCustomerEmail'])
-            ->getMock();
+        $quoteMock = $this->getFakeMock(\Buckaroo\Magento2\Test\Unit\Stubs\QuoteStub::class)
+            ->onlyMethods(['getShippingAddress', 'getBillingAddress', 'getPayment', 'getCustomer', 'reserveOrderId', 'getId', 'getCustomerEmail', 'setCustomerEmail'])->getMock();
         $quoteMock->method('getShippingAddress')->willReturn($address);
         $quoteMock->method('getBillingAddress')->willReturn($address);
         $quoteMock->method('getPayment')->willReturn($payment);
@@ -358,16 +337,14 @@ class OrderCreateTest extends BaseTest
             ->onlyMethods(['execute'])->getMock();
         $maskedMock->method('execute')->willReturn(1);
 
-        $repoMock = $this->getFakeMock(CartRepositoryInterface::class)
-            ->onlyMethods(['get', 'save'])->getMockForAbstractClass();
+        $repoMock = $this->getFakeMock(CartRepositoryInterface::class)->getMock();
         $repoMock->method('get')->willReturn($quoteMock);
 
         $sessionMock = $this->getFakeMock(CustomerSession::class)
             ->onlyMethods(['isLoggedIn'])->getMock();
         $sessionMock->method('isLoggedIn')->willReturn(false);
 
-        $quoteMgmtMock = $this->getFakeMock(CartManagementInterface::class)
-            ->onlyMethods(['placeOrder'])->getMockForAbstractClass();
+        $quoteMgmtMock = $this->getFakeMock(CartManagementInterface::class)->getMock();
         $quoteMgmtMock->method('placeOrder')
             ->willThrowException(new \RuntimeException('placeOrder failed'));
 

--- a/Test/Unit/Model/PaypalExpress/Response/TotalBreakdownTest.php
+++ b/Test/Unit/Model/PaypalExpress/Response/TotalBreakdownTest.php
@@ -21,6 +21,8 @@ declare(strict_types=1);
 
 namespace Buckaroo\Magento2\Test\Unit\Model\PaypalExpress\Response;
 
+
+use PHPUnit\Framework\Attributes\DataProvider;
 use Buckaroo\Magento2\Api\Data\BreakdownItemInterface;
 use Buckaroo\Magento2\Api\Data\BreakdownItemInterfaceFactory;
 use Buckaroo\Magento2\Model\PaypalExpress\Response\BreakdownItem;
@@ -62,10 +64,8 @@ class TotalBreakdownTest extends BaseTest
         float $taxSegment,
         string $currency = 'EUR'
     ): TotalBreakdown {
-        $quoteMock = $this->getFakeMock(Quote::class)
-            ->onlyMethods(['getId'])
-            ->addMethods(['getGrandTotal', 'getQuoteCurrencyCode'])
-            ->getMock();
+        $quoteMock = $this->getFakeMock(\Buckaroo\Magento2\Test\Unit\Stubs\QuoteStub::class)
+            ->onlyMethods(['getId', 'getGrandTotal', 'getQuoteCurrencyCode'])->getMock();
         $quoteMock->method('getGrandTotal')->willReturn($grandTotal);
         $quoteMock->method('getQuoteCurrencyCode')->willReturn($currency);
         $quoteMock->method('getId')->willReturn(1);
@@ -73,13 +73,11 @@ class TotalBreakdownTest extends BaseTest
         $segments = $this->buildSegments($shippingSegment, $taxSegment);
 
         $totalsMock = $this->getFakeMock(TotalsInterface::class)
-            ->onlyMethods(['getTotalSegments'])
-            ->getMockForAbstractClass();
+            ->getMock();
         $totalsMock->method('getTotalSegments')->willReturn($segments);
 
         $repoMock = $this->getFakeMock(CartTotalRepositoryInterface::class)
-            ->onlyMethods(['get'])
-            ->getMockForAbstractClass();
+            ->getMock();
         $repoMock->method('get')->with(1)->willReturn($totalsMock);
 
         $factoryMock = $this->getMockBuilder(BreakdownItemInterfaceFactory::class)
@@ -114,8 +112,7 @@ class TotalBreakdownTest extends BaseTest
                 continue;
             }
             $seg = $this->getFakeMock(TotalSegmentInterface::class)
-                ->onlyMethods(['getValue'])
-                ->getMockForAbstractClass();
+                ->getMock();
             $seg->method('getValue')->willReturn((string)$value);
             $segments[$code] = $seg;
         }
@@ -127,9 +124,7 @@ class TotalBreakdownTest extends BaseTest
     // getItemTotal() correctness
     // -------------------------------------------------------------------------
 
-    /**
-     * @dataProvider breakdownProvider
-     */
+    #[DataProvider('breakdownProvider')]
     public function testGetItemTotalReturnsGrandTotalMinusShippingMinusTax(
         float $grandTotal,
         float $shipping,
@@ -158,13 +153,12 @@ class TotalBreakdownTest extends BaseTest
     // Invariant: item_total + shipping + tax_total == grand_total (no off-by-1c)
     // -------------------------------------------------------------------------
 
-    /**
-     * @dataProvider breakdownProvider
-     */
+    #[DataProvider('breakdownProvider')]
     public function testBreakdownComponentsSumExactlyToGrandTotal(
         float $grandTotal,
         float $shipping,
-        float $tax
+        float $tax,
+        string $expectedItemTotal
     ): void {
         $breakdown = $this->makeBreakdown($grandTotal, $shipping, $tax);
 
@@ -184,24 +178,19 @@ class TotalBreakdownTest extends BaseTest
 
     public function testCartTotalRepositoryIsCalledOnlyOncePerBreakdownRequest(): void
     {
-        $quoteMock = $this->getFakeMock(Quote::class)
-            ->onlyMethods(['getId'])
-            ->addMethods(['getGrandTotal', 'getQuoteCurrencyCode'])
-            ->getMock();
+        $quoteMock = $this->getFakeMock(\Buckaroo\Magento2\Test\Unit\Stubs\QuoteStub::class)
+            ->onlyMethods(['getId', 'getGrandTotal', 'getQuoteCurrencyCode'])->getMock();
         $quoteMock->method('getGrandTotal')->willReturn(29.98);
         $quoteMock->method('getQuoteCurrencyCode')->willReturn('EUR');
         $quoteMock->method('getId')->willReturn(42);
 
-        $taxSeg = $this->getFakeMock(TotalSegmentInterface::class)
-            ->onlyMethods(['getValue'])->getMockForAbstractClass();
+        $taxSeg = $this->getFakeMock(TotalSegmentInterface::class)->getMock();
         $taxSeg->method('getValue')->willReturn('4.79');
 
-        $totalsMock = $this->getFakeMock(TotalsInterface::class)
-            ->onlyMethods(['getTotalSegments'])->getMockForAbstractClass();
+        $totalsMock = $this->getFakeMock(TotalsInterface::class)->getMock();
         $totalsMock->method('getTotalSegments')->willReturn(['tax' => $taxSeg]);
 
-        $repoMock = $this->getFakeMock(CartTotalRepositoryInterface::class)
-            ->onlyMethods(['get'])->getMockForAbstractClass();
+        $repoMock = $this->getFakeMock(CartTotalRepositoryInterface::class)->getMock();
 
         // THE KEY ASSERTION: exactly 1 repo call even though 3 getters are invoked
         $repoMock->expects($this->once())

--- a/Test/Unit/Model/PaypalExpress/Response/TotalBreakdownTest.php
+++ b/Test/Unit/Model/PaypalExpress/Response/TotalBreakdownTest.php
@@ -170,6 +170,7 @@ class TotalBreakdownTest extends BaseTest
         );
 
         $this->assertSame(round($grandTotal, 2), $sum);
+        $this->assertSame($expectedItemTotal, $breakdown->getItemTotal()->getValue());
     }
 
     // -------------------------------------------------------------------------

--- a/Test/Unit/Model/Push/AfterpayProcessorTest.php
+++ b/Test/Unit/Model/Push/AfterpayProcessorTest.php
@@ -1,0 +1,176 @@
+<?php
+declare(strict_types=1);
+
+namespace Buckaroo\Magento2\Test\Unit\Model\Push;
+
+use Buckaroo\Magento2\Test\Unit\Stubs\PushRequestInterfaceStub;
+
+/**
+ * @SuppressWarnings(PHPMD.TooManyFields)
+ */
+class AfterpayProcessorTest extends \Buckaroo\Magento2\Test\BaseTest
+{
+    protected $instanceClass = 'Buckaroo\Magento2\Model\Push\AfterpayProcessor';
+
+    private $orderRequestServiceMock;
+    private $pushTransactionTypeMock;
+    private $loggerMock;
+    private $helperMock;
+    private $transactionMock;
+    private $groupTransactionMock;
+    private $buckarooStatusCodeMock;
+    private $orderStatusFactoryMock;
+    private $configAccountMock;
+    private $giftCardRefundServiceMock;
+    private $uncancelServiceMock;
+    private $resourceConnectionMock;
+    private $giftcardCollectionMock;
+    private $afterpayConfigMock;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->orderRequestServiceMock = $this->getFakeMock('Buckaroo\Magento2\Service\Push\OrderRequestService')->getMock();
+        $this->pushTransactionTypeMock = $this->getFakeMock('Buckaroo\Magento2\Model\Push\PushTransactionType')->getMock();
+        $this->loggerMock = $this->getFakeMock('Buckaroo\Magento2\Logging\BuckarooLoggerInterface')->getMock();
+        $this->helperMock = $this->getFakeMock('Buckaroo\Magento2\Helper\Data')->getMock();
+        $this->transactionMock = $this->getFakeMock('Magento\Sales\Api\Data\TransactionInterface')->getMock();
+        $this->groupTransactionMock = $this->getFakeMock('Buckaroo\Magento2\Helper\PaymentGroupTransaction')->getMock();
+        $this->buckarooStatusCodeMock = $this->getFakeMock('Buckaroo\Magento2\Model\BuckarooStatusCode')->getMock();
+        $this->orderStatusFactoryMock = $this->getFakeMock('Buckaroo\Magento2\Model\OrderStatusFactory')->getMock();
+        $this->configAccountMock = $this->getFakeMock('Buckaroo\Magento2\Model\ConfigProvider\Account')->getMock();
+        $this->giftCardRefundServiceMock = $this->getFakeMock('Buckaroo\Magento2\Model\Service\GiftCardRefundService')->getMock();
+        $this->uncancelServiceMock = $this->getFakeMock('Buckaroo\Magento2\Service\Order\Uncancel')->getMock();
+        $this->resourceConnectionMock = $this->getFakeMock('Magento\Framework\App\ResourceConnection')->getMock();
+        $this->giftcardCollectionMock = $this->getFakeMock('Buckaroo\Magento2\Model\ResourceModel\Giftcard\Collection')->getMock();
+        $this->afterpayConfigMock = $this->getFakeMock('Buckaroo\Magento2\Model\ConfigProvider\Method\Afterpay20')->getMock();
+
+        // The processor constructor does not receive a CurrencyFactory and falls back to
+        // ObjectManager::getInstance(); provide one for the duration of the test.
+        $appObjectManagerMock = $this->getFakeMock('Magento\Framework\ObjectManagerInterface')->getMock();
+        $appObjectManagerMock->method('get')->willReturn(
+            $this->getFakeMock('Magento\Directory\Model\CurrencyFactory')->getMock()
+        );
+        \Magento\Framework\App\ObjectManager::setInstance($appObjectManagerMock);
+    }
+
+    public function tearDown(): void
+    {
+        $property = new \ReflectionProperty(\Magento\Framework\App\ObjectManager::class, '_instance');
+        $property->setValue(null, null);
+
+        parent::tearDown();
+    }
+
+    public function getInstance(array $args = [])
+    {
+        return parent::getInstance($args + [
+            'orderRequestService'   => $this->orderRequestServiceMock,
+            'pushTransactionType'   => $this->pushTransactionTypeMock,
+            'logger'                => $this->loggerMock,
+            'helper'                => $this->helperMock,
+            'transaction'           => $this->transactionMock,
+            'groupTransaction'      => $this->groupTransactionMock,
+            'buckarooStatusCode'    => $this->buckarooStatusCodeMock,
+            'orderStatusFactory'    => $this->orderStatusFactoryMock,
+            'configAccount'         => $this->configAccountMock,
+            'giftCardRefundService' => $this->giftCardRefundServiceMock,
+            'uncancelService'       => $this->uncancelServiceMock,
+            'resourceConnection'    => $this->resourceConnectionMock,
+            'giftcardCollection'    => $this->giftcardCollectionMock,
+            'afterpayConfig'        => $this->afterpayConfigMock,
+        ]);
+    }
+
+    /**
+     * @param array $trueAdditional list of [name, value] pairs for which
+     *                              hasAdditionalInformation() returns true
+     */
+    private function createPushRequest(array $trueAdditional = [])
+    {
+        $mock = $this->getFakeMock(PushRequestInterfaceStub::class)->getMock();
+        $mock->method('hasAdditionalInformation')->willReturnCallback(
+            function ($name, $value) use ($trueAdditional) {
+                return in_array([$name, $value], $trueAdditional, true);
+            }
+        );
+
+        return $mock;
+    }
+
+    public function testInvoiceShouldBeSavedDefersInvoiceForMagentoCaptureWithInvoiceAfterShipment(): void
+    {
+        $instance = $this->getInstance();
+
+        $pushRequest = $this->createPushRequest([
+            ['initiated_by_magento', 1],
+            ['service_action_from_magento', 'capture'],
+        ]);
+        $this->afterpayConfigMock->method('isInvoiceCreatedAfterShipment')->willReturn(true);
+
+        $this->setProperty('pushRequest', $pushRequest, $instance);
+
+        $paymentDetails = [];
+        $result = $this->invokeArgs('invoiceShouldBeSaved', [&$paymentDetails], $instance);
+
+        $this->assertFalse($result);
+        $this->assertTrue($this->getProperty('dontSaveOrderUponSuccessPush', $instance));
+    }
+
+    public function testInvoiceShouldBeSavedWhenInvoiceAfterShipmentIsDisabled(): void
+    {
+        $instance = $this->getInstance();
+
+        $pushRequest = $this->createPushRequest([
+            ['initiated_by_magento', 1],
+            ['service_action_from_magento', 'capture'],
+        ]);
+        $this->afterpayConfigMock->method('isInvoiceCreatedAfterShipment')->willReturn(false);
+
+        $this->setProperty('pushRequest', $pushRequest, $instance);
+
+        $paymentDetails = [];
+        $result = $this->invokeArgs('invoiceShouldBeSaved', [&$paymentDetails], $instance);
+
+        $this->assertTrue($result);
+        $this->assertFalse($this->getProperty('dontSaveOrderUponSuccessPush', $instance));
+    }
+
+    public function testInvoiceShouldBeSavedForPushNotInitiatedByMagento(): void
+    {
+        $instance = $this->getInstance();
+
+        $pushRequest = $this->createPushRequest();
+
+        // Short-circuit: the shipment-mode config must not even be consulted.
+        $this->afterpayConfigMock->expects($this->never())->method('isInvoiceCreatedAfterShipment');
+
+        $this->setProperty('pushRequest', $pushRequest, $instance);
+
+        $paymentDetails = [];
+        $result = $this->invokeArgs('invoiceShouldBeSaved', [&$paymentDetails], $instance);
+
+        $this->assertTrue($result);
+        $this->assertFalse($this->getProperty('dontSaveOrderUponSuccessPush', $instance));
+    }
+
+    public function testInvoiceShouldBeSavedForMagentoPushWithDifferentServiceAction(): void
+    {
+        $instance = $this->getInstance();
+
+        $pushRequest = $this->createPushRequest([
+            ['initiated_by_magento', 1],
+            ['service_action_from_magento', 'pay'],
+        ]);
+        $this->afterpayConfigMock->method('isInvoiceCreatedAfterShipment')->willReturn(true);
+
+        $this->setProperty('pushRequest', $pushRequest, $instance);
+
+        $paymentDetails = [];
+        $result = $this->invokeArgs('invoiceShouldBeSaved', [&$paymentDetails], $instance);
+
+        $this->assertTrue($result);
+        $this->assertFalse($this->getProperty('dontSaveOrderUponSuccessPush', $instance));
+    }
+}

--- a/Test/Unit/Model/Push/DefaultProcessorTest.php
+++ b/Test/Unit/Model/Push/DefaultProcessorTest.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 namespace Buckaroo\Magento2\Test\Unit\Model\Push;
 
+
+use PHPUnit\Framework\Attributes\DataProvider;
 use Magento\Sales\Model\Order;
 
 class DefaultProcessorTest extends \Buckaroo\Magento2\Test\BaseTest
@@ -105,9 +107,7 @@ class DefaultProcessorTest extends \Buckaroo\Magento2\Test\BaseTest
         ];
     }
 
-    /**
-     * @dataProvider pendingPaymentEmailProvider
-     */
+    #[DataProvider('pendingPaymentEmailProvider')]
     public function testShouldSendPendingPaymentEmail(
         bool $emailSent,
         bool $orderIsCanceled,

--- a/Test/Unit/Model/Push/IdealPushProcessorTest.php
+++ b/Test/Unit/Model/Push/IdealPushProcessorTest.php
@@ -1,0 +1,86 @@
+<?php
+declare(strict_types=1);
+
+namespace Buckaroo\Magento2\Test\Unit\Model\Push;
+
+use Buckaroo\Magento2\Model\Push\IdealPushProcessor;
+
+class IdealPushProcessorTest extends \Buckaroo\Magento2\Test\BaseTest
+{
+    protected $instanceClass = 'Buckaroo\Magento2\Model\Push\IdealPushProcessor';
+
+    private $orderRequestServiceMock;
+    private $pushTransactionTypeMock;
+    private $loggerMock;
+    private $helperMock;
+    private $transactionMock;
+    private $groupTransactionMock;
+    private $buckarooStatusCodeMock;
+    private $orderStatusFactoryMock;
+    private $configAccountMock;
+    private $giftCardRefundServiceMock;
+    private $uncancelServiceMock;
+    private $resourceConnectionMock;
+    private $giftcardCollectionMock;
+    private $currencyFactoryMock;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->orderRequestServiceMock = $this->getFakeMock('Buckaroo\Magento2\Service\Push\OrderRequestService')->getMock();
+        $this->pushTransactionTypeMock = $this->getFakeMock('Buckaroo\Magento2\Model\Push\PushTransactionType')->getMock();
+        $this->loggerMock = $this->getFakeMock('Buckaroo\Magento2\Logging\BuckarooLoggerInterface')->getMock();
+        $this->helperMock = $this->getFakeMock('Buckaroo\Magento2\Helper\Data')->getMock();
+        $this->transactionMock = $this->getFakeMock('Magento\Sales\Api\Data\TransactionInterface')->getMock();
+        $this->groupTransactionMock = $this->getFakeMock('Buckaroo\Magento2\Helper\PaymentGroupTransaction')->getMock();
+        $this->buckarooStatusCodeMock = $this->getFakeMock('Buckaroo\Magento2\Model\BuckarooStatusCode')->getMock();
+        $this->orderStatusFactoryMock = $this->getFakeMock('Buckaroo\Magento2\Model\OrderStatusFactory')->getMock();
+        $this->configAccountMock = $this->getFakeMock('Buckaroo\Magento2\Model\ConfigProvider\Account')->getMock();
+        $this->giftCardRefundServiceMock = $this->getFakeMock('Buckaroo\Magento2\Model\Service\GiftCardRefundService')->getMock();
+        $this->uncancelServiceMock = $this->getFakeMock('Buckaroo\Magento2\Service\Order\Uncancel')->getMock();
+        $this->resourceConnectionMock = $this->getFakeMock('Magento\Framework\App\ResourceConnection')->getMock();
+        $this->giftcardCollectionMock = $this->getFakeMock('Buckaroo\Magento2\Model\ResourceModel\Giftcard\Collection')->getMock();
+        $this->currencyFactoryMock = $this->getFakeMock('Magento\Directory\Model\CurrencyFactory')->getMock();
+    }
+
+    public function getInstance(array $args = [])
+    {
+        return parent::getInstance($args + [
+            'orderRequestService'   => $this->orderRequestServiceMock,
+            'pushTransactionType'   => $this->pushTransactionTypeMock,
+            'logger'                => $this->loggerMock,
+            'helper'                => $this->helperMock,
+            'transaction'           => $this->transactionMock,
+            'groupTransaction'      => $this->groupTransactionMock,
+            'buckarooStatusCode'    => $this->buckarooStatusCodeMock,
+            'orderStatusFactory'    => $this->orderStatusFactoryMock,
+            'configAccount'         => $this->configAccountMock,
+            'giftCardRefundService' => $this->giftCardRefundServiceMock,
+            'uncancelService'       => $this->uncancelServiceMock,
+            'resourceConnection'    => $this->resourceConnectionMock,
+            'giftcardCollection'    => $this->giftcardCollectionMock,
+            'currencyFactory'       => $this->currencyFactoryMock,
+        ]);
+    }
+
+    public function testGetSpecificPaymentDetailsIsEmptyForIdeal(): void
+    {
+        // iDEAL overrides the DefaultProcessor hook to add no method-specific
+        // payment information (no issuer/consumer details) to the order payment.
+        $this->assertSame([], $this->invoke('getSpecificPaymentDetails', $this->getInstance()));
+    }
+
+    public function testIdealPushUsesDedicatedLockPrefixAndPayTransactionType(): void
+    {
+        $this->assertSame('C021', IdealPushProcessor::BUCK_PUSH_IDEAL_PAY);
+
+        $lockPrefix = new \ReflectionClassConstant(IdealPushProcessor::class, 'LOCK_PREFIX');
+        $this->assertSame('bk_push_ideal_', $lockPrefix->getValue());
+        $this->assertSame(
+            IdealPushProcessor::class,
+            $lockPrefix->getDeclaringClass()->getName(),
+            'IdealPushProcessor must declare its own lock prefix so iDEAL pushes are locked separately'
+        );
+    }
+}

--- a/Test/Unit/Model/Push/KlarnaKpProcessorTest.php
+++ b/Test/Unit/Model/Push/KlarnaKpProcessorTest.php
@@ -1,0 +1,543 @@
+<?php
+declare(strict_types=1);
+
+namespace Buckaroo\Magento2\Test\Unit\Model\Push;
+
+use Buckaroo\Magento2\Model\Method\BuckarooAdapter;
+use Buckaroo\Magento2\Test\Unit\Stubs\OrderStub;
+use Buckaroo\Magento2\Test\Unit\Stubs\PushRequestInterfaceStub;
+use Magento\Sales\Model\Order;
+
+/**
+ * Minimal stand-in for a Buckaroo payment method instance, mirroring the
+ * public static $requestOnVoid flag on BuckarooAdapter that the processor toggles.
+ */
+class FakeKlarnaMethodInstance
+{
+    public static $requestOnVoid = true;
+}
+
+/**
+ * @SuppressWarnings(PHPMD.TooManyFields)
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
+class KlarnaKpProcessorTest extends \Buckaroo\Magento2\Test\BaseTest
+{
+    protected $instanceClass = 'Buckaroo\Magento2\Model\Push\KlarnaKpProcessor';
+
+    private $orderRequestServiceMock;
+    private $pushTransactionTypeMock;
+    private $loggerMock;
+    private $helperMock;
+    private $transactionMock;
+    private $groupTransactionMock;
+    private $buckarooStatusCodeMock;
+    private $orderStatusFactoryMock;
+    private $configAccountMock;
+    private $giftCardRefundServiceMock;
+    private $uncancelServiceMock;
+    private $resourceConnectionMock;
+    private $giftcardCollectionMock;
+    private $klarnakpConfigMock;
+    private $escaperMock;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->orderRequestServiceMock = $this->getFakeMock('Buckaroo\Magento2\Service\Push\OrderRequestService')->getMock();
+        $this->pushTransactionTypeMock = $this->getFakeMock('Buckaroo\Magento2\Model\Push\PushTransactionType')->getMock();
+        $this->loggerMock = $this->getFakeMock('Buckaroo\Magento2\Logging\BuckarooLoggerInterface')->getMock();
+        $this->helperMock = $this->getFakeMock('Buckaroo\Magento2\Helper\Data')->getMock();
+        $this->transactionMock = $this->getFakeMock('Magento\Sales\Api\Data\TransactionInterface')->getMock();
+        $this->groupTransactionMock = $this->getFakeMock('Buckaroo\Magento2\Helper\PaymentGroupTransaction')->getMock();
+        $this->buckarooStatusCodeMock = $this->getFakeMock('Buckaroo\Magento2\Model\BuckarooStatusCode')->getMock();
+        $this->orderStatusFactoryMock = $this->getFakeMock('Buckaroo\Magento2\Model\OrderStatusFactory')->getMock();
+        $this->configAccountMock = $this->getFakeMock('Buckaroo\Magento2\Model\ConfigProvider\Account')->getMock();
+        $this->giftCardRefundServiceMock = $this->getFakeMock('Buckaroo\Magento2\Model\Service\GiftCardRefundService')->getMock();
+        $this->uncancelServiceMock = $this->getFakeMock('Buckaroo\Magento2\Service\Order\Uncancel')->getMock();
+        $this->resourceConnectionMock = $this->getFakeMock('Magento\Framework\App\ResourceConnection')->getMock();
+        $this->giftcardCollectionMock = $this->getFakeMock('Buckaroo\Magento2\Model\ResourceModel\Giftcard\Collection')->getMock();
+        $this->klarnakpConfigMock = $this->getFakeMock('Buckaroo\Magento2\Model\ConfigProvider\Method\Klarnakp')->getMock();
+        $this->escaperMock = $this->getFakeMock('Magento\Framework\Escaper')->getMock();
+
+        // The processor constructor does not receive a CurrencyFactory and falls back to
+        // ObjectManager::getInstance(); provide one for the duration of the test.
+        $appObjectManagerMock = $this->getFakeMock('Magento\Framework\ObjectManagerInterface')->getMock();
+        $appObjectManagerMock->method('get')->willReturn(
+            $this->getFakeMock('Magento\Directory\Model\CurrencyFactory')->getMock()
+        );
+        \Magento\Framework\App\ObjectManager::setInstance($appObjectManagerMock);
+
+        FakeKlarnaMethodInstance::$requestOnVoid = true;
+    }
+
+    public function tearDown(): void
+    {
+        $property = new \ReflectionProperty(\Magento\Framework\App\ObjectManager::class, '_instance');
+        $property->setValue(null, null);
+
+        parent::tearDown();
+    }
+
+    public function getInstance(array $args = [])
+    {
+        return parent::getInstance($args + [
+            'orderRequestService'   => $this->orderRequestServiceMock,
+            'pushTransactionType'   => $this->pushTransactionTypeMock,
+            'logger'                => $this->loggerMock,
+            'helper'                => $this->helperMock,
+            'transaction'           => $this->transactionMock,
+            'groupTransaction'      => $this->groupTransactionMock,
+            'buckarooStatusCode'    => $this->buckarooStatusCodeMock,
+            'orderStatusFactory'    => $this->orderStatusFactoryMock,
+            'configAccount'         => $this->configAccountMock,
+            'giftCardRefundService' => $this->giftCardRefundServiceMock,
+            'uncancelService'       => $this->uncancelServiceMock,
+            'resourceConnection'    => $this->resourceConnectionMock,
+            'giftcardCollection'    => $this->giftcardCollectionMock,
+            'klarnakpConfig'        => $this->klarnakpConfigMock,
+            'escaper'               => $this->escaperMock,
+        ]);
+    }
+
+    /**
+     * Build a push request double.
+     *
+     * @param array $getters        getter name => return value
+     * @param array $trueAdditional list of [name, value] pairs for which
+     *                              hasAdditionalInformation() returns true
+     * @param array $truePostData   list of [name, value] pairs for which hasPostData() returns true
+     */
+    private function createPushRequest(
+        array $getters = [],
+        array $trueAdditional = [],
+        array $truePostData = []
+    ) {
+        $defaults = [
+            'getStatusCode'                           => null,
+            'getDatarequest'                          => null,
+            'getInvoiceNumber'                        => null,
+            'getTransactions'                         => null,
+            'getRelatedtransactionRefund'             => null,
+            'getServiceKlarnakpCaptureid'             => null,
+            'getServiceKlarnakpAutopaytransactionkey' => null,
+            'getServiceKlarnakpReservationnumber'     => null,
+        ];
+
+        $mock = $this->getFakeMock(PushRequestInterfaceStub::class)->getMock();
+        foreach (array_merge($defaults, $getters) as $method => $value) {
+            $mock->method($method)->willReturn($value);
+        }
+        $mock->method('hasAdditionalInformation')->willReturnCallback(
+            function ($name, $value) use ($trueAdditional) {
+                return in_array([$name, $value], $trueAdditional, true);
+            }
+        );
+        $mock->method('hasPostData')->willReturnCallback(
+            function ($name, $value) use ($truePostData) {
+                return in_array([$name, $value], $truePostData, true);
+            }
+        );
+
+        return $mock;
+    }
+
+    public function testGetTransactionKeyReturnsTransactionsFromPush(): void
+    {
+        $instance = $this->getInstance();
+
+        $pushRequest = $this->createPushRequest(['getTransactions' => 'TRX-123']);
+        $this->setProperty('pushRequest', $pushRequest, $instance);
+
+        $this->assertSame('TRX-123', $this->invoke('getTransactionKey', $instance));
+    }
+
+    public function testGetTransactionKeyPrefersAutoPayTransactionKey(): void
+    {
+        $instance = $this->getInstance();
+
+        $pushRequest = $this->createPushRequest([
+            'getTransactions'                         => 'TRX-123',
+            'getServiceKlarnakpAutopaytransactionkey' => 'AUTOPAY-456',
+        ]);
+        $this->setProperty('pushRequest', $pushRequest, $instance);
+
+        $this->assertSame('AUTOPAY-456', $this->invoke('getTransactionKey', $instance));
+    }
+
+    private function createOrderWithPayment(
+        $paymentMock,
+        bool $hasInvoices = false,
+        string $state = Order::STATE_NEW
+    ) {
+        $orderMock = $this->getFakeMock(OrderStub::class)->getMock();
+        $orderMock->method('getPayment')->willReturn($paymentMock);
+        $orderMock->method('hasInvoices')->willReturn($hasInvoices);
+        $orderMock->method('getState')->willReturn($state);
+        $orderMock->method('getIncrementId')->willReturn('100000001');
+
+        return $orderMock;
+    }
+
+    public function testSkipPushSkipsMagentoCapturePushWhenInvoiceExists(): void
+    {
+        $instance = $this->getInstance();
+
+        $pushRequest = $this->createPushRequest(
+            ['getServiceKlarnakpCaptureid' => 'CAPTURE-1'],
+            [['initiated_by_magento', 1], ['service_action_from_magento', 'pay']]
+        );
+        $paymentMock = $this->getFakeMock('Magento\Sales\Model\Order\Payment')->getMock();
+        $paymentMock->method('getAdditionalInformation')->willReturn(null);
+
+        $this->setProperty('pushRequest', $pushRequest, $instance);
+        $this->setProperty('order', $this->createOrderWithPayment($paymentMock, true), $instance);
+
+        $this->assertTrue($this->invoke('skipPush', $instance));
+    }
+
+    public function testSkipPushSkipsMagentoCapturePushWhenAlreadyCaptured(): void
+    {
+        $instance = $this->getInstance();
+
+        $pushRequest = $this->createPushRequest(
+            ['getServiceKlarnakpCaptureid' => 'CAPTURE-1'],
+            [['initiated_by_magento', 1], ['service_action_from_magento', 'pay']]
+        );
+        $paymentMock = $this->getFakeMock('Magento\Sales\Model\Order\Payment')->getMock();
+        $paymentMock->method('getAdditionalInformation')
+            ->with('buckaroo_already_captured')
+            ->willReturn('1');
+
+        $this->setProperty('pushRequest', $pushRequest, $instance);
+        $this->setProperty('order', $this->createOrderWithPayment($paymentMock, false), $instance);
+
+        $this->assertTrue($this->invoke('skipPush', $instance));
+    }
+
+    public function testSkipPushProcessesMagentoCapturePushWhenCaptureWasNotProcessed(): void
+    {
+        $instance = $this->getInstance();
+
+        $pushRequest = $this->createPushRequest(
+            ['getServiceKlarnakpCaptureid' => 'CAPTURE-1'],
+            [['initiated_by_magento', 1], ['service_action_from_magento', 'pay']]
+        );
+        $paymentMock = $this->getFakeMock('Magento\Sales\Model\Order\Payment')->getMock();
+        $paymentMock->method('getAdditionalInformation')->willReturn(null);
+
+        $this->setProperty('pushRequest', $pushRequest, $instance);
+        $this->setProperty('order', $this->createOrderWithPayment($paymentMock, false), $instance);
+
+        $this->assertFalse($this->invoke('skipPush', $instance));
+    }
+
+    public function testSkipPushSkipsRedundantAutoPayConfirmationPush(): void
+    {
+        $instance = $this->getInstance();
+
+        $pushRequest = $this->createPushRequest(
+            ['getServiceKlarnakpAutopaytransactionkey' => 'AUTOPAY-456']
+        );
+        $paymentMock = $this->getFakeMock('Magento\Sales\Model\Order\Payment')->getMock();
+        $paymentMock->method('getAdditionalInformation')->willReturn(null);
+
+        $this->setProperty('pushRequest', $pushRequest, $instance);
+        $this->setProperty('order', $this->createOrderWithPayment($paymentMock, true), $instance);
+
+        $this->assertTrue($this->invoke('skipPush', $instance));
+    }
+
+    public function testSkipPushFallsBackToParentWhenNoKlarnaConditionApplies(): void
+    {
+        $instance = $this->getInstance();
+
+        $pushRequest = $this->createPushRequest(
+            ['getServiceKlarnakpAutopaytransactionkey' => 'AUTOPAY-456']
+        );
+        // No invoice, not captured, no skip_push counter: nothing to skip.
+        $paymentMock = $this->getFakeMock('Magento\Sales\Model\Order\Payment')->getMock();
+        $paymentMock->method('getAdditionalInformation')->willReturn(null);
+
+        $this->setProperty('pushRequest', $pushRequest, $instance);
+        $this->setProperty('order', $this->createOrderWithPayment($paymentMock, false), $instance);
+        $this->setProperty('payment', $paymentMock, $instance);
+
+        $this->assertFalse($this->invoke('skipPush', $instance));
+    }
+
+    public function testSetBuckarooReservationNumberSavesNumberFromPush(): void
+    {
+        $instance = $this->getInstance();
+
+        $pushRequest = $this->createPushRequest(
+            ['getServiceKlarnakpReservationnumber' => 'RESERVATION-1']
+        );
+
+        $orderMock = $this->getFakeMock(OrderStub::class)->getMock();
+        $orderMock->method('getIncrementId')->willReturn('100000001');
+        $orderMock->expects($this->once())
+            ->method('setBuckarooReservationNumber')
+            ->with('RESERVATION-1')
+            ->willReturnSelf();
+        $orderMock->expects($this->once())->method('save')->willReturnSelf();
+
+        $this->setProperty('pushRequest', $pushRequest, $instance);
+        $this->setProperty('order', $orderMock, $instance);
+
+        $this->assertTrue($this->invoke('setBuckarooReservationNumber', $instance));
+    }
+
+    public function testSetBuckarooReservationNumberReturnsFalseWithoutNumberInPush(): void
+    {
+        $instance = $this->getInstance();
+
+        $pushRequest = $this->createPushRequest();
+
+        $orderMock = $this->getFakeMock(OrderStub::class)->getMock();
+        $orderMock->method('getIncrementId')->willReturn('100000001');
+        $orderMock->expects($this->never())->method('setBuckarooReservationNumber');
+        $orderMock->expects($this->never())->method('save');
+
+        $this->setProperty('pushRequest', $pushRequest, $instance);
+        $this->setProperty('order', $orderMock, $instance);
+
+        $this->assertFalse($this->invoke('setBuckarooReservationNumber', $instance));
+    }
+
+    public function testInvoiceShouldBeSavedDefersInvoiceWhenCreatedAfterShipment(): void
+    {
+        $instance = $this->getInstance();
+
+        $pushRequest = $this->createPushRequest(
+            [],
+            [['initiated_by_magento', 1], ['service_action_from_magento', 'pay']],
+            [['transaction_method', 'KlarnaKp']]
+        );
+        $this->klarnakpConfigMock->method('isInvoiceCreatedAfterShipment')->willReturn(true);
+
+        $this->setProperty('pushRequest', $pushRequest, $instance);
+
+        $paymentDetails = [];
+        $result = $this->invokeArgs('invoiceShouldBeSaved', [&$paymentDetails], $instance);
+
+        $this->assertFalse($result);
+        $this->assertTrue($this->getProperty('dontSaveOrderUponSuccessPush', $instance));
+    }
+
+    public function testInvoiceShouldBeSavedWhenInvoiceAfterShipmentIsDisabled(): void
+    {
+        $instance = $this->getInstance();
+
+        $pushRequest = $this->createPushRequest(
+            [],
+            [['initiated_by_magento', 1], ['service_action_from_magento', 'pay']],
+            [['transaction_method', 'KlarnaKp']]
+        );
+        $this->klarnakpConfigMock->method('isInvoiceCreatedAfterShipment')->willReturn(false);
+
+        $this->setProperty('pushRequest', $pushRequest, $instance);
+
+        $paymentDetails = [];
+        $result = $this->invokeArgs('invoiceShouldBeSaved', [&$paymentDetails], $instance);
+
+        $this->assertTrue($result);
+        $this->assertFalse($this->getProperty('dontSaveOrderUponSuccessPush', $instance));
+    }
+
+    public function testInvoiceShouldBeSavedForReservePushWithReservationNumber(): void
+    {
+        $instance = $this->getInstance();
+
+        $pushRequest = $this->createPushRequest(
+            ['getServiceKlarnakpReservationnumber' => 'RESERVATION-1'],
+            [['initiated_by_magento', 1], ['service_action_from_magento', 'pay']],
+            [['transaction_method', 'KlarnaKp']]
+        );
+        $this->klarnakpConfigMock->method('isInvoiceCreatedAfterShipment')->willReturn(true);
+
+        $this->setProperty('pushRequest', $pushRequest, $instance);
+
+        $paymentDetails = [];
+        $result = $this->invokeArgs('invoiceShouldBeSaved', [&$paymentDetails], $instance);
+
+        $this->assertTrue($result);
+        $this->assertFalse($this->getProperty('dontSaveOrderUponSuccessPush', $instance));
+    }
+
+    private function preparePushAuthorization($instance, string $statusCode, string $orderState)
+    {
+        $pushRequest = $this->createPushRequest(['getStatusCode' => $statusCode]);
+
+        $paymentMock = $this->getFakeMock('Magento\Sales\Model\Order\Payment')->getMock();
+        $paymentMock->method('getMethod')->willReturn('buckaroo_magento2_klarnakp');
+
+        $orderMock = $this->getFakeMock(OrderStub::class)->getMock();
+        $orderMock->method('getState')->willReturn($orderState);
+
+        $this->setProperty('pushRequest', $pushRequest, $instance);
+        $this->setProperty('order', $orderMock, $instance);
+        $this->setProperty('payment', $paymentMock, $instance);
+
+        return $orderMock;
+    }
+
+    public function testProcessSucceededPushAuthorizationMovesNewOrderToProcessing(): void
+    {
+        $instance = $this->getInstance();
+
+        $orderMock = $this->preparePushAuthorization($instance, '190', Order::STATE_NEW);
+        $orderMock->expects($this->once())->method('setState')->with(Order::STATE_PROCESSING)->willReturnSelf();
+        $orderMock->expects($this->once())->method('save')->willReturnSelf();
+
+        $this->invoke('processSucceededPushAuthorization', $instance);
+    }
+
+    public function testProcessSucceededPushAuthorizationLeavesCanceledOrderStateUntouched(): void
+    {
+        $instance = $this->getInstance();
+
+        // Canceled orders are accepted (Klarna allows completion within 48 hours) but the
+        // canceled -> new transition is delegated to canUpdateOrderStatus, not done here.
+        $orderMock = $this->preparePushAuthorization($instance, '190', Order::STATE_CANCELED);
+        $orderMock->expects($this->never())->method('setState');
+        $orderMock->expects($this->never())->method('save');
+
+        $this->invoke('processSucceededPushAuthorization', $instance);
+    }
+
+    public function testProcessSucceededPushAuthorizationSkipsOrderInFinalState(): void
+    {
+        $instance = $this->getInstance();
+
+        $orderMock = $this->preparePushAuthorization($instance, '190', Order::STATE_COMPLETE);
+        $orderMock->expects($this->never())->method('setState');
+        $orderMock->expects($this->never())->method('save');
+
+        $this->invoke('processSucceededPushAuthorization', $instance);
+    }
+
+    public function testProcessSucceededPushAuthorizationIgnoresNonSuccessStatus(): void
+    {
+        $instance = $this->getInstance();
+
+        $orderMock = $this->preparePushAuthorization($instance, '490', Order::STATE_NEW);
+        $orderMock->expects($this->never())->method('setState');
+        $orderMock->expects($this->never())->method('save');
+
+        $this->invoke('processSucceededPushAuthorization', $instance);
+    }
+
+    /**
+     * Build the fixture for a Plaza-originated cancel reservation push:
+     * status 190, not initiated by Magento, no invoice number, order in processing,
+     * and a datarequest transaction that Magento does not know.
+     */
+    private function preparePlazaCancelPush($instance, string $incomingTrx, array $knownTransactions)
+    {
+        $pushRequest = $this->createPushRequest([
+            'getStatusCode'  => '190',
+            'getDatarequest' => $incomingTrx,
+        ]);
+
+        $paymentMock = $this->getFakeMock('Magento\Sales\Model\Order\Payment')->getMock();
+        $paymentMock->method('getAdditionalInformation')->willReturnMap([
+            [BuckarooAdapter::BUCKAROO_ALL_TRANSACTIONS, $knownTransactions],
+        ]);
+
+        $orderMock = $this->getFakeMock(OrderStub::class)->getMock();
+        $orderMock->method('getState')->willReturn(Order::STATE_PROCESSING);
+        $orderMock->method('getIncrementId')->willReturn('100000001');
+        $orderMock->method('getPayment')->willReturn($paymentMock);
+
+        $this->setProperty('pushRequest', $pushRequest, $instance);
+        $this->setProperty('order', $orderMock, $instance);
+        $this->setProperty('payment', $paymentMock, $instance);
+
+        return [$orderMock, $paymentMock];
+    }
+
+    public function testProcessPushByStatusCancelsOrderForPlazaCancelReservationPush(): void
+    {
+        $instance = $this->getInstance();
+
+        [$orderMock, ] = $this->preparePlazaCancelPush($instance, 'PLAZA-TRX', ['KNOWN-TRX' => ['C021']]);
+        $orderMock->method('canCancel')->willReturn(false);
+
+        $this->orderStatusFactoryMock->expects($this->once())
+            ->method('get')
+            ->with(891, $orderMock)
+            ->willReturn('buckaroo_cancelled');
+
+        $this->escaperMock->method('escapeHtml')->willReturnArgument(0);
+
+        $expectedDescription = 'Order cancelled via Buckaroo Plaza (KlarnaKp reservation released).'
+            . ' Cancel transaction: <a href="https://plaza.buckaroo.nl/Transaction/DataRequest/Details/PLAZA-TRX"'
+            . ' target="_blank">PLAZA-TRX</a>.';
+
+        $this->orderRequestServiceMock->expects($this->once())
+            ->method('updateOrderStatus')
+            ->with(Order::STATE_CANCELED, 'buckaroo_cancelled', $expectedDescription);
+
+        $this->assertTrue($this->invoke('processPushByStatus', $instance));
+    }
+
+    public function testProcessPushByStatusPlazaCancelDisablesVoidRequestWhileCancelling(): void
+    {
+        $instance = $this->getInstance();
+
+        [$orderMock, $paymentMock] = $this->preparePlazaCancelPush(
+            $instance,
+            'PLAZA-TRX',
+            ['KNOWN-TRX' => ['C021']]
+        );
+        $orderMock->method('canCancel')->willReturn(true);
+
+        $paymentMock->method('getMethodInstance')->willReturn(new FakeKlarnaMethodInstance());
+        $paymentMock->expects($this->once())
+            ->method('setAdditionalInformation')
+            ->with('buckaroo_failed_authorize', 1)
+            ->willReturnSelf();
+        $paymentMock->expects($this->once())->method('save')->willReturnSelf();
+
+        $orderMock->expects($this->once())
+            ->method('cancel')
+            ->willReturnCallback(function () use ($orderMock) {
+                // The static void-request flag must be off while the order is cancelled,
+                // otherwise cancel() would trigger a void request back to Buckaroo.
+                $this->assertFalse(FakeKlarnaMethodInstance::$requestOnVoid);
+                return $orderMock;
+            });
+        $orderMock->expects($this->once())->method('save')->willReturnSelf();
+
+        $this->orderStatusFactoryMock->method('get')->willReturn('buckaroo_cancelled');
+        $this->escaperMock->method('escapeHtml')->willReturnArgument(0);
+        $this->orderRequestServiceMock->expects($this->once())->method('updateOrderStatus');
+
+        $this->assertTrue($this->invoke('processPushByStatus', $instance));
+
+        // And it must be restored afterwards.
+        $this->assertTrue(FakeKlarnaMethodInstance::$requestOnVoid);
+    }
+
+    public function testProcessPushByStatusFallsThroughToParentForKnownTransaction(): void
+    {
+        $instance = $this->getInstance();
+
+        // The incoming datarequest transaction is already known to Magento,
+        // so this is not a Plaza cancel reservation push.
+        $this->preparePlazaCancelPush($instance, 'KNOWN-TRX', ['KNOWN-TRX' => ['C021']]);
+
+        $this->pushTransactionTypeMock->method('getStatusKey')->willReturn('BUCKAROO_MAGENTO2_STATUSCODE_NEUTRAL');
+        $this->pushTransactionTypeMock->method('getStatusMessage')->willReturn('Neutral status message');
+        $this->orderStatusFactoryMock->method('get')->willReturn('some_status');
+
+        $this->orderRequestServiceMock->expects($this->never())->method('updateOrderStatus');
+        $this->orderRequestServiceMock->expects($this->once())
+            ->method('setOrderNotificationNote')
+            ->with('Neutral status message');
+
+        $this->assertTrue($this->invoke('processPushByStatus', $instance));
+    }
+}

--- a/Test/Unit/Model/Push/PaypalProcessorTest.php
+++ b/Test/Unit/Model/Push/PaypalProcessorTest.php
@@ -1,0 +1,188 @@
+<?php
+declare(strict_types=1);
+
+namespace Buckaroo\Magento2\Test\Unit\Model\Push;
+
+use Buckaroo\Magento2\Test\Unit\Stubs\PushRequestInterfaceStub;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+/**
+ * @SuppressWarnings(PHPMD.TooManyFields)
+ */
+class PaypalProcessorTest extends \Buckaroo\Magento2\Test\BaseTest
+{
+    protected $instanceClass = 'Buckaroo\Magento2\Model\Push\PaypalProcessor';
+
+    private $orderRequestServiceMock;
+    private $pushTransactionTypeMock;
+    private $loggerMock;
+    private $helperMock;
+    private $transactionMock;
+    private $groupTransactionMock;
+    private $buckarooStatusCodeMock;
+    private $orderStatusFactoryMock;
+    private $configAccountMock;
+    private $giftCardRefundServiceMock;
+    private $uncancelServiceMock;
+    private $resourceConnectionMock;
+    private $giftcardCollectionMock;
+    private $paypalConfigMock;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->orderRequestServiceMock = $this->getFakeMock('Buckaroo\Magento2\Service\Push\OrderRequestService')->getMock();
+        $this->pushTransactionTypeMock = $this->getFakeMock('Buckaroo\Magento2\Model\Push\PushTransactionType')->getMock();
+        $this->loggerMock = $this->getFakeMock('Buckaroo\Magento2\Logging\BuckarooLoggerInterface')->getMock();
+        $this->helperMock = $this->getFakeMock('Buckaroo\Magento2\Helper\Data')->getMock();
+        $this->transactionMock = $this->getFakeMock('Magento\Sales\Api\Data\TransactionInterface')->getMock();
+        $this->groupTransactionMock = $this->getFakeMock('Buckaroo\Magento2\Helper\PaymentGroupTransaction')->getMock();
+        $this->buckarooStatusCodeMock = $this->getFakeMock('Buckaroo\Magento2\Model\BuckarooStatusCode')->getMock();
+        $this->orderStatusFactoryMock = $this->getFakeMock('Buckaroo\Magento2\Model\OrderStatusFactory')->getMock();
+        $this->configAccountMock = $this->getFakeMock('Buckaroo\Magento2\Model\ConfigProvider\Account')->getMock();
+        $this->giftCardRefundServiceMock = $this->getFakeMock('Buckaroo\Magento2\Model\Service\GiftCardRefundService')->getMock();
+        $this->uncancelServiceMock = $this->getFakeMock('Buckaroo\Magento2\Service\Order\Uncancel')->getMock();
+        $this->resourceConnectionMock = $this->getFakeMock('Magento\Framework\App\ResourceConnection')->getMock();
+        $this->giftcardCollectionMock = $this->getFakeMock('Buckaroo\Magento2\Model\ResourceModel\Giftcard\Collection')->getMock();
+        $this->paypalConfigMock = $this->getFakeMock('Buckaroo\Magento2\Model\ConfigProvider\Method\Paypal')->getMock();
+
+        // The processor constructor does not receive a CurrencyFactory and falls back to
+        // ObjectManager::getInstance(); provide one for the duration of the test.
+        $appObjectManagerMock = $this->getFakeMock('Magento\Framework\ObjectManagerInterface')->getMock();
+        $appObjectManagerMock->method('get')->willReturn(
+            $this->getFakeMock('Magento\Directory\Model\CurrencyFactory')->getMock()
+        );
+        \Magento\Framework\App\ObjectManager::setInstance($appObjectManagerMock);
+    }
+
+    public function tearDown(): void
+    {
+        $property = new \ReflectionProperty(\Magento\Framework\App\ObjectManager::class, '_instance');
+        $property->setValue(null, null);
+
+        parent::tearDown();
+    }
+
+    public function getInstance(array $args = [])
+    {
+        return parent::getInstance($args + [
+            'orderRequestService'   => $this->orderRequestServiceMock,
+            'pushTransactionType'   => $this->pushTransactionTypeMock,
+            'logger'                => $this->loggerMock,
+            'helper'                => $this->helperMock,
+            'transaction'           => $this->transactionMock,
+            'groupTransaction'      => $this->groupTransactionMock,
+            'buckarooStatusCode'    => $this->buckarooStatusCodeMock,
+            'orderStatusFactory'    => $this->orderStatusFactoryMock,
+            'configAccount'         => $this->configAccountMock,
+            'giftCardRefundService' => $this->giftCardRefundServiceMock,
+            'uncancelService'       => $this->uncancelServiceMock,
+            'resourceConnection'    => $this->resourceConnectionMock,
+            'giftcardCollection'    => $this->giftcardCollectionMock,
+            'paypalConfig'          => $this->paypalConfigMock,
+        ]);
+    }
+
+    private function prepareGetNewStatus($instance, string $statusKey, string $paymentMethodCode)
+    {
+        $pushRequestMock = $this->getFakeMock(PushRequestInterfaceStub::class)->getMock();
+        $pushRequestMock->method('getStatusCode')->willReturn('190');
+
+        $paymentMock = $this->getFakeMock('Magento\Sales\Model\Order\Payment')->getMock();
+        $paymentMock->method('getMethod')->willReturn($paymentMethodCode);
+
+        $orderMock = $this->getFakeMock('Magento\Sales\Model\Order')->getMock();
+        $orderMock->method('getPayment')->willReturn($paymentMock);
+
+        $this->pushTransactionTypeMock->method('getStatusKey')->willReturn($statusKey);
+
+        $this->orderStatusFactoryMock->expects($this->once())
+            ->method('get')
+            ->with('190', $orderMock)
+            ->willReturn('base_success_status');
+
+        $this->setProperty('pushRequest', $pushRequestMock, $instance);
+        $this->setProperty('order', $orderMock, $instance);
+    }
+
+    public function testGetNewStatusUsesSellersProtectionIneligibleStatusForSuccessfulPaypalPush(): void
+    {
+        $instance = $this->getInstance();
+
+        $this->prepareGetNewStatus(
+            $instance,
+            'BUCKAROO_MAGENTO2_STATUSCODE_SUCCESS',
+            'buckaroo_magento2_paypal'
+        );
+
+        $this->paypalConfigMock->method('getSellersProtection')->willReturn(true);
+        $this->paypalConfigMock->method('getSellersProtectionIneligible')
+            ->willReturn('sellers_protection_ineligible');
+
+        $this->assertSame('sellers_protection_ineligible', $this->invoke('getNewStatus', $instance));
+    }
+
+    public static function sellersProtectionNotAppliedProvider(): array
+    {
+        return [
+            'sellers protection disabled' => [
+                'sellersProtection'  => false,
+                'ineligibleStatus'   => 'sellers_protection_ineligible',
+            ],
+            'no ineligible status configured' => [
+                'sellersProtection'  => true,
+                'ineligibleStatus'   => '',
+            ],
+        ];
+    }
+
+    #[DataProvider('sellersProtectionNotAppliedProvider')]
+    public function testGetNewStatusKeepsFactoryStatusWhenSellersProtectionDoesNotApply(
+        bool $sellersProtection,
+        string $ineligibleStatus
+    ): void {
+        $instance = $this->getInstance();
+
+        $this->prepareGetNewStatus(
+            $instance,
+            'BUCKAROO_MAGENTO2_STATUSCODE_SUCCESS',
+            'buckaroo_magento2_paypal'
+        );
+
+        $this->paypalConfigMock->method('getSellersProtection')->willReturn($sellersProtection);
+        $this->paypalConfigMock->method('getSellersProtectionIneligible')->willReturn($ineligibleStatus);
+
+        $this->assertSame('base_success_status', $this->invoke('getNewStatus', $instance));
+    }
+
+    public function testGetNewStatusKeepsFactoryStatusForNonSuccessPush(): void
+    {
+        $instance = $this->getInstance();
+
+        $this->prepareGetNewStatus(
+            $instance,
+            'BUCKAROO_MAGENTO2_STATUSCODE_PENDING_PROCESSING',
+            'buckaroo_magento2_paypal'
+        );
+
+        $this->paypalConfigMock->expects($this->never())->method('getSellersProtectionIneligible');
+
+        $this->assertSame('base_success_status', $this->invoke('getNewStatus', $instance));
+    }
+
+    public function testGetNewStatusKeepsFactoryStatusForOtherPaymentMethod(): void
+    {
+        $instance = $this->getInstance();
+
+        $this->prepareGetNewStatus(
+            $instance,
+            'BUCKAROO_MAGENTO2_STATUSCODE_SUCCESS',
+            'buckaroo_magento2_ideal'
+        );
+
+        $this->paypalConfigMock->expects($this->never())->method('getSellersProtectionIneligible');
+
+        $this->assertSame('base_success_status', $this->invoke('getNewStatus', $instance));
+    }
+}

--- a/Test/Unit/Model/Push/PushProcessorsFactoryTest.php
+++ b/Test/Unit/Model/Push/PushProcessorsFactoryTest.php
@@ -1,0 +1,235 @@
+<?php
+declare(strict_types=1);
+
+namespace Buckaroo\Magento2\Test\Unit\Model\Push;
+
+use Buckaroo\Magento2\Exception as BuckarooException;
+use Buckaroo\Magento2\Model\Push\PushProcessorInterface;
+use Buckaroo\Magento2\Model\Push\PushTransactionType;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+class PushProcessorsFactoryTest extends \Buckaroo\Magento2\Test\BaseTest
+{
+    protected $instanceClass = 'Buckaroo\Magento2\Model\Push\PushProcessorsFactory';
+
+    private const PROCESSORS = [
+        'default'           => 'DefaultProcessorClass',
+        'ideal'             => 'IdealProcessorClass',
+        'klarnakp'          => 'KlarnaKpProcessorClass',
+        'payperemail'       => 'PayPerEmailProcessorClass',
+        'group_transaction' => 'GroupTransactionProcessorClass',
+        'credit_managment'  => 'CreditManagementProcessorClass',
+        'refund'            => 'RefundProcessorClass',
+        'cancel_authorize'  => 'CancelAuthorizeProcessorClass',
+    ];
+
+    private $orderRequestServiceMock;
+    private $objectManagerMock;
+
+    public function setUp(): void
+    {
+        parent::setUp();
+
+        $this->orderRequestServiceMock = $this->getFakeMock('Buckaroo\Magento2\Service\Push\OrderRequestService')
+            ->getMock();
+        $this->objectManagerMock = $this->getFakeMock('Magento\Framework\ObjectManagerInterface')->getMock();
+    }
+
+    public function getInstance(array $args = [])
+    {
+        return parent::getInstance($args + [
+            'orderRequestService' => $this->orderRequestServiceMock,
+            'objectManager'       => $this->objectManagerMock,
+            'pushProcessors'      => self::PROCESSORS,
+        ]);
+    }
+
+    /**
+     * Build a PushTransactionType mock describing an incoming push.
+     */
+    private function createPushTransactionType(
+        string $paymentMethod = 'unknownmethod',
+        bool $isFromPayPerEmail = false,
+        bool $isGroupTransaction = false,
+        string $pushType = PushTransactionType::BUCK_PUSH_TYPE_TRANSACTION,
+        ?string $serviceAction = null
+    ) {
+        $mock = $this->getFakeMock(PushTransactionType::class)->getMock();
+        $mock->method('getPaymentMethod')->willReturn($paymentMethod);
+        $mock->method('isFromPayPerEmail')->willReturn($isFromPayPerEmail);
+        $mock->method('isGroupTransaction')->willReturn($isGroupTransaction);
+        $mock->method('getPushType')->willReturn($pushType);
+        $mock->method('getServiceAction')->willReturn($serviceAction);
+
+        return $mock;
+    }
+
+    public function testGetThrowsLogicExceptionWhenNoProcessorsConfigured(): void
+    {
+        $instance = $this->getInstance(['pushProcessors' => []]);
+
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Push processors is not set.');
+
+        $instance->get($this->createPushTransactionType());
+    }
+
+    public static function processorResolutionProvider(): array
+    {
+        return [
+            'payment method resolves its own processor, case-insensitive' => [
+                'paymentMethod'      => 'iDEAL',
+                'isFromPayPerEmail'  => false,
+                'isGroupTransaction' => false,
+                'pushType'           => PushTransactionType::BUCK_PUSH_TYPE_TRANSACTION,
+                'serviceAction'      => null,
+                'expectedClass'      => 'IdealProcessorClass',
+            ],
+            'unknown payment method falls back to default processor' => [
+                'paymentMethod'      => 'somebrandnewmethod',
+                'isFromPayPerEmail'  => false,
+                'isGroupTransaction' => false,
+                'pushType'           => PushTransactionType::BUCK_PUSH_TYPE_TRANSACTION,
+                'serviceAction'      => null,
+                'expectedClass'      => 'DefaultProcessorClass',
+            ],
+            'payperemail origin overrides the payment method processor' => [
+                'paymentMethod'      => 'ideal',
+                'isFromPayPerEmail'  => true,
+                'isGroupTransaction' => false,
+                'pushType'           => PushTransactionType::BUCK_PUSH_TYPE_TRANSACTION,
+                'serviceAction'      => 'pay',
+                'expectedClass'      => 'PayPerEmailProcessorClass',
+            ],
+            'payperemail refund goes to the refund processor instead' => [
+                'paymentMethod'      => 'ideal',
+                'isFromPayPerEmail'  => true,
+                'isGroupTransaction' => false,
+                'pushType'           => PushTransactionType::BUCK_PUSH_TYPE_TRANSACTION,
+                'serviceAction'      => 'refund',
+                'expectedClass'      => 'RefundProcessorClass',
+            ],
+            'group transaction push wins over payment method' => [
+                'paymentMethod'      => 'ideal',
+                'isFromPayPerEmail'  => false,
+                'isGroupTransaction' => true,
+                'pushType'           => PushTransactionType::BUCK_PUSH_TYPE_TRANSACTION,
+                'serviceAction'      => null,
+                'expectedClass'      => 'GroupTransactionProcessorClass',
+            ],
+            'group transaction wins over invoice push type' => [
+                'paymentMethod'      => 'ideal',
+                'isFromPayPerEmail'  => false,
+                'isGroupTransaction' => true,
+                'pushType'           => PushTransactionType::BUCK_PUSH_TYPE_INVOICE,
+                'serviceAction'      => null,
+                'expectedClass'      => 'GroupTransactionProcessorClass',
+            ],
+            'invoice push resolves credit management processor' => [
+                'paymentMethod'      => 'ideal',
+                'isFromPayPerEmail'  => false,
+                'isGroupTransaction' => false,
+                'pushType'           => PushTransactionType::BUCK_PUSH_TYPE_INVOICE,
+                'serviceAction'      => null,
+                'expectedClass'      => 'CreditManagementProcessorClass',
+            ],
+            'refund service action resolves refund processor' => [
+                'paymentMethod'      => 'klarnakp',
+                'isFromPayPerEmail'  => false,
+                'isGroupTransaction' => false,
+                'pushType'           => PushTransactionType::BUCK_PUSH_TYPE_TRANSACTION,
+                'serviceAction'      => 'refund',
+                'expectedClass'      => 'RefundProcessorClass',
+            ],
+            'cancel_authorize service action resolves cancel authorize processor' => [
+                'paymentMethod'      => 'klarnakp',
+                'isFromPayPerEmail'  => false,
+                'isGroupTransaction' => false,
+                'pushType'           => PushTransactionType::BUCK_PUSH_TYPE_TRANSACTION,
+                'serviceAction'      => 'cancel_authorize',
+                'expectedClass'      => 'CancelAuthorizeProcessorClass',
+            ],
+        ];
+    }
+
+    #[DataProvider('processorResolutionProvider')]
+    public function testGetResolvesProcessorClass(
+        string $paymentMethod,
+        bool $isFromPayPerEmail,
+        bool $isGroupTransaction,
+        string $pushType,
+        ?string $serviceAction,
+        string $expectedClass
+    ): void {
+        $instance = $this->getInstance();
+
+        $pushTransactionType = $this->createPushTransactionType(
+            $paymentMethod,
+            $isFromPayPerEmail,
+            $isGroupTransaction,
+            $pushType,
+            $serviceAction
+        );
+
+        $processorMock = $this->getFakeMock(PushProcessorInterface::class)->getMock();
+
+        $this->objectManagerMock->expects($this->once())
+            ->method('get')
+            ->with($expectedClass)
+            ->willReturn($processorMock);
+
+        $this->assertSame($processorMock, $instance->get($pushTransactionType));
+    }
+
+    public function testGetThrowsBuckarooExceptionForIncompleteInvoicePush(): void
+    {
+        $instance = $this->getInstance();
+
+        $pushTransactionType = $this->createPushTransactionType(
+            'ideal',
+            false,
+            false,
+            PushTransactionType::BUCK_PUSH_TYPE_INVOICE_INCOMPLETE
+        );
+
+        $this->objectManagerMock->expects($this->never())->method('get');
+
+        $this->expectException(BuckarooException::class);
+        $this->expectExceptionMessage('Skipped handling this invoice push because it is too soon.');
+
+        $instance->get($pushTransactionType);
+    }
+
+    public function testGetThrowsBuckarooExceptionWhenResolvedProcessorClassIsEmpty(): void
+    {
+        $instance = $this->getInstance(['pushProcessors' => ['default' => '']]);
+
+        $pushTransactionType = $this->createPushTransactionType('somebrandnewmethod');
+
+        $this->objectManagerMock->expects($this->never())->method('get');
+
+        $this->expectException(BuckarooException::class);
+        $this->expectExceptionMessage('Unknown Push Processor type');
+
+        $instance->get($pushTransactionType);
+    }
+
+    public function testGetCachesTheResolvedProcessorAcrossCalls(): void
+    {
+        $instance = $this->getInstance();
+
+        $processorMock = $this->getFakeMock(PushProcessorInterface::class)->getMock();
+
+        $this->objectManagerMock->expects($this->once())
+            ->method('get')
+            ->with('IdealProcessorClass')
+            ->willReturn($processorMock);
+
+        $firstCallType = $this->createPushTransactionType('ideal');
+        // A second call with a completely different push type must not re-resolve.
+        $secondCallType = $this->createPushTransactionType('klarnakp');
+
+        $this->assertSame($processorMock, $instance->get($firstCallType));
+        $this->assertSame($processorMock, $instance->get($secondCallType));
+    }
+}

--- a/Test/Unit/Model/Push/PushTransactionTypeTest.php
+++ b/Test/Unit/Model/Push/PushTransactionTypeTest.php
@@ -1,0 +1,337 @@
+<?php
+declare(strict_types=1);
+
+namespace Buckaroo\Magento2\Test\Unit\Model\Push;
+
+use Buckaroo\Magento2\Model\BuckarooStatusCode;
+use Buckaroo\Magento2\Model\Push\PushTransactionType;
+use Buckaroo\Magento2\Test\Unit\Stubs\PushRequestInterfaceStub;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+class PushTransactionTypeTest extends \Buckaroo\Magento2\Test\BaseTest
+{
+    protected $instanceClass = 'Buckaroo\Magento2\Model\Push\PushTransactionType';
+
+    public function getInstance(array $args = [])
+    {
+        // Use the real status code map so key/message derivation is actually computed.
+        return parent::getInstance($args + ['buckarooStatusCode' => new BuckarooStatusCode()]);
+    }
+
+    /**
+     * Build a push request double. Keys of $data are getter names, values their returns.
+     * The 'additionalInformation' key is a name => value map for getAdditionalInformation().
+     */
+    private function createPushRequest(array $data = [])
+    {
+        $defaults = [
+            'getTransactionMethod'                     => null,
+            'getPrimaryService'                        => null,
+            'getStatusCode'                            => null,
+            'getTransactionType'                       => null,
+            'getDatarequest'                           => null,
+            'getInvoicekey'                            => null,
+            'getSchemekey'                             => null,
+            'getServiceCreditmanagement3Invoicekey'    => null,
+            'getEventparametersStatuscode'             => null,
+            'getEventparametersTransactionstatuscode'  => null,
+            'getAmountCredit'                          => null,
+        ];
+
+        $additionalInformation = $data['additionalInformation'] ?? [];
+        unset($data['additionalInformation']);
+
+        $mock = $this->getFakeMock(PushRequestInterfaceStub::class)->getMock();
+        foreach (array_merge($defaults, $data) as $method => $value) {
+            $mock->method($method)->willReturn($value);
+        }
+        $mock->method('getAdditionalInformation')->willReturnCallback(
+            function (string $name) use ($additionalInformation) {
+                return $additionalInformation[$name] ?? null;
+            }
+        );
+
+        return $mock;
+    }
+
+    private function createOrder(string $savedCm3InvoiceKey = '', bool $isCanceled = false)
+    {
+        $paymentMock = $this->getFakeMock('Magento\Sales\Model\Order\Payment')->getMock();
+        $paymentMock->method('getAdditionalInformation')
+            ->with('buckaroo_cm3_invoice_key')
+            ->willReturn($savedCm3InvoiceKey);
+
+        $orderMock = $this->getFakeMock('Magento\Sales\Model\Order')->getMock();
+        $orderMock->method('getPayment')->willReturn($paymentMock);
+        $orderMock->method('isCanceled')->willReturn($isCanceled);
+
+        return $orderMock;
+    }
+
+    public function testDerivesTransactionPushWithSuccessStatus(): void
+    {
+        $instance = $this->getInstance();
+
+        $pushRequest = $this->createPushRequest([
+            'getTransactionMethod' => 'ideal',
+            'getStatusCode'        => '190',
+            'getTransactionType'   => 'C021',
+        ]);
+
+        $instance->getPushTransactionType($pushRequest, $this->createOrder());
+
+        $this->assertSame(PushTransactionType::BUCK_PUSH_TYPE_TRANSACTION, $instance->getPushType());
+        $this->assertSame(190, $instance->getStatusCode());
+        $this->assertSame('BUCKAROO_MAGENTO2_STATUSCODE_SUCCESS', $instance->getStatusKey());
+        $this->assertSame('Success', $instance->getStatusMessage());
+        $this->assertSame('ideal', $instance->getPaymentMethod());
+        $this->assertFalse($instance->isGroupTransaction());
+        $this->assertFalse($instance->isCreditManagment());
+        $this->assertFalse($instance->isFromPayPerEmail());
+        $this->assertNull($instance->getServiceAction());
+    }
+
+    public function testUsesPrimaryServiceWhenTransactionMethodIsMissing(): void
+    {
+        $instance = $this->getInstance();
+
+        $pushRequest = $this->createPushRequest([
+            'getTransactionMethod' => null,
+            'getPrimaryService'    => 'KlarnaKp',
+            'getStatusCode'        => '190',
+        ]);
+
+        $instance->getPushTransactionType($pushRequest, $this->createOrder());
+
+        $this->assertSame('KlarnaKp', $instance->getPaymentMethod());
+    }
+
+    public function testDerivesInvoicePushWhenCm3InvoiceKeyIsSaved(): void
+    {
+        $instance = $this->getInstance();
+
+        $pushRequest = $this->createPushRequest([
+            'getInvoicekey'                => 'INVOICE-KEY',
+            'getSchemekey'                 => 'SCHEME-KEY',
+            'getEventparametersStatuscode' => '791',
+        ]);
+
+        $instance->getPushTransactionType($pushRequest, $this->createOrder('SAVED-CM3-KEY'));
+
+        $this->assertSame(PushTransactionType::BUCK_PUSH_TYPE_INVOICE, $instance->getPushType());
+        $this->assertTrue($instance->isCreditManagment());
+        $this->assertSame(791, $instance->getStatusCode());
+        $this->assertSame('BUCKAROO_MAGENTO2_STATUSCODE_PENDING_PROCESSING', $instance->getStatusKey());
+        $this->assertSame('Waiting for processor', $instance->getStatusMessage());
+    }
+
+    public function testEventTransactionStatusCodeOverridesEventStatusCodeForInvoicePush(): void
+    {
+        $instance = $this->getInstance();
+
+        $pushRequest = $this->createPushRequest([
+            'getInvoicekey'                           => 'INVOICE-KEY',
+            'getSchemekey'                            => 'SCHEME-KEY',
+            'getEventparametersStatuscode'            => '791',
+            'getEventparametersTransactionstatuscode' => '190',
+        ]);
+
+        $instance->getPushTransactionType($pushRequest, $this->createOrder('SAVED-CM3-KEY'));
+
+        $this->assertSame(190, $instance->getStatusCode());
+        $this->assertSame('BUCKAROO_MAGENTO2_STATUSCODE_SUCCESS', $instance->getStatusKey());
+    }
+
+    public function testDerivesIncompleteInvoicePushWhenNoCm3InvoiceKeySaved(): void
+    {
+        $instance = $this->getInstance();
+
+        $pushRequest = $this->createPushRequest([
+            'getInvoicekey' => 'INVOICE-KEY',
+            'getSchemekey'  => 'SCHEME-KEY',
+        ]);
+
+        $instance->getPushTransactionType($pushRequest, $this->createOrder(''));
+
+        $this->assertSame(PushTransactionType::BUCK_PUSH_TYPE_INVOICE_INCOMPLETE, $instance->getPushType());
+        $this->assertFalse($instance->isCreditManagment());
+    }
+
+    public function testDerivesDatarequestPush(): void
+    {
+        $instance = $this->getInstance();
+
+        $pushRequest = $this->createPushRequest([
+            'getDatarequest' => 'DATAREQUEST-KEY',
+            'getStatusCode'  => '890',
+        ]);
+
+        $instance->getPushTransactionType($pushRequest, $this->createOrder());
+
+        $this->assertSame(PushTransactionType::BUCK_PUSH_TYPE_DATAREQUEST, $instance->getPushType());
+        $this->assertSame(890, $instance->getStatusCode());
+        $this->assertSame('BUCKAROO_MAGENTO2_STATUSCODE_CANCELLED_BY_USER', $instance->getStatusKey());
+        $this->assertSame('Cancelled by consumer', $instance->getStatusMessage());
+    }
+
+    public function testUnmatchedPushTypeStillFallsBackToSuccessStatusCode(): void
+    {
+        $instance = $this->getInstance();
+
+        // No invoice key, no datarequest, but an order that already has a cm3 invoice key:
+        // none of the push type branches match, so the push type is empty.
+        $pushRequest = $this->createPushRequest([
+            'getStatusCode' => '190',
+        ]);
+
+        $instance->getPushTransactionType($pushRequest, $this->createOrder('SAVED-CM3-KEY'));
+
+        $this->assertSame('', $instance->getPushType());
+        $this->assertSame(190, $instance->getStatusCode());
+        $this->assertSame('BUCKAROO_MAGENTO2_STATUSCODE_SUCCESS', $instance->getStatusKey());
+    }
+
+    public function testUnknownStatusCodeResolvesToNeutralKey(): void
+    {
+        $instance = $this->getInstance();
+
+        $pushRequest = $this->createPushRequest([
+            'getStatusCode' => '12345',
+        ]);
+
+        $instance->getPushTransactionType($pushRequest, $this->createOrder());
+
+        $this->assertSame(12345, $instance->getStatusCode());
+        $this->assertSame('BUCKAROO_MAGENTO2_STATUSCODE_NEUTRAL', $instance->getStatusKey());
+        $this->assertSame('Onbekende responsecode: 12345', $instance->getStatusMessage());
+    }
+
+    public function testGroupTransactionIsDetectedFromI150TransactionType(): void
+    {
+        $instance = $this->getInstance();
+
+        $pushRequest = $this->createPushRequest([
+            'getStatusCode'      => '190',
+            'getTransactionType' => PushTransactionType::BUCK_PUSH_GROUPTRANSACTION_TYPE,
+        ]);
+
+        $instance->getPushTransactionType($pushRequest, $this->createOrder());
+
+        $this->assertTrue($instance->isGroupTransaction());
+    }
+
+    public function testServiceActionComesFromMagentoAdditionalInformation(): void
+    {
+        $instance = $this->getInstance();
+
+        $pushRequest = $this->createPushRequest([
+            'getStatusCode'         => '190',
+            'additionalInformation' => ['service_action_from_magento' => 'capture'],
+        ]);
+
+        $instance->getPushTransactionType($pushRequest, $this->createOrder());
+
+        $this->assertSame('capture', $instance->getServiceAction());
+    }
+
+    public function testServiceActionBecomesRefundForCreditAmountOnSuccessfulPush(): void
+    {
+        $instance = $this->getInstance();
+
+        $pushRequest = $this->createPushRequest([
+            'getStatusCode'   => '190',
+            'getAmountCredit' => '10.00',
+        ]);
+
+        $instance->getPushTransactionType($pushRequest, $this->createOrder());
+
+        $this->assertSame('refund', $instance->getServiceAction());
+    }
+
+    public function testServiceActionBecomesCancelAuthorizeForCanceledAuthorization(): void
+    {
+        $instance = $this->getInstance();
+
+        $pushRequest = $this->createPushRequest([
+            'getStatusCode'      => '890',
+            'getAmountCredit'    => '10.00',
+            'getTransactionType' => PushTransactionType::BUCK_PUSH_CANCEL_AUTHORIZE_TYPE,
+        ]);
+
+        $instance->getPushTransactionType($pushRequest, $this->createOrder('', true));
+
+        $this->assertSame('cancel_authorize', $instance->getServiceAction());
+    }
+
+    public function testServiceActionStaysRefundWhenOrderIsNotCanceled(): void
+    {
+        $instance = $this->getInstance();
+
+        $pushRequest = $this->createPushRequest([
+            'getStatusCode'      => '890',
+            'getAmountCredit'    => '10.00',
+            'getTransactionType' => PushTransactionType::BUCK_PUSH_CANCEL_AUTHORIZE_TYPE,
+        ]);
+
+        $instance->getPushTransactionType($pushRequest, $this->createOrder('', false));
+
+        $this->assertSame('refund', $instance->getServiceAction());
+    }
+
+    public static function payPerEmailOriginProvider(): array
+    {
+        return [
+            'frompayperemail additional information flag' => [
+                ['frompayperemail' => '1'],
+                true,
+            ],
+            'service action frompayperemail' => [
+                ['service_action_from_magento' => 'frompayperemail'],
+                true,
+            ],
+            'service action frompaylink' => [
+                ['service_action_from_magento' => 'frompaylink'],
+                true,
+            ],
+            'regular push is not from payperemail' => [
+                [],
+                false,
+            ],
+        ];
+    }
+
+    #[DataProvider('payPerEmailOriginProvider')]
+    public function testIsFromPayPerEmailDetection(array $additionalInformation, bool $expected): void
+    {
+        $instance = $this->getInstance();
+
+        $pushRequest = $this->createPushRequest([
+            'getStatusCode'         => '190',
+            'additionalInformation' => $additionalInformation,
+        ]);
+
+        $instance->getPushTransactionType($pushRequest, $this->createOrder());
+
+        $this->assertSame($expected, $instance->isFromPayPerEmail());
+    }
+
+    public function testStateIsOnlyInitializedOnce(): void
+    {
+        $instance = $this->getInstance();
+
+        $firstPushRequest = $this->createPushRequest([
+            'getTransactionMethod' => 'ideal',
+            'getStatusCode'        => '190',
+        ]);
+        $secondPushRequest = $this->createPushRequest([
+            'getTransactionMethod' => 'klarnakp',
+            'getStatusCode'        => '490',
+        ]);
+
+        $instance->getPushTransactionType($firstPushRequest, $this->createOrder());
+        $instance->getPushTransactionType($secondPushRequest, $this->createOrder());
+
+        $this->assertSame('ideal', $instance->getPaymentMethod());
+        $this->assertSame(190, $instance->getStatusCode());
+    }
+}

--- a/Test/Unit/Model/Refund/PushRequestStub.php
+++ b/Test/Unit/Model/Refund/PushRequestStub.php
@@ -5,6 +5,12 @@ namespace Buckaroo\Magento2\Test\Unit\Model\Refund;
 
 use Buckaroo\Magento2\Api\Data\PushRequestInterface;
 
+/**
+ * Fixed-value implementation of PushRequestInterface for refund push tests.
+ * Interface-mandated parameters are intentionally unused.
+ *
+ * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+ */
 abstract class PushRequestStub implements PushRequestInterface
 {
     public function hasAdditionalInformation($key, $value)

--- a/Test/Unit/Model/Refund/PushTest.php
+++ b/Test/Unit/Model/Refund/PushTest.php
@@ -86,15 +86,7 @@ class PushTest extends \Buckaroo\Magento2\Test\BaseTest
 
     public function testReceiveRefundPushSuccess()
     {
-        $postDataMock = $this->getMockForAbstractClass(
-            PushRequestInterface::class,
-            [],
-            '',
-            true,
-            true,
-            true,
-            ['getTransactions', 'getAdditionalInformation', 'getTransactionMethod', 'getTransactionType', 'getAmountCredit', 'hasAdditionalInformation', 'getCurrency', 'getStatusCode', 'getStatusMessage']
-        );
+        $postDataMock = $this->createMock(\Buckaroo\Magento2\Test\Unit\Stubs\PushRequestInterfaceStub::class);
 
         $postDataMock->method('getTransactions')->willReturn('trans123');
         $postDataMock->method('getAdditionalInformation')->willReturn(null);
@@ -147,7 +139,7 @@ class PushTest extends \Buckaroo\Magento2\Test\BaseTest
 
     public function testReceiveRefundPushDisabled()
     {
-        $postDataMock = $this->getMockForAbstractClass(PushRequestInterface::class);
+        $postDataMock = $this->createMock(PushRequestInterface::class);
         $orderMock = $this->getFakeMock(Order::class)->getMock();
 
         $this->configRefundMock->method('getAllowPush')->willReturn(false);
@@ -162,7 +154,7 @@ class PushTest extends \Buckaroo\Magento2\Test\BaseTest
 
     public function testReceiveRefundPushExistingCreditmemo()
     {
-        $postDataMock = $this->getMockForAbstractClass(
+        $postDataMock = $this->createMock(
             PushRequestInterface::class,
             [],
             '',
@@ -190,7 +182,7 @@ class PushTest extends \Buckaroo\Magento2\Test\BaseTest
 
     public function testReceiveRefundPushInvalidSignature()
     {
-        $postDataMock = $this->getMockForAbstractClass(PushRequestInterface::class);
+        $postDataMock = $this->createMock(PushRequestInterface::class);
         $orderMock = $this->getFakeMock(Order::class)->getMock();
         $orderMock->method('canCreditmemo')->willReturn(false);
 
@@ -207,15 +199,7 @@ class PushTest extends \Buckaroo\Magento2\Test\BaseTest
     public function testCreateCreditmemoFailure()
     {
         // Test the actual functionality - when createCreditmemo returns false
-        $postDataMock = $this->getMockForAbstractClass(
-            PushRequestInterface::class,
-            [],
-            '',
-            true,
-            true,
-            true,
-            ['getAmountCredit', 'getCurrency']
-        );
+        $postDataMock = $this->createMock(\Buckaroo\Magento2\Test\Unit\Stubs\PushRequestInterfaceStub::class);
         $postDataMock->method('getAmountCredit')->willReturn(100.0);
         $postDataMock->method('getCurrency')->willReturn('EUR');
 

--- a/Test/Unit/Model/Refund/PushTest.php
+++ b/Test/Unit/Model/Refund/PushTest.php
@@ -154,15 +154,7 @@ class PushTest extends \Buckaroo\Magento2\Test\BaseTest
 
     public function testReceiveRefundPushExistingCreditmemo()
     {
-        $postDataMock = $this->createMock(
-            PushRequestInterface::class,
-            [],
-            '',
-            true,
-            true,
-            true,
-            ['getTransactions']
-        );
+        $postDataMock = $this->createMock(PushRequestInterface::class);
         $postDataMock->method('getTransactions')->willReturn('trans123');
 
         $creditmemoCollectionMock = $this->getFakeMock(\Magento\Sales\Model\ResourceModel\Order\Creditmemo\Collection::class)->getMock();

--- a/Test/Unit/Model/SecondChanceRepositoryTest.php
+++ b/Test/Unit/Model/SecondChanceRepositoryTest.php
@@ -20,6 +20,8 @@
 
 namespace Buckaroo\Magento2\Test\Unit\Model;
 
+
+use PHPUnit\Framework\Attributes\DataProvider;
 use Buckaroo\Magento2\Model\SecondChanceRepository;
 use Buckaroo\Magento2\Model\SecondChanceFactory;
 use Buckaroo\Magento2\Model\ResourceModel\SecondChance as ResourceSecondChance;
@@ -134,8 +136,8 @@ class SecondChanceRepositoryTest extends \Buckaroo\Magento2\Test\BaseTest
      * @param string $paymentMethod
      * @param int    $expectedCalls
      *
-     * @dataProvider createSecondChanceProvider
      */
+    #[DataProvider('createSecondChanceProvider')]
     public function testCreateSecondChance($secondChanceEnabled, $paymentMethod, $expectedCalls)
     {
         $store = $this->getFakeMock(Store::class, true);
@@ -164,7 +166,7 @@ class SecondChanceRepositoryTest extends \Buckaroo\Magento2\Test\BaseTest
             $order->method('getCustomerEmail')->willReturn('test@example.com');
 
             // Create proper mock for the interface using getMockForAbstractClass to handle all abstract methods
-            $secondChanceData = $this->getMockForAbstractClass(\Buckaroo\Magento2\Api\Data\SecondChanceInterface::class);
+            $secondChanceData = $this->createMock(\Buckaroo\Magento2\Api\Data\SecondChanceInterface::class);
             $secondChanceData->method('setOrderId')->willReturn($secondChanceData);
             $secondChanceData->method('setStoreId')->willReturn($secondChanceData);
             $secondChanceData->method('setCustomerEmail')->willReturn($secondChanceData);
@@ -189,7 +191,7 @@ class SecondChanceRepositoryTest extends \Buckaroo\Magento2\Test\BaseTest
             // For cases where expectedCalls = 0, ensure factory and resource are set up properly
             $secondChanceDataFactory = $this->getFakeMock(SecondChanceInterfaceFactory::class, true);
             // Still need to return a valid mock even when not saving, as the method may still call create()
-            $secondChanceData = $this->getMockForAbstractClass(\Buckaroo\Magento2\Api\Data\SecondChanceInterface::class);
+            $secondChanceData = $this->createMock(\Buckaroo\Magento2\Api\Data\SecondChanceInterface::class);
             $secondChanceData->method('setOrderId')->willReturn($secondChanceData);
             $secondChanceData->method('setStoreId')->willReturn($secondChanceData);
             $secondChanceData->method('setCustomerEmail')->willReturn($secondChanceData);
@@ -278,8 +280,8 @@ class SecondChanceRepositoryTest extends \Buckaroo\Magento2\Test\BaseTest
      * @param array $stockData
      * @param bool  $expectedResult
      *
-     * @dataProvider checkOrderProductsIsInStockProvider
      */
+    #[DataProvider('checkOrderProductsIsInStockProvider')]
     public function testCheckOrderProductsIsInStock($orderItems, $stockData, $expectedResult)
     {
         $order = $this->getFakeMock(Order::class, true);
@@ -331,9 +333,9 @@ class SecondChanceRepositoryTest extends \Buckaroo\Magento2\Test\BaseTest
      * @param int    $step
      * @param string $expectedTemplate
      *
-     * @dataProvider sendMailProvider
      * @SuppressWarnings(PHPMD.ExcessiveMethodLength)
      */
+    #[DataProvider('sendMailProvider')]
     public function testSendMail($step, $expectedTemplate)
     {
         $order = $this->getFakeMock(Order::class, true);

--- a/Test/Unit/Model/Total/Creditmemo/BuckarooFeeTest.php
+++ b/Test/Unit/Model/Total/Creditmemo/BuckarooFeeTest.php
@@ -21,9 +21,9 @@
 
 namespace Buckaroo\Magento2\Test\Unit\Model\Total\Creditmemo;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use Magento\Sales\Model\Order;
 use Magento\Sales\Model\Order\Creditmemo;
-use Magento\Sales\Model\Order\Invoice;
 use Buckaroo\Magento2\Model\Total\Creditmemo\BuckarooFee;
 use Buckaroo\Magento2\Test\BaseTest;
 
@@ -74,15 +74,10 @@ class BuckarooFeeTest extends BaseTest
      * @param $feerefunded
      * @param $expectedGrandTotal
      * @param $expectedTotalRefunded
-     *
-     * @dataProvider collectProvider
      */
+    #[DataProvider('collectProvider')]
     public function testCollect($fee, $feeinvoiced, $feerefunded, $expectedGrandTotal, $expectedTotalRefunded)
     {
-        // Use parameters to avoid PHPMD warnings
-        $this->assertIsNumeric($expectedGrandTotal, 'Expected grand total should be numeric');
-        $this->assertIsNumeric($expectedTotalRefunded, 'Expected total refunded should be numeric');
-
         // Mock Payment
         $paymentMock = $this->getFakeMock(\Magento\Sales\Model\Order\Payment::class)
             ->onlyMethods(['getMethod'])
@@ -90,48 +85,37 @@ class BuckarooFeeTest extends BaseTest
         $paymentMock->method('getMethod')->willReturn('buckaroo_magento2_ideal');
 
         // Mock CreditmemoCollection
-        $creditmemoCollectionMock = $this->createMock(\Magento\Sales\Model\ResourceModel\Order\Creditmemo\Collection::class);
+        $creditmemoCollectionMock =
+            $this->createMock(\Magento\Sales\Model\ResourceModel\Order\Creditmemo\Collection::class);
 
-        // Mock Order with proper method tracking
+        // Partial Order mock: getPayment/getCreditmemosCollection are mocked, the buckaroo
+        // fee fields go through the real DataObject magic getters/setters so collect()
+        // mutates real state we can assert on afterwards.
         $orderMock = $this->getFakeMock(Order::class)
-            ->addMethods([
-                'getBaseBuckarooFeeInvoiced', 'getBaseBuckarooFeeRefunded', 'getBuckarooFeeRefunded',
-                'setBaseBuckarooFeeRefunded', 'setBuckarooFeeRefunded'
-            ])
             ->onlyMethods(['getPayment', 'getCreditmemosCollection'])
             ->getMock();
-
         $orderMock->method('getPayment')->willReturn($paymentMock);
         $orderMock->method('getCreditmemosCollection')->willReturn($creditmemoCollectionMock);
-        $orderMock->method('getBaseBuckarooFeeInvoiced')->willReturn($feeinvoiced);
-        $orderMock->method('getBaseBuckarooFeeRefunded')->willReturn($feerefunded);
-        $orderMock->method('getBuckarooFeeRefunded')->willReturn($feerefunded);
+        $orderMock->setBaseBuckarooFeeInvoiced($feeinvoiced);
+        $orderMock->setBaseBuckarooFeeRefunded($feerefunded);
+        $orderMock->setBuckarooFeeRefunded($feerefunded);
 
-        // Mock Invoice
-        $invoiceMock = $this->getFakeMock(Invoice::class)
-            ->addMethods(['getBaseBuckarooFee', 'getBuckarooFee'])
+        // Invoice mock: the invoiced buckaroo fee amounts drive the calculation.
+        $invoiceMock = $this->getFakeMock(\Buckaroo\Magento2\Test\Unit\Stubs\InvoiceStub::class)
+            ->onlyMethods(['getBaseBuckarooFee', 'getBuckarooFee'])
             ->getMock();
         $invoiceMock->method('getBaseBuckarooFee')->willReturn($fee);
         $invoiceMock->method('getBuckarooFee')->willReturn($fee);
 
-        // Mock Creditmemo
+        // Partial Creditmemo mock: only the order/invoice lookups are mocked, the grand
+        // totals and buckaroo fee fields use the real (stateful) implementation.
         $creditmemoMock = $this->getFakeMock(Creditmemo::class)
-            ->addMethods([
-                'getBaseBuckarooFee', 'getBuckarooFee', 'setBaseBuckarooFee', 'setBuckarooFee'
-            ])
-            ->onlyMethods(['getOrder', 'getInvoice', 'getBaseGrandTotal', 'getGrandTotal', 'setBaseGrandTotal', 'setGrandTotal'])
+            ->onlyMethods(['getOrder', 'getInvoice'])
             ->getMock();
-
         $creditmemoMock->method('getOrder')->willReturn($orderMock);
         $creditmemoMock->method('getInvoice')->willReturn($invoiceMock);
-
-        // Set initial values
-        $initialGrandTotal = 100;
-        $initialBaseGrandTotal = 100;
-        $creditmemoMock->method('getGrandTotal')->willReturn($initialGrandTotal);
-        $creditmemoMock->method('getBaseGrandTotal')->willReturn($initialBaseGrandTotal);
-        $creditmemoMock->method('getBaseBuckarooFee')->willReturn(0);
-        $creditmemoMock->method('getBuckarooFee')->willReturn(0);
+        $creditmemoMock->setGrandTotal(0);
+        $creditmemoMock->setBaseGrandTotal(0);
 
         // Mock Request (use HTTP request which has getPost method)
         $requestMock = $this->createMock(\Magento\Framework\App\Request\Http::class);
@@ -141,8 +125,36 @@ class BuckarooFeeTest extends BaseTest
         $result = $instance->collect($creditmemoMock);
 
         $this->assertInstanceOf(BuckarooFee::class, $result);
-
-        // Test passes if no exceptions are thrown and the method returns self
         $this->assertSame($instance, $result);
+
+        // The creditmemo grand totals must be raised by exactly the refundable fee.
+        $this->assertEquals(
+            $expectedGrandTotal,
+            $creditmemoMock->getGrandTotal(),
+            'Creditmemo grand total should equal initial total plus the refundable buckaroo fee'
+        );
+        $this->assertEquals(
+            $expectedGrandTotal,
+            $creditmemoMock->getBaseGrandTotal(),
+            'Creditmemo base grand total should equal initial total plus the refundable base buckaroo fee'
+        );
+
+        // The order refunded-fee counters must be increased by the refunded fee.
+        $this->assertEquals(
+            $expectedTotalRefunded,
+            $orderMock->getBaseBuckarooFeeRefunded(),
+            'Order base_buckaroo_fee_refunded should be increased by the refunded base fee'
+        );
+        $this->assertEquals(
+            $expectedTotalRefunded,
+            $orderMock->getBuckarooFeeRefunded(),
+            'Order buckaroo_fee_refunded should be increased by the refunded fee'
+        );
+
+        // When a fee is actually refunded it must also be written onto the creditmemo itself.
+        if ($fee && $feeinvoiced > $feerefunded) {
+            $this->assertEquals($fee, $creditmemoMock->getBaseBuckarooFee());
+            $this->assertEquals($fee, $creditmemoMock->getBuckarooFee());
+        }
     }
 }

--- a/Test/Unit/Model/Total/Creditmemo/Tax/BuckarooFeeTest.php
+++ b/Test/Unit/Model/Total/Creditmemo/Tax/BuckarooFeeTest.php
@@ -21,6 +21,8 @@
 
 namespace Buckaroo\Magento2\Test\Unit\Model\Total\Creditmemo\Tax;
 
+
+use PHPUnit\Framework\Attributes\DataProvider;
 use Magento\Sales\Model\Order;
 use Magento\Sales\Model\Order\Creditmemo;
 use Magento\Sales\Model\Order\Invoice;
@@ -68,17 +70,12 @@ class BuckarooFeeTest extends BaseTest
      * @param $expectedGrandTotal
      * @param $expectedTotalRefunded
      *
-     * @dataProvider collectProvider
      */
+    #[DataProvider('collectProvider')]
     public function testCollect($tax, $taxinvoiced, $taxrefunded, $expectedGrandTotal, $expectedTotalRefunded)
     {
-        $orderMock = $this->getFakeMock(Order::class)
-            ->addMethods([
-                'getBuckarooFeeBaseTaxAmountInvoiced',
-                'getBuckarooFeeBaseTaxAmountRefunded',
-                'setBuckarooFeeBaseTaxAmountRefunded'
-            ])
-            ->getMock();
+        $orderMock = $this->getFakeMock(\Buckaroo\Magento2\Test\Unit\Stubs\OrderStub::class)
+            ->onlyMethods(['getBuckarooFeeBaseTaxAmountInvoiced', 'getBuckarooFeeBaseTaxAmountRefunded', 'setBuckarooFeeBaseTaxAmountRefunded'])->getMock();
         $orderMock->setBuckarooFeeBaseTaxAmountInvoiced($taxinvoiced);
         $orderMock->setBuckarooFeeBaseTaxAmountRefunded($taxrefunded);
         $orderMock->setBuckarooFeeTaxAmountRefunded($taxrefunded);
@@ -97,12 +94,8 @@ class BuckarooFeeTest extends BaseTest
             $initialRefunded = $value;
         });
 
-        $invoiceMock = $this->getFakeMock(Invoice::class)
-            ->addMethods([
-                'getBuckarooFeeBaseTaxAmount',
-                'getBuckarooFeeTaxAmount'
-            ])
-            ->getMock();
+        $invoiceMock = $this->getFakeMock(\Buckaroo\Magento2\Test\Unit\Stubs\InvoiceStub::class)
+            ->onlyMethods(['getBuckarooFeeBaseTaxAmount', 'getBuckarooFeeTaxAmount'])->getMock();
         $invoiceMock->setBuckarooFeeBaseTaxAmount($tax);
         $invoiceMock->setBuckarooFeeTaxAmount($tax);
 

--- a/Test/Unit/Model/Total/Quote/BuckarooFeeTest.php
+++ b/Test/Unit/Model/Total/Quote/BuckarooFeeTest.php
@@ -20,18 +20,17 @@
  */
 namespace Buckaroo\Magento2\Test\Unit\Model\Total\Quote;
 
-use Magento\Catalog\Helper\Data;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Magento\Framework\Pricing\PriceCurrencyInterface;
 use Magento\Quote\Api\Data\ShippingAssignmentInterface;
+use Magento\Quote\Api\Data\ShippingInterface;
 use Magento\Quote\Model\Quote;
-use Magento\Quote\Model\Quote\Address\Total;
-use Buckaroo\Magento2\Model\Config\Source\TaxClass\Calculation;
-use Buckaroo\Magento2\Model\ConfigProvider\Account;
-use Buckaroo\Magento2\Model\ConfigProvider\BuckarooFee as ConfigProviderBuckarooFee;
-use Buckaroo\Magento2\Model\ConfigProvider\Factory;
-use Buckaroo\Magento2\Model\Method\BuckarooAdapter;
+use Buckaroo\Magento2\Helper\PaymentGroupTransaction;
 use Buckaroo\Magento2\Model\Total\Quote\BuckarooFee;
 use Buckaroo\Magento2\Service\BuckarooFee\Calculate;
+use Buckaroo\Magento2\Test\Unit\Stubs\QuoteStub;
+use Buckaroo\Magento2\Test\Unit\Stubs\StdObjectStub;
+use Buckaroo\Magento2\Test\Unit\Stubs\TotalStub;
 
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
@@ -40,312 +39,276 @@ class BuckarooFeeTest extends \Buckaroo\Magento2\Test\BaseTest
 {
     protected $instanceClass = BuckarooFee::class;
 
-    public function testGetBaseFeeReturnFalseForANonExistingConfigProvider()
+    /**
+     * Build a shipping assignment mock. Its shipping address is needed by
+     * AbstractTotal::collect(), which runs before any Buckaroo logic.
+     *
+     * @param bool $hasItems
+     *
+     * @return \PHPUnit\Framework\MockObject\MockObject
+     */
+    private function getShippingAssignmentMock($hasItems = true)
     {
-        $paymentCode = 'buckaroo_magento2_non_existing';
+        $addressMock = $this->getFakeMock(\Magento\Quote\Model\Quote\Address::class, true);
 
-        $paymentMethodMock = $this->getFakeMock(BuckarooAdapter::class, false)
-            ->addMethods(['getBuckarooPaymentMethodCode'])
-            ->getMock();
-        $paymentMethodMock->method('getBuckarooPaymentMethodCode')->willReturn($paymentCode);
-
-        $quoteMock = $this->getFakeMock(Quote::class, false)
-            ->onlyMethods(['getShippingAddress', 'getPayment'])
-            ->getMock();
-
-        $addressMock = $this->getFakeMock(\Magento\Quote\Model\Quote\Address::class, false)->getMock();
-        $quoteMock->method('getShippingAddress')->willReturn($addressMock);
-
-        $paymentMock = $this->getFakeMock(\Magento\Quote\Model\Quote\Payment::class, false)
-            ->onlyMethods(['getMethod', 'getMethodInstance'])
-            ->getMock();
-        $quoteMock->method('getPayment')->willReturn($paymentMock);
-        $paymentMock->method('getMethod')->willReturn($paymentCode);
-        $paymentMock->method('getMethodInstance')->willReturn($paymentMethodMock);
-
-        $shippingAssignmentMock = $this->getFakeMock(ShippingAssignmentInterface::class, false)
-            ->onlyMethods(['getItems', 'getShipping'])
-            ->getMockForAbstractClass();
-        $shippingAssignmentMock->method('getItems')->willReturn(true);
-
-        $shippingMock = $this->getFakeMock(\Magento\Quote\Api\Data\ShippingInterface::class, false)->getMockForAbstractClass();
+        $shippingMock = $this->getFakeMock(ShippingInterface::class, true);
         $shippingMock->method('getAddress')->willReturn($addressMock);
+
+        $shippingAssignmentMock = $this->getFakeMock(ShippingAssignmentInterface::class, true);
+        $shippingAssignmentMock->method('getItems')->willReturn($hasItems ? [new \stdClass()] : []);
         $shippingAssignmentMock->method('getShipping')->willReturn($shippingMock);
 
-        $totalMock = $this->getFakeMock(Total::class, false)
-            ->addMethods(['setBuckarooFee', 'setBaseBuckarooFee'])
-            ->getMock();
-        $totalMock->method('setBuckarooFee')->willReturn(0);
-        $totalMock->method('setBaseBuckarooFee')->willReturn(0);
-
-        $feeResultMock = $this->getMockBuilder(\stdClass::class)
-            ->addMethods(['getAmount', 'getRoundedAmount'])
-            ->getMock();
-        $feeResultMock->method('getAmount')->willReturn(0.0);
-        $feeResultMock->method('getRoundedAmount')->willReturn(0.0);
-
-        $calculateMock = $this->getFakeMock(Calculate::class, false)
-            ->onlyMethods(['calculatePaymentFee'])
-            ->getMock();
-        $calculateMock->method('calculatePaymentFee')->willReturn($feeResultMock);
-
-        $instance = $this->getInstance(['calculate' => $calculateMock]);
-        $result = $instance->collect($quoteMock, $shippingAssignmentMock, $totalMock);
-
-        $this->assertEquals($instance, $result);
-    }
-
-    public function testGetBaseFeeReturnFalseForAnInvalidFeeValue()
-    {
-        $paymentCode = 'buckaroo_magento2_ideal';
-
-        $quoteMock = $this->getFakeMock(Quote::class, false)
-            ->onlyMethods(['getShippingAddress', 'getPayment'])
-            ->getMock();
-
-        $addressMock = $this->getFakeMock(\Magento\Quote\Model\Quote\Address::class, false)
-            ->addMethods(['getAddress'])
-            ->getMock();
-        $addressMock->method('getAddress')->willReturn($addressMock);
-
-        $quoteMock->method('getShippingAddress')->willReturn($addressMock);
-
-        $paymentMock = $this->getFakeMock(\Magento\Quote\Model\Quote\Payment::class, false)
-            ->onlyMethods(['getMethod', 'getMethodInstance'])
-            ->getMock();
-        $quoteMock->method('getPayment')->willReturn($paymentMock);
-        $paymentMock->method('getMethod')->willReturn($paymentCode);
-        $paymentMock->method('getMethodInstance')->willReturn(new \stdClass());
-
-        $feeResultMock = $this->getMockBuilder(\stdClass::class)
-            ->addMethods(['getAmount', 'getRoundedAmount'])
-            ->getMock();
-        $feeResultMock->method('getAmount')->willReturn(0.0);
-        $feeResultMock->method('getRoundedAmount')->willReturn(0.0);
-
-        $calculateMock = $this->getFakeMock(Calculate::class, false)->onlyMethods(['calculatePaymentFee'])->getMock();
-        $calculateMock->method('calculatePaymentFee')->willReturn($feeResultMock);
-
-        $shippingAssignmentMock = $this->getFakeMock(ShippingAssignmentInterface::class, false)
-            ->onlyMethods(['getItems', 'getShipping'])
-            ->getMockForAbstractClass();
-        $shippingAssignmentMock->method('getItems')->willReturn(true);
-
-        $shippingMock = $this->getFakeMock(\Magento\Quote\Api\Data\ShippingInterface::class, false)->getMockForAbstractClass();
-        $shippingMock->method('getAddress')->willReturn($addressMock);
-        $shippingAssignmentMock->method('getShipping')->willReturn($shippingMock);
-
-        $totalMock = $this->getFakeMock(Total::class, false)->getMock();
-
-        $instance = $this->getInstance(['calculate' => $calculateMock]);
-        $result = $instance->collect($quoteMock, $shippingAssignmentMock, $totalMock);
-
-        $this->assertEquals($instance, $result);
-    }
-
-    public function testGetBaseFeeReturnsConfigValueIfIsNumber()
-    {
-        $expectedFee = 1.89;
-
-        $quoteMock = $this->getFakeMock(Quote::class, false)
-            ->onlyMethods(['getShippingAddress'])
-            ->getMock();
-
-        $addressMock = $this->getFakeMock(\Magento\Quote\Model\Quote\Address::class, false)
-            ->addMethods(['getAddress'])
-            ->getMock();
-        $addressMock->method('getAddress')->willReturn($addressMock);
-
-        $quoteMock->method('getShippingAddress')->willReturn($addressMock);
-
-        $shippingAssignmentMock = $this->getFakeMock(ShippingAssignmentInterface::class, false)
-            ->onlyMethods(['getItems', 'getShipping'])
-            ->getMockForAbstractClass();
-        $shippingAssignmentMock->method('getItems')->willReturn(true);
-
-        $shippingMock = $this->getFakeMock(\Magento\Quote\Api\Data\ShippingInterface::class, false)->getMockForAbstractClass();
-        $shippingMock->method('getAddress')->willReturn($addressMock);
-        $shippingAssignmentMock->method('getShipping')->willReturn($shippingMock);
-
-        $totalMock = $this->getFakeMock(Total::class)
-            ->addMethods(['setBuckarooFee', 'setBaseBuckarooFee'])
-            ->getMock();
-        $totalMock->method('setBuckarooFee')->willReturn(0);
-        $totalMock->method('setBaseBuckarooFee')->willReturn(0);
-
-        $calculateMock = $this->getFakeMock(Calculate::class)
-            ->onlyMethods(['calculatePaymentFee'])
-            ->getMock();
-        $feeResultMock = $this->getMockBuilder(\stdClass::class)
-            ->addMethods(['getAmount', 'getRoundedAmount'])
-            ->getMock();
-        $feeResultMock->method('getAmount')->willReturn($expectedFee);
-        $feeResultMock->method('getRoundedAmount')->willReturn($expectedFee);
-        $calculateMock->method('calculatePaymentFee')->willReturn($feeResultMock);
-
-        $instance = $this->getInstance(['calculate' => $calculateMock]);
-        $result = $instance->collect($quoteMock, $shippingAssignmentMock, $totalMock);
-
-        $this->assertEquals($instance, $result);
+        return $shippingAssignmentMock;
     }
 
     /**
-     * @dataProvider baseFeePercentageDataProvider
+     * Build a Calculate service mock that must never be consulted.
      *
-     * @param mixed $paymentCode
-     * @param mixed $fee
-     * @param mixed $feeMode
-     * @param mixed $quoteMethod
-     * @param mixed $quoteAmount
-     * @param mixed $expectedValue
+     * @return \PHPUnit\Framework\MockObject\MockObject
      */
-    public function testGetBaseFeeCalculatesPercentageOnCorrectTotal(
-        $paymentCode,
-        $fee,
-        $feeMode,
-        $quoteMethod,
-        $quoteAmount,
-        $expectedValue
-    ) {
-        // Use all parameters to avoid PHPMD warnings - validate based on actual data types
-        $this->assertIsString($paymentCode, 'Payment code should be a string');
-        $this->assertIsString($fee, 'Fee should be a string (can contain percentage)');
-        $this->assertIsString($feeMode, 'Fee mode should be a string');
-        $this->assertIsString($quoteMethod, 'Quote method should be a string');
-        $this->assertIsNumeric($quoteAmount, 'Quote amount should be numeric');
-        $this->assertIsNumeric($expectedValue, 'Expected value should be numeric');
-
-        $quoteMock = $this->getFakeMock(Quote::class)
-            ->onlyMethods(['getShippingAddress'])
-            ->getMock();
-
-        $addressMock = $this->getFakeMock(\Magento\Quote\Model\Quote\Address::class)
-            ->addMethods(['getAddress'])
-            ->getMock();
-        $addressMock->method('getAddress')->willReturn($addressMock);
-
-        $quoteMock->method('getShippingAddress')->willReturn($addressMock);
-
-        $shippingAssignmentMock = $this->getFakeMock(ShippingAssignmentInterface::class)
-            ->onlyMethods(['getItems', 'getShipping'])
-            ->getMockForAbstractClass();
-        $shippingAssignmentMock->method('getItems')->willReturn(true);
-
-        $shippingMock = $this->getFakeMock(\Magento\Quote\Api\Data\ShippingInterface::class, false)->getMockForAbstractClass();
-        $shippingMock->method('getAddress')->willReturn($addressMock);
-        $shippingAssignmentMock->method('getShipping')->willReturn($shippingMock);
-
-        $totalMock = $this->getFakeMock(Total::class)->addMethods(['setBuckarooFee', 'setBaseBuckarooFee'])
-            ->getMock();
-        $totalMock->method('setBuckarooFee')->willReturn(0);
-        $totalMock->method('setBaseBuckarooFee')->willReturn(0);
-
+    private function getNeverCalledCalculateMock()
+    {
         $calculateMock = $this->getFakeMock(Calculate::class)
             ->onlyMethods(['calculatePaymentFee'])
             ->getMock();
-        $feeResultMock = $this->getMockBuilder(\stdClass::class)
-            ->addMethods(['getAmount', 'getRoundedAmount'])
-            ->getMock();
-        $feeResultMock->method('getAmount')->willReturn($expectedValue);
-        $feeResultMock->method('getRoundedAmount')->willReturn($expectedValue);
-        $calculateMock->method('calculatePaymentFee')->willReturn($feeResultMock);
+        $calculateMock->expects($this->never())->method('calculatePaymentFee');
 
-        $instance = $this->getInstance(['calculate' => $calculateMock]);
-        $result = $instance->collect($quoteMock, $shippingAssignmentMock, $totalMock);
-
-        $this->assertEquals($instance, $result);
+        return $calculateMock;
     }
 
-    /**
-     * @dataProvider baseFeePercentageDataProvider
-     *
-     * @param mixed $paymentCode
-     * @param mixed $fee
-     * @param mixed $feeMode
-     * @param mixed $quoteMethod
-     * @param mixed $quoteAmount
-     * @param mixed $expectedValue
-     */
-    public function testGetBaseFeeCalculatesPercentageOnCorrectTotalWithBillingAddress(
-        $paymentCode,
-        $fee,
-        $feeMode,
-        $quoteMethod,
-        $quoteAmount,
-        $expectedValue
-    ) {
-        // Use all parameters to avoid PHPMD warnings - validate based on actual data types
-        $this->assertIsString($paymentCode, 'Payment code should be a string');
-        $this->assertIsString($fee, 'Fee should be a string (can contain percentage)');
-        $this->assertIsString($feeMode, 'Fee mode should be a string');
-        $this->assertIsString($quoteMethod, 'Quote method should be a string');
-        $this->assertIsNumeric($quoteAmount, 'Quote amount should be numeric');
-        $this->assertIsNumeric($expectedValue, 'Expected value should be numeric');
-
-        $quoteMock = $this->getFakeMock(Quote::class)
-            ->onlyMethods(['getShippingAddress'])
+    public function testCollectReturnsSelfWithoutTouchingTotalsWhenThereAreNoShippingItems()
+    {
+        $quoteMock = $this->getFakeMock(QuoteStub::class)
+            ->onlyMethods(['setBuckarooFee', 'setBaseBuckarooFee'])
             ->getMock();
+        $quoteMock->expects($this->never())->method('setBuckarooFee');
+        $quoteMock->expects($this->never())->method('setBaseBuckarooFee');
 
-        $addressMock = $this->getFakeMock(\Magento\Quote\Model\Quote\Address::class)
-            ->addMethods(['getAddress'])
+        $totalMock = $this->getFakeMock(TotalStub::class)
+            ->onlyMethods(['setBuckarooFee', 'setBaseBuckarooFee', 'setGrandTotal', 'setBaseGrandTotal'])
             ->getMock();
-        $addressMock->method('getAddress')->willReturn($addressMock);
+        $totalMock->expects($this->never())->method('setBuckarooFee');
+        $totalMock->expects($this->never())->method('setBaseBuckarooFee');
+        $totalMock->expects($this->never())->method('setGrandTotal');
+        $totalMock->expects($this->never())->method('setBaseGrandTotal');
 
-        $quoteMock->method('getShippingAddress')->willReturn($addressMock);
+        $instance = $this->getInstance(['calculate' => $this->getNeverCalledCalculateMock()]);
+        $result = $instance->collect($quoteMock, $this->getShippingAssignmentMock(false), $totalMock);
 
-        $shippingAssignmentMock = $this->getFakeMock(ShippingAssignmentInterface::class)
-            ->onlyMethods(['getItems', 'getShipping'])
-            ->getMockForAbstractClass();
-        $shippingAssignmentMock->method('getItems')->willReturn(true);
+        $this->assertSame($instance, $result);
+    }
 
-        $shippingMock = $this->getFakeMock(\Magento\Quote\Api\Data\ShippingInterface::class, false)->getMockForAbstractClass();
-        $shippingMock->method('getAddress')->willReturn($addressMock);
-        $shippingAssignmentMock->method('getShipping')->willReturn($shippingMock);
+    public function testCollectOnlyResetsFeeTotalsWhenOrderIsAlreadyPartiallyPaid()
+    {
+        $reservedOrderId = '100000123';
 
-        $totalMock = $this->getFakeMock(Total::class)->addMethods(['setBuckarooFee', 'setBaseBuckarooFee'])
+        $quoteMock = $this->getFakeMock(QuoteStub::class)
+            ->onlyMethods(['getReservedOrderId', 'setBuckarooFee', 'setBaseBuckarooFee'])
             ->getMock();
-        $totalMock->method('setBuckarooFee')->willReturn(0);
-        $totalMock->method('setBaseBuckarooFee')->willReturn(0);
+        $quoteMock->method('getReservedOrderId')->willReturn($reservedOrderId);
+        $quoteMock->expects($this->never())->method('setBuckarooFee');
+        $quoteMock->expects($this->never())->method('setBaseBuckarooFee');
 
-        $calculateMock = $this->getFakeMock(Calculate::class)
-            ->onlyMethods(['calculatePaymentFee'])
+        $totalMock = $this->getFakeMock(TotalStub::class)
+            ->onlyMethods(['setBuckarooFee', 'setBaseBuckarooFee', 'setGrandTotal', 'setBaseGrandTotal'])
             ->getMock();
-        $feeResultMock = $this->getMockBuilder(\stdClass::class)
-            ->addMethods(['getAmount', 'getRoundedAmount'])
+        $totalMock->expects($this->once())->method('setBuckarooFee')->with(0)->willReturnSelf();
+        $totalMock->expects($this->once())->method('setBaseBuckarooFee')->with(0)->willReturnSelf();
+        $totalMock->expects($this->never())->method('setGrandTotal');
+        $totalMock->expects($this->never())->method('setBaseGrandTotal');
+
+        $groupTransactionMock = $this->getFakeMock(PaymentGroupTransaction::class)
+            ->onlyMethods(['getAlreadyPaid'])
             ->getMock();
-        $feeResultMock->method('getAmount')->willReturn($expectedValue);
-        $feeResultMock->method('getRoundedAmount')->willReturn($expectedValue);
-        $calculateMock->method('calculatePaymentFee')->willReturn($feeResultMock);
+        $groupTransactionMock->expects($this->once())
+            ->method('getAlreadyPaid')
+            ->with($reservedOrderId)
+            ->willReturn(10.0);
 
-        $instance = $this->getInstance(['calculate' => $calculateMock]);
-        $result = $instance->collect($quoteMock, $shippingAssignmentMock, $totalMock);
+        $instance = $this->getInstance([
+            'groupTransaction' => $groupTransactionMock,
+            'calculate' => $this->getNeverCalledCalculateMock(),
+        ]);
+        $result = $instance->collect($quoteMock, $this->getShippingAssignmentMock(), $totalMock);
 
-        $this->assertEquals($instance, $result);
+        $this->assertSame($instance, $result);
     }
 
     /**
      * @return array
      */
-    public static function baseFeePercentageDataProvider()
+    public static function nonChargeableFeeResultProvider()
     {
         return [
-            [
-                'buckaroo_magento2_ideal',
-                '10%',
-                'subtotal',
-                'getBaseSubtotal',
-                45.0000,
-                4.5000
+            'calculate returns null' => [null],
+            'fee amount is zero' => [0.0],
+            'fee amount below one cent' => [0.009],
+        ];
+    }
+
+    /**
+     * @param float|null $amount Calculated fee amount, null when Calculate returns no result at all.
+     */
+    #[DataProvider('nonChargeableFeeResultProvider')]
+    public function testCollectDoesNotChargeFeeWhenCalculateReturnsNoUsableFee($amount)
+    {
+        $feeResult = null;
+        if ($amount !== null) {
+            $feeResult = $this->getMockBuilder(StdObjectStub::class)->getMock();
+            $feeResult->method('getAmount')->willReturn($amount);
+            $feeResult->method('getRoundedAmount')->willReturn($amount);
+        }
+
+        $quoteMock = $this->getFakeMock(QuoteStub::class)
+            ->onlyMethods(['setBuckarooFee', 'setBaseBuckarooFee'])
+            ->getMock();
+        $quoteMock->expects($this->never())->method('setBuckarooFee');
+        $quoteMock->expects($this->never())->method('setBaseBuckarooFee');
+
+        $totalMock = $this->getFakeMock(TotalStub::class)
+            ->onlyMethods(['setBuckarooFee', 'setBaseBuckarooFee', 'setGrandTotal', 'setBaseGrandTotal'])
+            ->getMock();
+        $totalMock->expects($this->once())->method('setBuckarooFee')->with(0)->willReturnSelf();
+        $totalMock->expects($this->once())->method('setBaseBuckarooFee')->with(0)->willReturnSelf();
+        $totalMock->expects($this->never())->method('setGrandTotal');
+        $totalMock->expects($this->never())->method('setBaseGrandTotal');
+
+        $calculateMock = $this->getFakeMock(Calculate::class)
+            ->onlyMethods(['calculatePaymentFee'])
+            ->getMock();
+        $calculateMock->expects($this->once())
+            ->method('calculatePaymentFee')
+            ->with($quoteMock, $totalMock)
+            ->willReturn($feeResult);
+
+        $priceCurrencyMock = $this->getFakeMock(PriceCurrencyInterface::class, true);
+        $priceCurrencyMock->expects($this->never())->method('convert');
+
+        $instance = $this->getInstance([
+            'priceCurrency' => $priceCurrencyMock,
+            'calculate' => $calculateMock,
+        ]);
+        $result = $instance->collect($quoteMock, $this->getShippingAssignmentMock(), $totalMock);
+
+        $this->assertSame($instance, $result);
+    }
+
+    /**
+     * @return array
+     */
+    public static function collectFeeDataProvider()
+    {
+        return [
+            'fee converted to quote currency' => [
+                4.50,   // rounded base fee returned by the Calculate service
+                5.40,   // fee after base->quote currency conversion
+                45.00,  // grand total before the fee
+                45.00,  // base grand total before the fee
             ],
-            [
-                'buckaroo_magento2_ideal',
-                '9%',
-                'subtotal_incl_tax',
-                'getBaseSubtotalTotalInclTax',
-                45.0000,
-                4.0500
+            'fee with 1:1 conversion rate' => [
+                4.05,
+                4.05,
+                100.00,
+                90.00,
             ],
         ];
+    }
+
+    /**
+     * @param float $roundedBaseFee
+     * @param float $convertedFee
+     * @param float $initialGrandTotal
+     * @param float $initialBaseGrandTotal
+     */
+    #[DataProvider('collectFeeDataProvider')]
+    public function testCollectWritesConvertedFeeAndRaisesGrandTotals(
+        $roundedBaseFee,
+        $convertedFee,
+        $initialGrandTotal,
+        $initialBaseGrandTotal
+    ) {
+        $expectedGrandTotal = $initialGrandTotal + $convertedFee;
+        $expectedBaseGrandTotal = $initialBaseGrandTotal + $roundedBaseFee;
+
+        $quoteMock = $this->getFakeMock(QuoteStub::class)
+            ->onlyMethods(['setBuckarooFee', 'setBaseBuckarooFee'])
+            ->getMock();
+        $quoteMock->expects($this->once())->method('setBuckarooFee')->with($convertedFee)->willReturnSelf();
+        $quoteMock->expects($this->once())->method('setBaseBuckarooFee')->with($roundedBaseFee)->willReturnSelf();
+
+        $totalMock = $this->getFakeMock(TotalStub::class)
+            ->onlyMethods([
+                'setBuckarooFee',
+                'setBaseBuckarooFee',
+                'getGrandTotal',
+                'getBaseGrandTotal',
+                'setGrandTotal',
+                'setBaseGrandTotal',
+            ])
+            ->getMock();
+        $totalMock->method('getGrandTotal')->willReturn($initialGrandTotal);
+        $totalMock->method('getBaseGrandTotal')->willReturn($initialBaseGrandTotal);
+
+        $feeCalls = [];
+        $totalMock->expects($this->exactly(2))
+            ->method('setBuckarooFee')
+            ->willReturnCallback(function ($value) use (&$feeCalls, $totalMock) {
+                $feeCalls[] = $value;
+                return $totalMock;
+            });
+
+        $baseFeeCalls = [];
+        $totalMock->expects($this->exactly(2))
+            ->method('setBaseBuckarooFee')
+            ->willReturnCallback(function ($value) use (&$baseFeeCalls, $totalMock) {
+                $baseFeeCalls[] = $value;
+                return $totalMock;
+            });
+
+        $totalMock->expects($this->once())->method('setGrandTotal')->with($expectedGrandTotal)->willReturnSelf();
+        $totalMock->expects($this->once())->method('setBaseGrandTotal')->with($expectedBaseGrandTotal)->willReturnSelf();
+
+        $feeResult = $this->getMockBuilder(StdObjectStub::class)->getMock();
+        $feeResult->method('getAmount')->willReturn($roundedBaseFee);
+        $feeResult->method('getRoundedAmount')->willReturn($roundedBaseFee);
+
+        $calculateMock = $this->getFakeMock(Calculate::class)
+            ->onlyMethods(['calculatePaymentFee'])
+            ->getMock();
+        $calculateMock->expects($this->once())
+            ->method('calculatePaymentFee')
+            ->with($quoteMock, $totalMock)
+            ->willReturn($feeResult);
+
+        $priceCurrencyMock = $this->getFakeMock(PriceCurrencyInterface::class, true);
+        $priceCurrencyMock->expects($this->once())
+            ->method('convert')
+            ->with($roundedBaseFee)
+            ->willReturn($convertedFee);
+
+        $groupTransactionMock = $this->getFakeMock(PaymentGroupTransaction::class)
+            ->onlyMethods(['getAlreadyPaid'])
+            ->getMock();
+        $groupTransactionMock->method('getAlreadyPaid')->willReturn(0);
+
+        $instance = $this->getInstance([
+            'priceCurrency' => $priceCurrencyMock,
+            'groupTransaction' => $groupTransactionMock,
+            'calculate' => $calculateMock,
+        ]);
+        $result = $instance->collect($quoteMock, $this->getShippingAssignmentMock(), $totalMock);
+
+        $this->assertSame($instance, $result);
+        $this->assertSame(
+            [0, $convertedFee],
+            $feeCalls,
+            'Total buckaroo_fee must be reset to 0 and then set to the converted fee amount'
+        );
+        $this->assertSame(
+            [0, $roundedBaseFee],
+            $baseFeeCalls,
+            'Total base_buckaroo_fee must be reset to 0 and then set to the rounded base fee amount'
+        );
     }
 
     public function testGetLabelReturnsLabel()
@@ -378,10 +341,14 @@ class BuckarooFeeTest extends \Buckaroo\Magento2\Test\BaseTest
 
         $quoteMock = $this->getFakeMock(Quote::class, false)->getMock();
 
-        $totalMock = $this->getFakeMock(Total::class)
-            ->addMethods([
-                'getBuckarooFee', 'getBaseBuckarooFee', 'getBuckarooFeeInclTax',
-                'getBaseBuckarooFeeInclTax', 'getBuckarooFeeTaxAmount', 'getBuckarooFeeBaseTaxAmount'
+        $totalMock = $this->getFakeMock(TotalStub::class)
+            ->onlyMethods([
+                'getBuckarooFee',
+                'getBaseBuckarooFee',
+                'getBuckarooFeeInclTax',
+                'getBaseBuckarooFeeInclTax',
+                'getBuckarooFeeTaxAmount',
+                'getBuckarooFeeBaseTaxAmount',
             ])
             ->getMock();
         $totalMock->method('getBuckarooFee')->willReturn($expectedBuckarooFee);
@@ -395,312 +362,5 @@ class BuckarooFeeTest extends \Buckaroo\Magento2\Test\BaseTest
         $result = $instance->fetch($quoteMock, $totalMock);
 
         $this->assertEquals($expected, $result);
-    }
-
-    public function testCollectShouldReturnCorrectTotalsData()
-    {
-        $quoteMock = $this->getFakeMock(Quote::class, false)
-            ->onlyMethods(['getShippingAddress'])
-            ->getMock();
-
-        $addressMock = $this->getFakeMock(\Magento\Quote\Model\Quote\Address::class, false)->getMock();
-        $quoteMock->method('getShippingAddress')->willReturn($addressMock);
-
-        $shippingAssignmentMock = $this->getFakeMock(ShippingAssignmentInterface::class)
-            ->onlyMethods(['getItems', 'getShipping'])
-            ->getMockForAbstractClass();
-        $shippingAssignmentMock->method('getItems')->willReturn(true);
-
-        $shippingMock = $this->getFakeMock(\Magento\Quote\Api\Data\ShippingInterface::class, false)->getMockForAbstractClass();
-        $shippingMock->method('getAddress')->willReturn($addressMock);
-        $shippingAssignmentMock->method('getShipping')->willReturn($shippingMock);
-
-        $totalMock = $this->getFakeMock(Total::class)
-            ->addMethods(['setBuckarooFee', 'setBaseBuckarooFee'])
-            ->getMock();
-        $totalMock->method('setBuckarooFee')->willReturn(0);
-        $totalMock->method('setBaseBuckarooFee')->willReturn(0);
-
-        $calculateMock = $this->getFakeMock(Calculate::class)
-            ->onlyMethods(['calculatePaymentFee'])
-            ->getMock();
-        $feeResultMock = $this->getMockBuilder(\stdClass::class)->addMethods(['getAmount', 'getRoundedAmount'])->getMock();
-        $feeResultMock->method('getAmount')->willReturn(1.23);
-        $feeResultMock->method('getRoundedAmount')->willReturn(1.23);
-        $calculateMock->method('calculatePaymentFee')->willReturn($feeResultMock);
-
-        $instance = $this->getInstance(['calculate' => $calculateMock]);
-        $result = $instance->collect($quoteMock, $shippingAssignmentMock, $totalMock);
-
-        $this->assertEquals($instance, $result);
-    }
-
-    public function testCollectShouldReturnSelfIfNoShippingItems()
-    {
-        $quoteMock = $this->getFakeMock(Quote::class, false)
-            ->onlyMethods(['getShippingAddress'])
-            ->getMock();
-
-        $addressMock = $this->getFakeMock(\Magento\Quote\Model\Quote\Address::class, false)->getMock();
-        $quoteMock->method('getShippingAddress')->willReturn($addressMock);
-
-        $shippingAssignmentMock = $this->getFakeMock(ShippingAssignmentInterface::class, false)
-            ->onlyMethods(['getItems', 'getShipping'])
-            ->getMockForAbstractClass();
-        $shippingAssignmentMock->method('getItems')->willReturn(false);
-
-        $shippingMock = $this->getFakeMock(\Magento\Quote\Api\Data\ShippingInterface::class, false)->getMockForAbstractClass();
-        $shippingMock->method('getAddress')->willReturn($addressMock);
-        $shippingAssignmentMock->method('getShipping')->willReturn($shippingMock);
-
-        $totalMock = $this->getFakeMock(Total::class)->addMethods(['setBuckarooFee', 'setBaseBuckarooFee'])
-            ->getMock();
-        $totalMock->method('setBuckarooFee')->willReturn(0);
-        $totalMock->method('setBaseBuckarooFee')->willReturn(0);
-
-        $calculateMock = $this->getFakeMock(Calculate::class)
-            ->onlyMethods(['calculatePaymentFee'])
-            ->getMock();
-        $calculateMock->method('calculatePaymentFee')->willReturn(0);
-
-        $instance = $this->getInstance(['calculate' => $calculateMock]);
-        $result = $instance->collect($quoteMock, $shippingAssignmentMock, $totalMock);
-
-        $this->assertEquals($instance, $result);
-    }
-
-    /**
-     * @dataProvider collectPaymentMethodDataProvider
-     *
-     * @param mixed $method
-     */
-    public function testCollectShouldReturnSelfIfNoPaymentMethodOrNonBuckarooMethod($method)
-    {
-
-        $quoteMock = $this->getFakeMock(Quote::class)
-            ->onlyMethods(['getPayment', 'getShippingAddress'])
-            ->getMock();
-        $paymentMock = $this->getFakeMock(\Magento\Quote\Model\Quote\Payment::class, false)
-            ->onlyMethods(['getMethod', 'getMethodInstance'])
-            ->getMockForAbstractClass();
-        $paymentMock->method('getMethod')->willReturn($method);
-
-        $addressMock = $this->getFakeMock(\Magento\Quote\Model\Quote\Address::class)
-            ->addMethods(['getAddress'])
-            ->getMock();
-        $addressMock->method('getAddress')->willReturn($addressMock);
-
-        $quoteMock->method('getShippingAddress')->willReturn($addressMock);
-
-        $shippingAssignmentMock = $this->getFakeMock(ShippingAssignmentInterface::class)
-            ->onlyMethods(['getItems'])
-            ->getMockForAbstractClass();
-        $shippingAssignmentMock->method('getItems')->willReturn(true);
-
-        $shippingMock = $this->getFakeMock(\Magento\Quote\Api\Data\ShippingInterface::class, false)->getMockForAbstractClass();
-        $shippingMock->method('getAddress')->willReturn($addressMock);
-        $shippingAssignmentMock->method('getShipping')->willReturn($shippingMock);
-
-        $totalMock = $this->getFakeMock(Total::class)->addMethods(['setBuckarooFee', 'setBaseBuckarooFee'])
-            ->getMock();
-        $totalMock->method('setBuckarooFee')->willReturn(0);
-        $totalMock->method('setBaseBuckarooFee')->willReturn(0);
-
-        $instance = $this->getInstance();
-        $result = $instance->collect($quoteMock, $shippingAssignmentMock, $totalMock);
-
-        $this->assertEquals($instance, $result);
-    }
-
-    public static function collectPaymentMethodDataProvider()
-    {
-        return [
-            [
-                false
-            ],
-            [
-                'check_mo'
-            ]
-        ];
-    }
-
-    public function testCollectShouldReturnSelfIfFeeIsZero()
-    {
-        $expectedFee = 0;
-        $paymentCode = 'buckaroo_magento2_ideal';
-
-        $paymentMethodMock = $this->getFakeMock(BuckarooAdapter::class, false)
-            ->addMethods(['getBuckarooPaymentMethodCode'])
-            ->getMock();
-        $paymentMethodMock->method('getBuckarooPaymentMethodCode')->willReturn($paymentCode);
-
-        $quoteMock = $this->getFakeMock(Quote::class)
-            ->onlyMethods(["getPayment"])
-            ->getMock();
-        $paymentMock = $this->getFakeMock(\Magento\Quote\Model\Quote\Payment::class, false)
-            ->onlyMethods(['getMethod', 'getMethodInstance'])
-            ->getMockForAbstractClass();
-        $paymentMock->method('getMethod')->willReturn($paymentCode);
-        $paymentMock->method('getMethodInstance')->willReturn($paymentMethodMock);
-
-        $quoteMock->method('getPayment')->willReturn($paymentMock);
-
-        $addressMock = $this->getFakeMock(\Magento\Quote\Model\Quote\Address::class)
-            ->getMock();
-
-        $shippingMock = $this->getFakeMock(\Magento\Quote\Api\Data\ShippingInterface::class, false)
-            ->onlyMethods(['getAddress'])
-            ->getMockForAbstractClass();
-        $shippingMock->method('getAddress')->willReturn($addressMock);
-
-        $shippingAssignmentMock = $this->getFakeMock(ShippingAssignmentInterface::class)
-            ->onlyMethods(['getItems', 'getShipping'])
-            ->getMockForAbstractClass();
-        $shippingAssignmentMock->method('getItems')->willReturn(true);
-        $shippingAssignmentMock->method('getShipping')->willReturn($shippingMock);
-
-        $totalMock = $this->getFakeMock(Total::class)->addMethods(['setBuckarooFee', 'setBaseBuckarooFee'])
-            ->getMock();
-        $totalMock->method('setBuckarooFee')->willReturn(0);
-        $totalMock->method('setBaseBuckarooFee')->willReturn(0);
-
-        $configProviderFactoryMock = $this->getFakeMock(Factory::class)
-            ->onlyMethods(['has', 'get'])
-            ->addMethods(['getPaymentFee'])
-            ->getMock();
-        $configProviderFactoryMock->method('has')->with($paymentCode)->willReturn(true);
-        $configProviderFactoryMock->method('get')->with($paymentCode)->willReturnSelf();
-        $configProviderFactoryMock->method('getPaymentFee')->willReturn($expectedFee);
-
-        $configProviderFeeMock = $this->getFakeMock(ConfigProviderBuckarooFee::class)
-            ->addMethods(['getTaxClass','getPaymentFeeTax'])
-            ->getMock();
-        $configProviderFeeMock->method('getTaxClass')->willReturn(1);
-
-        $catalogHelperMock = $this->getFakeMock(Data::class)->onlyMethods(['getTaxPrice'])->getMock();
-        $catalogHelperMock->method('getTaxPrice')->willReturn($expectedFee);
-
-        $instance = $this->getInstance([
-            'configProviderBuckarooFee' => $configProviderFeeMock,
-            'configProviderMethodFactory' => $configProviderFactoryMock,
-            'catalogHelper' => $catalogHelperMock
-        ]);
-
-        $result = $instance->collect($quoteMock, $shippingAssignmentMock, $totalMock);
-        $this->assertEquals($instance, $result);
-    }
-
-    public function testCollectShouldReturnSelfIfInvalidMessage()
-    {
-        $paymentCode = 'buckaroo_magento2_ideal';
-
-        $quoteMock = $this->getFakeMock(Quote::class, false)
-            ->onlyMethods(['getPayment'])
-            ->getMock();
-
-        $paymentMock = $this->getFakeMock(\Magento\Quote\Model\Quote\Payment::class, false)
-            ->onlyMethods(['getMethod', 'getMethodInstance'])
-            ->getMock();
-        $paymentMock->method('getMethod')->willReturn($paymentCode);
-        $paymentMock->method('getMethodInstance')->willThrowException(new \Exception('Invalid message'));
-
-        $shippingAssignmentMock = $this->getFakeMock(ShippingAssignmentInterface::class, false)
-            ->onlyMethods(['getItems', 'getShipping'])
-            ->getMockForAbstractClass();
-        $shippingAssignmentMock->method('getItems')->willReturn(true);
-
-        $addressMock = $this->getFakeMock(\Magento\Quote\Model\Quote\Address::class, false)->getMock();
-        $shippingMock = $this->getFakeMock(\Magento\Quote\Api\Data\ShippingInterface::class, false)->getMockForAbstractClass();
-        $shippingMock->method('getAddress')->willReturn($addressMock);
-        $shippingAssignmentMock->method('getShipping')->willReturn($shippingMock);
-
-        $totalMock = $this->getFakeMock(Total::class)->addMethods(['setBuckarooFee', 'setBaseBuckarooFee'])
-            ->getMock();
-        $totalMock->method('setBuckarooFee')->willReturn(0);
-        $totalMock->method('setBaseBuckarooFee')->willReturn(0);
-
-        $instance = $this->getInstance();
-        $result = $instance->collect($quoteMock, $shippingAssignmentMock, $totalMock);
-
-        $this->assertEquals($instance, $result);
-    }
-
-    public function testCollectShouldSetTotalsOnQuote()
-    {
-        $paymentCode = 'buckaroo_magento2_ideal';
-        $fee = 1.1;
-        $taxIncl = Calculation::DISPLAY_TYPE_INCLUDING_TAX;
-        $store = $this->getFakeMock(\Magento\Store\Model\Store::class, false)->getMock();
-
-        $configProviderFactoryMock = $this->getFakeMock(Factory::class)
-            ->onlyMethods(['has', 'get'])
-            ->addMethods(['getPaymentFee'])
-            ->getMock();
-        $configProviderFactoryMock->method('has')->with($paymentCode)->willReturn(true);
-        $configProviderFactoryMock->method('get')->with($paymentCode)->willReturnSelf();
-        $configProviderFactoryMock->method('getPaymentFee')->willReturn(1.1);
-
-        $priceCurrencyMock = $this->getFakeMock(PriceCurrencyInterface::class)
-            ->onlyMethods(['convert'])
-            ->getMockForAbstractClass();
-        $priceCurrencyMock->method('convert')->with($fee, $store)->willReturn($fee);
-
-        $configProviderFeeMock = $this->getFakeMock(ConfigProviderBuckarooFee::class)
-            ->addMethods(['getTaxClass', 'getPaymentFeeTax'])
-            ->getMock();
-        $configProviderFeeMock->method('getTaxClass')->willReturn(1);
-        $configProviderFeeMock->method('getPaymentFeeTax')->willReturn($taxIncl);
-
-        $catalogHelperMock = $this->getFakeMock(Data::class)->onlyMethods(['getTaxPrice'])->getMock();
-        $catalogHelperMock->method('getTaxPrice')->willReturn($fee);
-
-        $paymentMethodMock = $this->getFakeMock(BuckarooAdapter::class, false)
-            ->addMethods(['getBuckarooPaymentMethodCode'])
-            ->getMock();
-        $paymentMethodMock->method('getBuckarooPaymentMethodCode')->willReturn($paymentCode);
-
-        $quoteMock = $this->getFakeMock(Quote::class)
-            ->onlyMethods(["getPayment", "getStore"])
-            ->addMethods(["setBuckarooFee", "setBaseBuckarooFee"])
-            ->getMock();
-        $paymentMock = $this->getFakeMock(\Magento\Quote\Model\Quote\Payment::class, false)
-            ->onlyMethods(['getMethodInstance'])
-            ->getMockForAbstractClass();
-        $paymentMock->method('getMethodInstance')->willReturn($paymentMethodMock);
-        $quoteMock->method('getPayment')->willReturn($paymentMock);
-        $quoteMock->method('setBuckarooFee')->willReturn($fee);
-        $quoteMock->method('setBaseBuckarooFee')->willReturn($fee);
-        $quoteMock->method('getStore')->willReturn($store);
-
-        $addressMock2 = $this->getFakeMock(\Magento\Quote\Model\Quote\Address::class)
-            ->getMock();
-
-        $shippingMock2 = $this->getFakeMock(\Magento\Quote\Api\Data\ShippingInterface::class, false)
-            ->onlyMethods(['getAddress'])
-            ->getMockForAbstractClass();
-        $shippingMock2->method('getAddress')->willReturn($addressMock2);
-
-        $shippingAssignmentMock = $this->getFakeMock(ShippingAssignmentInterface::class)
-            ->onlyMethods(['getItems', 'getShipping'])
-            ->getMockForAbstractClass();
-        $shippingAssignmentMock->method('getItems')->willReturn(true);
-        $shippingAssignmentMock->method('getShipping')->willReturn($shippingMock2);
-
-        $totalMock = $this->getFakeMock(Total::class)
-            ->addMethods([
-                'setBuckarooFee', 'setBaseBuckarooFee', 'getBaseGrandTotal',
-                'getGrandTotal', 'setBaseGrandTotal', 'setGrandTotal'
-            ])
-            ->getMock();
-
-        $instance = $this->getInstance([
-            'catalogHelper' => $catalogHelperMock,
-            'configProviderBuckarooFee' => $configProviderFeeMock,
-            'configProviderMethodFactory' => $configProviderFactoryMock,
-            'priceCurrency' => $priceCurrencyMock,
-        ]);
-
-        $result = $instance->collect($quoteMock, $shippingAssignmentMock, $totalMock);
-        $this->assertEquals($instance, $result);
     }
 }

--- a/Test/Unit/Model/Validator/PushTest.php
+++ b/Test/Unit/Model/Validator/PushTest.php
@@ -21,11 +21,25 @@
 
 namespace Buckaroo\Magento2\Test\Unit\Model\Validator;
 
+use Buckaroo\Magento2\Helper\Data;
+use Buckaroo\Magento2\Model\ConfigProvider\Account;
 use Buckaroo\Magento2\Model\Validator\Push;
 use Buckaroo\Magento2\Test\BaseTest;
+use Magento\Framework\Encryption\Encryptor;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class PushTest extends BaseTest
 {
+    /**
+     * Secret key as it would be stored (encrypted) in core_config_data.
+     */
+    private const ENCRYPTED_SECRET = 'encrypted-secret-key-value';
+
+    /**
+     * Secret key as configured in the Buckaroo plaza.
+     */
+    private const SECRET = 'S3cr3tBuckarooKey!';
+
     /**
      * @var string
      */
@@ -36,5 +50,445 @@ class PushTest extends BaseTest
         $instance = $this->getInstance();
         $this->expectException(\LogicException::class);
         $instance->validate(null);
+    }
+
+    /* ---------------------------------------------------------------------
+     * calculateSignature()
+     * ------------------------------------------------------------------ */
+
+    /**
+     * Pins the exact signature algorithm against a hand-computed vector:
+     * case-insensitive sort of accepted keys, concatenation of key=value
+     * pairs (original key casing preserved), secret appended, SHA-1 digest.
+     */
+    public function testCalculateSignatureMatchesHandComputedVector()
+    {
+        $payload = [
+            'brq_websitekey'           => 'ABCDEFGH',
+            'cust_customerName'        => 'John Doe',
+            'brq_amount'               => '10.00',
+            'BRQ_CURRENCY'             => 'EUR',
+            'add_initiated_by_magento' => '1',
+            'brq_invoicenumber'        => '100000001',
+            'brq_statuscode'           => '190',
+            'brq_transactions'         => '9BAE00E4B4C34DF08A1F5A3B1E7B27E2',
+            'brq_signature'            => 'must-not-be-part-of-the-signature',
+            'foo_bar'                  => 'must-not-be-signed',
+        ];
+
+        // Expected signature string derived by hand from the documented
+        // Buckaroo algorithm (case-insensitive alphabetical key order):
+        $expectedSignatureString =
+            'add_initiated_by_magento=1'
+            . 'brq_amount=10.00'
+            . 'BRQ_CURRENCY=EUR'
+            . 'brq_invoicenumber=100000001'
+            . 'brq_statuscode=190'
+            . 'brq_transactions=9BAE00E4B4C34DF08A1F5A3B1E7B27E2'
+            . 'brq_websitekey=ABCDEFGH'
+            . 'cust_customerName=John Doe'
+            . self::SECRET;
+
+        $instance = $this->getPushInstance();
+
+        $this->assertSame(sha1($expectedSignatureString), $instance->calculateSignature($payload));
+    }
+
+    public function testCalculateSignatureExcludesSignatureFieldsInBothCasings()
+    {
+        $basePayload = [
+            'brq_amount'        => '25.50',
+            'brq_invoicenumber' => '100000002',
+        ];
+
+        $withSignatures = $basePayload + [
+            'brq_signature' => 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            'BRQ_SIGNATURE' => 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+        ];
+
+        $instance = $this->getPushInstance();
+
+        $this->assertSame(
+            $instance->calculateSignature($basePayload),
+            $instance->calculateSignature($withSignatures)
+        );
+    }
+
+    public function testCalculateSignatureIgnoresKeysWithoutAcceptedPrefix()
+    {
+        $basePayload = ['brq_amount' => '1.00'];
+
+        $polluted = $basePayload + [
+            'form_key'      => 'attacker-controlled',
+            'random'        => 'value',
+            'brqamount'     => 'no-underscore-so-no-prefix-match',
+            'custom_field'  => 'prefix is custom, not cust',
+            'brq2_amount'   => 'prefix brq2 is not brq',
+        ];
+
+        $instance = $this->getPushInstance();
+
+        $this->assertSame(
+            $instance->calculateSignature($basePayload),
+            $instance->calculateSignature($polluted)
+        );
+    }
+
+    #[DataProvider('acceptedPrefixProvider')]
+    public function testCalculateSignatureAcceptsAllDocumentedPrefixes(string $key, string $value)
+    {
+        $instance = $this->getPushInstance();
+
+        $this->assertSame(
+            sha1($key . '=' . $value . self::SECRET),
+            $instance->calculateSignature([$key => $value])
+        );
+    }
+
+    public static function acceptedPrefixProvider(): array
+    {
+        return [
+            'lowercase brq'  => ['brq_amount', '1.00'],
+            'lowercase add'  => ['add_service_action', 'something'],
+            'lowercase cust' => ['cust_name', 'John'],
+            'uppercase BRQ'  => ['BRQ_AMOUNT', '1.00'],
+            'uppercase ADD'  => ['ADD_FIELD', 'x'],
+            'uppercase CUST' => ['CUST_FIELD', 'y'],
+        ];
+    }
+
+    public function testCalculateSignatureOfEmptyPayloadIsHashOfSecretOnly()
+    {
+        $instance = $this->getPushInstance();
+
+        $this->assertSame(sha1(self::SECRET), $instance->calculateSignature([]));
+    }
+
+    public function testCalculateSignatureRestoresSpaceMangledParameterName()
+    {
+        // PHP turns "brq_SERVICE_ideal_Additional Info" into
+        // "brq_SERVICE_ideal_Additional_Info" while parsing POST data.
+        // The signature must be computed over the original (spaced) name.
+        $payload = ['brq_SERVICE_ideal_Additional_Info' => 'some info'];
+
+        $instance = $this->getPushInstance();
+
+        $this->assertSame(
+            sha1('brq_SERVICE_ideal_Additional Info=some info' . self::SECRET),
+            $instance->calculateSignature($payload)
+        );
+    }
+
+    public function testCalculateSignaturePassesStoreToSecretKeyProvider()
+    {
+        $accountMock = $this->getFakeMock(Account::class)->getMock();
+        $accountMock->expects($this->once())
+            ->method('getSecretKey')
+            ->with(42)
+            ->willReturn(self::ENCRYPTED_SECRET);
+
+        $instance = $this->getPushInstance(self::SECRET, $accountMock);
+
+        $this->assertSame(
+            sha1('brq_amount=1.00' . self::SECRET),
+            $instance->calculateSignature(['brq_amount' => '1.00'], 42)
+        );
+    }
+
+    /* ---------------------------------------------------------------------
+     * validateSignature()
+     * ------------------------------------------------------------------ */
+
+    public function testValidateSignatureReturnsTrueForCorrectlySignedPayload()
+    {
+        $payload = self::examplePushPayload();
+        $payload['brq_signature'] = self::signPayload($payload, self::SECRET);
+
+        $instance = $this->getPushInstance();
+
+        $this->assertTrue($instance->validateSignature($payload, $payload));
+    }
+
+    #[DataProvider('tamperedPayloadProvider')]
+    public function testValidateSignatureReturnsFalseForTamperedPayload(string $key, string $tamperedValue)
+    {
+        $payload = self::examplePushPayload();
+        $payload['brq_signature'] = self::signPayload($payload, self::SECRET);
+
+        $tampered = $payload;
+        $tampered[$key] = $tamperedValue;
+
+        $instance = $this->getPushInstance();
+
+        $this->assertFalse($instance->validateSignature($tampered, $tampered));
+    }
+
+    public static function tamperedPayloadProvider(): array
+    {
+        return [
+            'amount changed'      => ['brq_amount', '0.01'],
+            'status forged'       => ['brq_statuscode', '190'],
+            'invoice redirected'  => ['brq_invoicenumber', '900000099'],
+            'signature replaced'  => ['brq_signature', sha1('forged')],
+        ];
+    }
+
+    public function testValidateSignatureReturnsFalseWhenSignedWithWrongSecret()
+    {
+        $payload = self::examplePushPayload();
+        $payload['brq_signature'] = self::signPayload($payload, 'attacker-guessed-secret');
+
+        $instance = $this->getPushInstance();
+
+        $this->assertFalse($instance->validateSignature($payload, $payload));
+    }
+
+    public function testValidateSignatureReturnsFalseWhenSignatureIsMissing()
+    {
+        $payload = self::examplePushPayload();
+
+        $instance = $this->getPushInstance();
+
+        $this->assertFalse($instance->validateSignature($payload, $payload));
+    }
+
+    public function testValidateSignatureReturnsFalseForEmptyPayloads()
+    {
+        $instance = $this->getPushInstance();
+
+        $this->assertFalse($instance->validateSignature([], []));
+    }
+
+    public function testValidateSignatureUsesOriginalPostDataForCalculation()
+    {
+        // The signature is calculated from the first argument
+        // ($originalPostData) while the signature itself is read from the
+        // second argument ($postData). Pin that contract.
+        $original = self::examplePushPayload();
+        $signature = self::signPayload($original, self::SECRET);
+
+        $casedPostData = array_change_key_case($original, CASE_UPPER);
+        $casedPostData['brq_signature'] = $signature;
+
+        $instance = $this->getPushInstance();
+
+        $this->assertTrue($instance->validateSignature($original, $casedPostData));
+    }
+
+    /* ---------------------------------------------------------------------
+     * buckarooArraySort()
+     * ------------------------------------------------------------------ */
+
+    public function testBuckarooArraySortSortsCaseInsensitivelyAndKeepsOriginalKeys()
+    {
+        // Case-sensitive (byte) order would put 'BRQ_Websitekey' before
+        // 'brq_amount'; the Buckaroo algorithm requires case-insensitive
+        // order, so 'brq_amount' must come first.
+        $input = [
+            'cust_name'       => 'John',
+            'BRQ_Websitekey'  => 'KEY',
+            'brq_amount'      => '1.00',
+            'ADD_service'     => 'ideal',
+            'brq_STATUSCODE'  => '190',
+        ];
+
+        $expected = [
+            'ADD_service'     => 'ideal',
+            'brq_amount'      => '1.00',
+            'brq_STATUSCODE'  => '190',
+            'BRQ_Websitekey'  => 'KEY',
+            'cust_name'       => 'John',
+        ];
+
+        $result = $this->invokeArgs('buckarooArraySort', [$input], $this->getPushInstance());
+
+        $this->assertSame($expected, $result);
+    }
+
+    /**
+     * Pins current behavior: keys that differ only in casing collapse into
+     * a single entry (the last one wins). This silently drops data from the
+     * signature base and is a suspected bug, but it is the behavior Buckaroo
+     * pushes rely on today.
+     */
+    public function testBuckarooArraySortCollapsesKeysDifferingOnlyInCase()
+    {
+        $input = [
+            'brq_test' => 'first',
+            'BRQ_TEST' => 'second',
+        ];
+
+        $result = $this->invokeArgs('buckarooArraySort', [$input], $this->getPushInstance());
+
+        $this->assertSame(['BRQ_TEST' => 'second'], $result);
+    }
+
+    /* ---------------------------------------------------------------------
+     * fixParameterNamesWithSpaces()
+     * ------------------------------------------------------------------ */
+
+    public function testFixParameterNamesWithSpacesRestoresAdditionalInfo()
+    {
+        $input = ['brq_SERVICE_ideal_Additional_Info' => 'value kept'];
+
+        $result = $this->invokeArgs('fixParameterNamesWithSpaces', [$input], $this->getPushInstance());
+
+        $this->assertSame(['brq_SERVICE_ideal_Additional Info' => 'value kept'], $result);
+    }
+
+    #[DataProvider('unmodifiedParameterNameProvider')]
+    public function testFixParameterNamesWithSpacesLeavesOtherKeysUntouched(string $key)
+    {
+        $input = [$key => 'value'];
+
+        $result = $this->invokeArgs('fixParameterNamesWithSpaces', [$input], $this->getPushInstance());
+
+        $this->assertSame($input, $result);
+    }
+
+    public static function unmodifiedParameterNameProvider(): array
+    {
+        return [
+            'plain brq key'               => ['brq_amount'],
+            'service key, other suffix'   => ['brq_SERVICE_ideal_consumerName'],
+            'lowercase service segment'   => ['brq_service_ideal_Additional_Info'],
+            'service name with underscore' => ['brq_SERVICE_after_pay_Additional_Info'],
+            'suffix only, no service'     => ['brq_Additional_Info'],
+        ];
+    }
+
+    /* ---------------------------------------------------------------------
+     * validateStatusCode()
+     * ------------------------------------------------------------------ */
+
+    public function testValidateStatusCodeReturnsMessageAndStatusForKnownCode()
+    {
+        $helperMock = $this->getFakeMock(Data::class)->getMock();
+        $helperMock->method('getStatusByValue')
+            ->with(190)
+            ->willReturn('BUCKAROO_MAGENTO2_STATUSCODE_SUCCESS');
+
+        $instance = $this->getInstance(['helper' => $helperMock]);
+
+        $this->assertSame(
+            [
+                'message' => 'Success',
+                'status'  => 'BUCKAROO_MAGENTO2_STATUSCODE_SUCCESS',
+                'code'    => 190,
+            ],
+            $instance->validateStatusCode(190)
+        );
+    }
+
+    public function testValidateStatusCodeReturnsNeutralForUnknownCode()
+    {
+        $helperMock = $this->getFakeMock(Data::class)->getMock();
+        $helperMock->method('getStatusByValue')->willReturn(null);
+
+        $instance = $this->getInstance(['helper' => $helperMock]);
+
+        $this->assertSame(
+            [
+                'message' => 'Onbekende responsecode: 999',
+                'status'  => 'BUCKAROO_MAGENTO2_STATUSCODE_NEUTRAL',
+                'code'    => 999,
+            ],
+            $instance->validateStatusCode(999)
+        );
+    }
+
+    /* ---------------------------------------------------------------------
+     * Helpers
+     * ------------------------------------------------------------------ */
+
+    /**
+     * Build a Push instance whose secret-key chain
+     * (Account::getSecretKey -> Encryptor::decrypt) yields $secret.
+     *
+     * @param string       $secret
+     * @param Account|null $accountMock
+     *
+     * @return Push
+     */
+    private function getPushInstance(string $secret = self::SECRET, ?Account $accountMock = null): Push
+    {
+        if ($accountMock === null) {
+            $accountMock = $this->getFakeMock(Account::class)->getMock();
+            $accountMock->method('getSecretKey')->willReturn(self::ENCRYPTED_SECRET);
+        }
+
+        $encryptorMock = $this->getFakeMock(Encryptor::class)->getMock();
+        $encryptorMock->method('decrypt')
+            ->with(self::ENCRYPTED_SECRET)
+            ->willReturn($secret);
+
+        return $this->getInstance([
+            'configProviderAccount' => $accountMock,
+            'encryptor'             => $encryptorMock,
+        ]);
+    }
+
+    /**
+     * A realistic Buckaroo push payload (without signature).
+     *
+     * @return array<string, string>
+     */
+    private static function examplePushPayload(): array
+    {
+        return [
+            'brq_amount'                     => '52.79',
+            'brq_currency'                   => 'EUR',
+            'brq_customer_name'              => 'J. de Tester',
+            'brq_invoicenumber'              => '100000001',
+            'brq_mutationtype'               => 'Collecting',
+            'brq_payment'                    => 'F2AE41A78E52D6AB4B4B4B4B4B4B4B4B',
+            'brq_payment_method'             => 'ideal',
+            'brq_SERVICE_ideal_consumerName' => 'J. de Tester',
+            'brq_statuscode'                 => '890',
+            'brq_statusmessage'              => 'Cancelled by consumer',
+            'brq_test'                       => 'true',
+            'brq_timestamp'                  => '2026-07-22 10:15:00',
+            'brq_transactions'               => '9BAE00E4B4C34DF08A1F5A3B1E7B27E2',
+            'brq_websitekey'                 => 'ABCDEFGH',
+            'add_initiated_by_magento'       => '1',
+            'cust_customerName'              => 'John Doe',
+        ];
+    }
+
+    /**
+     * Independent re-implementation of the Buckaroo signing algorithm used
+     * to produce signatures for validateSignature() tests. Kept deliberately
+     * separate from the production code so the tests fail if the production
+     * algorithm drifts.
+     *
+     * @param array<string, string> $payload
+     * @param string                $secret
+     *
+     * @return string
+     */
+    private static function signPayload(array $payload, string $secret): string
+    {
+        $accepted = ['brq', 'add', 'cust', 'BRQ', 'ADD', 'CUST'];
+
+        $filtered = [];
+        foreach ($payload as $key => $value) {
+            if (strtolower((string)$key) === 'brq_signature') {
+                continue;
+            }
+            if (in_array(explode('_', (string)$key)[0], $accepted, true)) {
+                $filtered[$key] = $value;
+            }
+        }
+
+        uksort($filtered, static function (string $a, string $b): int {
+            return strcmp(strtolower($a), strtolower($b));
+        });
+
+        $signatureString = '';
+        foreach ($filtered as $key => $value) {
+            $signatureString .= $key . '=' . $value;
+        }
+
+        return sha1($signatureString . $secret);
     }
 }

--- a/Test/Unit/Observer/CreateSecondChanceRecordTest.php
+++ b/Test/Unit/Observer/CreateSecondChanceRecordTest.php
@@ -7,6 +7,8 @@
 
 namespace Buckaroo\Magento2\Test\Unit\Observer;
 
+
+use PHPUnit\Framework\Attributes\DataProvider;
 use Buckaroo\Magento2\Observer\CreateSecondChanceRecord;
 use Buckaroo\Magento2\Model\SecondChanceRepository;
 use Buckaroo\Magento2\Model\ConfigProvider\SecondChance as ConfigProvider;
@@ -71,7 +73,6 @@ class CreateSecondChanceRecordTest extends \Buckaroo\Magento2\Test\BaseTest
     }
 
     /**
-     * @dataProvider executeDataProvider
      *
      * @param int    $orderId
      * @param string $state
@@ -81,6 +82,7 @@ class CreateSecondChanceRecordTest extends \Buckaroo\Magento2\Test\BaseTest
      * @param int    $expectedCreateCalls
      * @param int    $expectedDebugCalls
      */
+    #[DataProvider('executeDataProvider')]
     public function testExecute(
         int $orderId,
         string $state,

--- a/Test/Unit/Observer/InvoiceRegisterTest.php
+++ b/Test/Unit/Observer/InvoiceRegisterTest.php
@@ -21,76 +21,137 @@
 
 namespace Buckaroo\Magento2\Test\Unit\Observer;
 
-use Magento\Framework\Event\Observer;
-use Magento\Sales\Model\Order;
-use Buckaroo\Magento2\Test\BaseTest;
 use Buckaroo\Magento2\Observer\InvoiceRegister;
+use Buckaroo\Magento2\Test\BaseTest;
+use Buckaroo\Magento2\Test\Unit\Stubs\InvoiceStub;
+use Buckaroo\Magento2\Test\Unit\Stubs\ObserverStub;
+use Buckaroo\Magento2\Test\Unit\Stubs\OrderStub;
 
 class InvoiceRegisterTest extends BaseTest
 {
     protected $instanceClass = InvoiceRegister::class;
 
     /**
-     * Test the happy path. Nothing is changed.
+     * When the invoice carries no base Buckaroo fee, the order must never be
+     * loaded and none of the invoiced-fee setters may be called.
      */
-    public function testInvoiceRegisterHappyPath()
+    public function testExecuteWithoutFeeDoesNotTouchOrder()
     {
-        $observerMock = $this->getFakeMock(Observer::class)
-            ->onlyMethods(['getEvent'])
-            ->addMethods(['getInvoice', 'getBaseBuckarooFee'])
+        $invoiceMock = $this->getFakeMock(InvoiceStub::class)
+            ->onlyMethods(['getBaseBuckarooFee', 'getOrder'])
             ->getMock();
-        $observerMock->method('getEvent')->willReturnSelf();
-        $observerMock->method('getInvoice')->willReturnSelf();
-        $observerMock->method('getBaseBuckarooFee')->willReturn(false);
+        $invoiceMock->method('getBaseBuckarooFee')->willReturn(null);
+        $invoiceMock->expects($this->never())->method('getOrder');
+
+        $observerMock = $this->createObserverMock($invoiceMock);
 
         $instance = $this->getInstance();
         $result = $instance->execute($observerMock);
-        $this->assertInstanceOf(InvoiceRegister::class, $result);
+
+        $this->assertSame($instance, $result);
     }
 
     /**
-     * Test that the payment fee isset.
+     * When the invoice carries a Buckaroo fee, each invoiced-fee total on the
+     * order must be increased by exactly the invoice amount. All values are
+     * exact binary fractions so the float sums are precise.
      */
-    public function testInvoiceRegisterWithPaymentFee()
+    public function testExecuteWithFeeAddsInvoiceAmountsToOrderTotals()
     {
-        $orderMock = $this->getFakeMock(Order::class)
-            ->addMethods([
-                'setBuckarooFeeInvoiced', 'setBaseBuckarooFeeInvoiced', 'setBuckarooFeeTaxAmountInvoiced',
-                'setBuckarooFeeBaseTaxAmountInvoiced', 'setBuckarooFeeInclTaxInvoiced', 'setBaseBuckarooFeeInclTaxInvoiced',
-                'getBuckarooFeeInvoiced', 'getBaseBuckarooFeeInvoiced', 'getBuckarooFeeTaxAmountInvoiced',
-                'getBuckarooFeeBaseTaxAmountInvoiced', 'getBuckarooFeeInclTaxInvoiced', 'getBaseBuckarooFeeInclTaxInvoiced'
+        $invoiceMock = $this->getFakeMock(InvoiceStub::class)
+            ->onlyMethods([
+                'getBaseBuckarooFee',
+                'getBuckarooFee',
+                'getBuckarooFeeTaxAmount',
+                'getBuckarooFeeBaseTaxAmount',
+                'getBuckarooFeeInclTax',
+                'getBaseBuckarooFeeInclTax',
+                'getOrder',
             ])
             ->getMock();
-        $orderMock->method('setBuckarooFeeInvoiced');
-        $orderMock->method('setBaseBuckarooFeeInvoiced');
-        $orderMock->method('setBuckarooFeeTaxAmountInvoiced');
-        $orderMock->method('setBuckarooFeeBaseTaxAmountInvoiced');
-        $orderMock->method('setBuckarooFeeInclTaxInvoiced');
-        $orderMock->method('setBaseBuckarooFeeInclTaxInvoiced');
-        $orderMock->method('getBuckarooFeeInvoiced');
-        $orderMock->method('getBaseBuckarooFeeInvoiced');
-        $orderMock->method('getBuckarooFeeTaxAmountInvoiced');
-        $orderMock->method('getBuckarooFeeBaseTaxAmountInvoiced');
-        $orderMock->method('getBuckarooFeeInclTaxInvoiced');
-        $orderMock->method('getBaseBuckarooFeeInclTaxInvoiced');
+        $invoiceMock->method('getBaseBuckarooFee')->willReturn(2.0);
+        $invoiceMock->method('getBuckarooFee')->willReturn(2.5);
+        $invoiceMock->method('getBuckarooFeeTaxAmount')->willReturn(0.5);
+        $invoiceMock->method('getBuckarooFeeBaseTaxAmount')->willReturn(0.25);
+        $invoiceMock->method('getBuckarooFeeInclTax')->willReturn(3.0);
+        $invoiceMock->method('getBaseBuckarooFeeInclTax')->willReturn(2.25);
 
-        $observerMock = $this->getFakeMock(Observer::class)
-            ->onlyMethods(['getEvent'])
-            ->addMethods(['getInvoice', 'getBaseBuckarooFee', 'getBuckarooFee', 'getBuckarooFeeTaxAmount',
-                         'getBuckarooFeeBaseTaxAmount', 'getBuckarooFeeInclTax', 'getBaseBuckarooFeeInclTax', 'getOrder'])
-            ->getMockForAbstractClass();
-        $observerMock->method('getEvent')->willReturnSelf();
-        $observerMock->method('getInvoice')->willReturnSelf();
-        $observerMock->method('getBaseBuckarooFee')->willReturn(true);
-        $observerMock->method('getBuckarooFee');
-        $observerMock->method('getBuckarooFeeTaxAmount');
-        $observerMock->method('getBuckarooFeeBaseTaxAmount');
-        $observerMock->method('getBuckarooFeeInclTax');
-        $observerMock->method('getBaseBuckarooFeeInclTax');
-        $observerMock->method('getOrder')->willReturn($orderMock);
+        $orderMock = $this->getFakeMock(OrderStub::class)
+            ->onlyMethods([
+                'getBuckarooFeeInvoiced',
+                'getBaseBuckarooFeeInvoiced',
+                'getBuckarooFeeTaxAmountInvoiced',
+                'getBuckarooFeeBaseTaxAmountInvoiced',
+                'getBuckarooFeeInclTaxInvoiced',
+                'getBaseBuckarooFeeInclTaxInvoiced',
+                'setBuckarooFeeInvoiced',
+                'setBaseBuckarooFeeInvoiced',
+                'setBuckarooFeeTaxAmountInvoiced',
+                'setBuckarooFeeBaseTaxAmountInvoiced',
+                'setBuckarooFeeInclTaxInvoiced',
+                'setBaseBuckarooFeeInclTaxInvoiced',
+            ])
+            ->getMock();
+
+        // Already invoiced totals on the order.
+        $orderMock->method('getBuckarooFeeInvoiced')->willReturn(1.25);
+        $orderMock->method('getBaseBuckarooFeeInvoiced')->willReturn(1.0);
+        $orderMock->method('getBuckarooFeeTaxAmountInvoiced')->willReturn(0.25);
+        $orderMock->method('getBuckarooFeeBaseTaxAmountInvoiced')->willReturn(0.125);
+        $orderMock->method('getBuckarooFeeInclTaxInvoiced')->willReturn(1.5);
+        $orderMock->method('getBaseBuckarooFeeInclTaxInvoiced')->willReturn(1.125);
+
+        // Expected new totals: existing order total + invoice amount.
+        $orderMock->expects($this->once())
+            ->method('setBuckarooFeeInvoiced')
+            ->with(1.25 + 2.5)
+            ->willReturnSelf();
+        $orderMock->expects($this->once())
+            ->method('setBaseBuckarooFeeInvoiced')
+            ->with(1.0 + 2.0)
+            ->willReturnSelf();
+        $orderMock->expects($this->once())
+            ->method('setBuckarooFeeTaxAmountInvoiced')
+            ->with(0.25 + 0.5)
+            ->willReturnSelf();
+        $orderMock->expects($this->once())
+            ->method('setBuckarooFeeBaseTaxAmountInvoiced')
+            ->with(0.125 + 0.25)
+            ->willReturnSelf();
+        $orderMock->expects($this->once())
+            ->method('setBuckarooFeeInclTaxInvoiced')
+            ->with(1.5 + 3.0)
+            ->willReturnSelf();
+        $orderMock->expects($this->once())
+            ->method('setBaseBuckarooFeeInclTaxInvoiced')
+            ->with(1.125 + 2.25)
+            ->willReturnSelf();
+
+        $invoiceMock->method('getOrder')->willReturn($orderMock);
+
+        $observerMock = $this->createObserverMock($invoiceMock);
 
         $instance = $this->getInstance();
         $result = $instance->execute($observerMock);
-        $this->assertInstanceOf(InvoiceRegister::class, $result);
+
+        $this->assertSame($instance, $result);
+    }
+
+    /**
+     * Build an observer mock whose event exposes the given invoice.
+     *
+     * @param \PHPUnit\Framework\MockObject\MockObject $invoiceMock
+     *
+     * @return \PHPUnit\Framework\MockObject\MockObject
+     */
+    private function createObserverMock($invoiceMock)
+    {
+        $observerMock = $this->getFakeMock(ObserverStub::class)
+            ->onlyMethods(['getEvent', 'getInvoice'])
+            ->getMock();
+        $observerMock->method('getEvent')->willReturnSelf();
+        $observerMock->method('getInvoice')->willReturn($invoiceMock);
+
+        return $observerMock;
     }
 }

--- a/Test/Unit/Observer/SendOrderConfirmationTest.php
+++ b/Test/Unit/Observer/SendOrderConfirmationTest.php
@@ -21,95 +21,193 @@
 
 namespace Buckaroo\Magento2\Test\Unit\Observer;
 
-use Magento\Framework\Event\Observer;
-use Magento\Payment\Model\MethodInterface;
-use Magento\Sales\Model\Order;
-use Magento\Sales\Model\Order\Payment;
+use Buckaroo\Magento2\Logging\BuckarooLoggerInterface;
 use Buckaroo\Magento2\Model\ConfigProvider\Account;
 use Buckaroo\Magento2\Observer\SendOrderConfirmation;
 use Buckaroo\Magento2\Test\BaseTest;
+use Buckaroo\Magento2\Test\Unit\Stubs\ObserverStub;
+use Magento\Sales\Model\Order;
+use Magento\Sales\Model\Order\Email\Sender\OrderSender;
+use Magento\Sales\Model\Order\Payment;
 
 class SendOrderConfirmationTest extends BaseTest
 {
     protected $instanceClass = SendOrderConfirmation::class;
 
-    public function testExecuteNotBuckaroo()
+    /**
+     * A non-Buckaroo payment must cause an early return: no order lookup and
+     * no confirmation email.
+     */
+    public function testExecuteNotBuckarooNeverSendsEmail()
     {
-        $paymentMock = $this->getFakeMock(Payment::class)->onlyMethods(['getMethod'])->getMock();
+        $paymentMock = $this->getFakeMock(Payment::class)
+            ->onlyMethods(['getMethod', 'getOrder'])
+            ->getMock();
         $paymentMock->method('getMethod')->willReturn('fake_method');
+        $paymentMock->expects($this->never())->method('getOrder');
 
-        $observerMock = $this->getFakeMock(Observer::class)->addMethods(['getPayment'])->getMock();
-        $observerMock->method('getPayment')->willReturn($paymentMock);
+        $orderSenderMock = $this->createOrderSenderMock();
+        $orderSenderMock->expects($this->never())->method('send');
 
-        $instance = $this->getInstance();
-        $result = $instance->execute($observerMock);
-
-        // Add assertion to verify the method handles non-Buckaroo payments correctly
-        $this->assertNull($result, 'Execute should return null for non-Buckaroo payment methods');
+        $instance = $this->getInstance([
+            'orderSender' => $orderSenderMock,
+            'logger' => $this->createLoggerMock(),
+        ]);
+        $instance->execute($this->createObserverMock($paymentMock));
     }
 
-    public function testExecuteIsBuckarooNoOrderSend()
+    /**
+     * A redirect payment method must skip sending the confirmation email.
+     */
+    public function testExecuteRedirectMethodNeverSendsEmail()
     {
-        $orderMock = $this->getFakeMock(Order::class)->onlyMethods(['save'])->getMock();
-        $orderMock->method('save')->willReturnSelf();
+        $orderMock = $this->getFakeMock(Order::class, true);
+        $paymentMock = $this->createBuckarooPaymentMock($orderMock, true);
 
-        // Create a concrete mock class instead of trying to mock the abstract MethodInterface
-        $methodInstanceMock = $this->getMockBuilder(\stdClass::class)->getMock();
-        $methodInstanceMock->usesRedirect = true;
+        $orderSenderMock = $this->createOrderSenderMock();
+        $orderSenderMock->expects($this->never())->method('send');
 
-        $paymentMock = $this->getFakeMock(Payment::class)
-            ->onlyMethods(['getMethod', 'getOrder', 'getMethodInstance'])
-            ->getMock();
-        $paymentMock->method('getMethod')->willReturn('buckaroo_magento2');
-        $paymentMock->method('getOrder')->willReturn($orderMock);
-        $paymentMock->method('getMethodInstance')->willReturn($methodInstanceMock);
+        $accountConfigMock = $this->createAccountConfigMock();
+        $accountConfigMock->expects($this->never())->method('getOrderConfirmationEmail');
 
-        $observerMock = $this->getFakeMock(Observer::class)->addMethods(['getPayment'])->getMock();
-        $observerMock->method('getPayment')->willReturn($paymentMock);
+        $instance = $this->getInstance([
+            'accountConfig' => $accountConfigMock,
+            'orderSender' => $orderSenderMock,
+            'logger' => $this->createLoggerMock(),
+        ]);
+        $instance->execute($this->createObserverMock($paymentMock));
+    }
 
-        $accountConfigMock = $this->getFakeMock(Account::class)->onlyMethods(['getOrderConfirmationEmail','getCreateOrderBeforeTransaction'])->getMock();
+    /**
+     * A non-redirect Buckaroo payment with confirmation email enabled, no
+     * email sent yet and a real increment id must send the confirmation
+     * email exactly once, in forced sync mode.
+     */
+    public function testExecuteSendsConfirmationEmailOnce()
+    {
+        $orderMock = $this->createOrderMock(false);
+        $paymentMock = $this->createBuckarooPaymentMock($orderMock, false);
+
+        $orderSenderMock = $this->createOrderSenderMock();
+        $orderSenderMock->expects($this->once())
+            ->method('send')
+            ->with($orderMock, true)
+            ->willReturn(true);
+
+        $accountConfigMock = $this->createAccountConfigMock();
         $accountConfigMock->method('getOrderConfirmationEmail')->willReturn(true);
         $accountConfigMock->method('getCreateOrderBeforeTransaction')->willReturn(false);
 
-        $instance = $this->getInstance(['accountConfig' => $accountConfigMock]);
-        $result = $instance->execute($observerMock);
-
-        // Add assertion to verify method execution for redirect payments
-        $this->assertNull($result, 'Execute should handle redirect payments without sending email');
+        $instance = $this->getInstance([
+            'accountConfig' => $accountConfigMock,
+            'orderSender' => $orderSenderMock,
+            'logger' => $this->createLoggerMock(),
+        ]);
+        $instance->execute($this->createObserverMock($paymentMock));
     }
 
-    public function testExecuteIsBuckarooOrderSend()
+    /**
+     * When the order email was already sent, the observer must not send it
+     * again even though everything else allows sending.
+     */
+    public function testExecuteEmailAlreadySentNeverSendsEmail()
+    {
+        $orderMock = $this->createOrderMock(true);
+        $paymentMock = $this->createBuckarooPaymentMock($orderMock, false);
+
+        $orderSenderMock = $this->createOrderSenderMock();
+        $orderSenderMock->expects($this->never())->method('send');
+
+        $accountConfigMock = $this->createAccountConfigMock();
+        $accountConfigMock->method('getOrderConfirmationEmail')->willReturn(true);
+        $accountConfigMock->method('getCreateOrderBeforeTransaction')->willReturn(false);
+
+        $instance = $this->getInstance([
+            'accountConfig' => $accountConfigMock,
+            'orderSender' => $orderSenderMock,
+            'logger' => $this->createLoggerMock(),
+        ]);
+        $instance->execute($this->createObserverMock($paymentMock));
+    }
+
+    /**
+     * @param bool $emailSent
+     *
+     * @return \PHPUnit\Framework\MockObject\MockObject
+     */
+    private function createOrderMock(bool $emailSent)
     {
         $orderMock = $this->getFakeMock(Order::class)
-            ->onlyMethods(['getEmailSent', 'getStore', 'getIncrementId', 'save'])
+            ->onlyMethods(['getEmailSent', 'getIncrementId', 'getStore', 'getStoreId', 'getId'])
             ->getMock();
-        $orderMock->method('save')->willReturnSelf();
-        $orderMock->method('getEmailSent')->willReturn(false);
-        $orderMock->method('getStore');
-        $orderMock->method('getIncrementId')->willReturn(rand(1, 100));
+        $orderMock->method('getEmailSent')->willReturn($emailSent);
+        $orderMock->method('getIncrementId')->willReturn('100000001');
+        $orderMock->method('getId')->willReturn(1);
 
-        // Create a concrete mock class instead of trying to mock the abstract MethodInterface
-        $methodInstanceMock = $this->getMockBuilder(\stdClass::class)->getMock();
-        $methodInstanceMock->usesRedirect = false;
+        return $orderMock;
+    }
+
+    /**
+     * @param \PHPUnit\Framework\MockObject\MockObject $orderMock
+     * @param bool                                     $usesRedirect
+     *
+     * @return \PHPUnit\Framework\MockObject\MockObject
+     */
+    private function createBuckarooPaymentMock($orderMock, bool $usesRedirect)
+    {
+        $methodInstance = new \stdClass();
+        $methodInstance->usesRedirect = $usesRedirect;
 
         $paymentMock = $this->getFakeMock(Payment::class)
             ->onlyMethods(['getMethod', 'getOrder', 'getMethodInstance'])
             ->getMock();
-        $paymentMock->method('getMethod')->willReturn('buckaroo_magento2');
+        $paymentMock->method('getMethod')->willReturn('buckaroo_magento2_ideal');
         $paymentMock->method('getOrder')->willReturn($orderMock);
-        $paymentMock->method('getMethodInstance')->willReturn($methodInstanceMock);
+        $paymentMock->method('getMethodInstance')->willReturn($methodInstance);
 
-        $observerMock = $this->getFakeMock(Observer::class)->addMethods(['getPayment'])->getMock();
+        return $paymentMock;
+    }
+
+    /**
+     * @param \PHPUnit\Framework\MockObject\MockObject $paymentMock
+     *
+     * @return \PHPUnit\Framework\MockObject\MockObject
+     */
+    private function createObserverMock($paymentMock)
+    {
+        $observerMock = $this->getFakeMock(ObserverStub::class)
+            ->onlyMethods(['getPayment'])
+            ->getMock();
         $observerMock->method('getPayment')->willReturn($paymentMock);
 
-        $accountConfigMock = $this->getFakeMock(Account::class)->onlyMethods(['getOrderConfirmationEmail','getCreateOrderBeforeTransaction'])->getMock();
-        $accountConfigMock->method('getOrderConfirmationEmail')->willReturn(true);
-        $accountConfigMock->method('getCreateOrderBeforeTransaction')->willReturn(false);
+        return $observerMock;
+    }
 
-        $instance = $this->getInstance(['accountConfig' => $accountConfigMock]);
-        $result = $instance->execute($observerMock);
+    /**
+     * @return \PHPUnit\Framework\MockObject\MockObject
+     */
+    private function createOrderSenderMock()
+    {
+        return $this->getFakeMock(OrderSender::class)
+            ->onlyMethods(['send'])
+            ->getMock();
+    }
 
-        // Add assertion to verify method execution for non-redirect payments
-        $this->assertNull($result, 'Execute should handle non-redirect payments and process order email');
+    /**
+     * @return \PHPUnit\Framework\MockObject\MockObject
+     */
+    private function createAccountConfigMock()
+    {
+        return $this->getFakeMock(Account::class)
+            ->onlyMethods(['getOrderConfirmationEmail', 'getCreateOrderBeforeTransaction'])
+            ->getMock();
+    }
+
+    /**
+     * @return \PHPUnit\Framework\MockObject\MockObject
+     */
+    private function createLoggerMock()
+    {
+        return $this->getMockBuilder(BuckarooLoggerInterface::class)->getMock();
     }
 }

--- a/Test/Unit/Observer/SetBuckarooFeeTest.php
+++ b/Test/Unit/Observer/SetBuckarooFeeTest.php
@@ -36,16 +36,13 @@ class SetBuckarooFeeTest extends BaseTest
      */
     public function testInvoiceRegisterHappyPath()
     {
-        $quoteMock = $this->getMockBuilder(Quote::class)
+        $quoteMock = $this->getMockBuilder(\Buckaroo\Magento2\Test\Unit\Stubs\QuoteStub::class)
             ->disableOriginalConstructor()
-            ->addMethods(['getBaseBuckarooFee'])
-            ->getMock();
+            ->onlyMethods(['getBaseBuckarooFee'])->getMock();
         $quoteMock->method('getBaseBuckarooFee')->willReturn(false);
 
-        $observerMock = $this->getMockBuilder(Observer::class)
-            ->onlyMethods(['getEvent'])
-            ->addMethods(['getQuote'])
-            ->getMock();
+        $observerMock = $this->getMockBuilder(\Buckaroo\Magento2\Test\Unit\Stubs\ObserverStub::class)
+            ->onlyMethods(['getEvent', 'getQuote'])->getMock();
         $observerMock->method('getEvent')->willReturnSelf();
         $observerMock->method('getQuote')->willReturn($quoteMock);
 
@@ -68,17 +65,9 @@ class SetBuckarooFeeTest extends BaseTest
         $getBaseBuckarooFeeInclTax = rand(1, 1000);
         $getBuckarooFeeBaseTaxAmount = rand(1, 1000);
 
-        $orderMock = $this->getMockBuilder(Order::class)
+        $orderMock = $this->getMockBuilder(\Buckaroo\Magento2\Test\Unit\Stubs\OrderStub::class)
             ->disableOriginalConstructor()
-            ->addMethods([
-                'setBuckarooFee',
-                'setBaseBuckarooFee',
-                'setBuckarooFeeInclTax',
-                'setBuckarooFeeTaxAmount',
-                'setBaseBuckarooFeeInclTax',
-                'setBuckarooFeeBaseTaxAmount'
-            ])
-            ->getMock();
+            ->onlyMethods(['setBuckarooFee', 'setBaseBuckarooFee', 'setBuckarooFeeInclTax', 'setBuckarooFeeTaxAmount', 'setBaseBuckarooFeeInclTax', 'setBuckarooFeeBaseTaxAmount'])->getMock();
         $orderMock->expects($this->once())->method('setBuckarooFee')->with($buckarooFee);
         $orderMock->expects($this->once())->method('setBaseBuckarooFee')->with($buckarooBaseFee);
         $orderMock->expects($this->once())->method('setBuckarooFeeInclTax')->with($getBuckarooFeeInclTax);
@@ -86,17 +75,9 @@ class SetBuckarooFeeTest extends BaseTest
         $orderMock->expects($this->once())->method('setBaseBuckarooFeeInclTax')->with($getBaseBuckarooFeeInclTax);
         $orderMock->expects($this->once())->method('setBuckarooFeeBaseTaxAmount')->with($getBuckarooFeeBaseTaxAmount);
 
-        $quoteMock = $this->getMockBuilder(Quote::class)
+        $quoteMock = $this->getMockBuilder(\Buckaroo\Magento2\Test\Unit\Stubs\QuoteStub::class)
             ->disableOriginalConstructor()
-            ->addMethods([
-                'getBuckarooFee',
-                'getBaseBuckarooFee',
-                'getBuckarooFeeInclTax',
-                'getBuckarooFeeTaxAmount',
-                'getBaseBuckarooFeeInclTax',
-                'getBuckarooFeeBaseTaxAmount'
-            ])
-            ->getMock();
+            ->onlyMethods(['getBuckarooFee', 'getBaseBuckarooFee', 'getBuckarooFeeInclTax', 'getBuckarooFeeTaxAmount', 'getBaseBuckarooFeeInclTax', 'getBuckarooFeeBaseTaxAmount'])->getMock();
         $quoteMock->method('getBuckarooFee')->willReturn($buckarooFee);
         $quoteMock->method('getBaseBuckarooFee')->willReturn($buckarooBaseFee);
         $quoteMock->method('getBuckarooFeeInclTax')->willReturn($getBuckarooFeeInclTax);
@@ -104,10 +85,8 @@ class SetBuckarooFeeTest extends BaseTest
         $quoteMock->method('getBaseBuckarooFeeInclTax')->willReturn($getBaseBuckarooFeeInclTax);
         $quoteMock->method('getBuckarooFeeBaseTaxAmount')->willReturn($getBuckarooFeeBaseTaxAmount);
 
-        $observerMock = $this->getMockBuilder(Observer::class)
-            ->onlyMethods(['getEvent'])
-            ->addMethods(['getQuote', 'getOrder'])
-            ->getMock();
+        $observerMock = $this->getMockBuilder(\Buckaroo\Magento2\Test\Unit\Stubs\ObserverStub::class)
+            ->onlyMethods(['getEvent', 'getQuote', 'getOrder'])->getMock();
         $observerMock->method('getEvent')->willReturnSelf();
         $observerMock->method('getOrder')->willReturn($orderMock);
         $observerMock->method('getQuote')->willReturn($quoteMock);

--- a/Test/Unit/Observer/UpdateOrderStatusTest.php
+++ b/Test/Unit/Observer/UpdateOrderStatusTest.php
@@ -21,61 +21,157 @@
 
 namespace Buckaroo\Magento2\Test\Unit\Observer;
 
-use Magento\Framework\Event\Observer;
 use Buckaroo\Magento2\Model\ConfigProvider\Account;
 use Buckaroo\Magento2\Observer\UpdateOrderStatus;
 use Buckaroo\Magento2\Test\BaseTest;
+use Buckaroo\Magento2\Test\Unit\Stubs\ObserverStub;
+use Magento\Sales\Model\Order;
+use Magento\Sales\Model\Order\Payment;
 
 class UpdateOrderStatusTest extends BaseTest
 {
     protected $instanceClass = UpdateOrderStatus::class;
 
     /**
-     * Test what happens when this function is called but the payment method is not Buckaroo.
+     * A non-Buckaroo payment method must cause an early return: the order is
+     * never loaded and the account configuration is never consulted.
      */
-    public function testExecuteNotBuckaroo()
+    public function testExecuteNotBuckarooDoesNothing()
     {
-        $observerMock = $this->getMockBuilder(Observer::class)
-            ->onlyMethods(['getEvent'])
-            ->addMethods(['getPayment', 'getMethod'])
+        $paymentMock = $this->getFakeMock(Payment::class)
+            ->onlyMethods(['getMethod', 'getOrder'])
             ->getMock();
-        $observerMock->method('getPayment')->willReturnSelf();
-        $observerMock->method('getMethod')->willReturn('other_payment_method');
+        $paymentMock->method('getMethod')->willReturn('other_payment_method');
+        $paymentMock->expects($this->never())->method('getOrder');
 
-        $instance = $this->getInstance();
-        $result = $instance->execute($observerMock);
-
-        // Add assertion to verify method execution for non-Buckaroo payments
-        $this->assertNull($result, 'Execute should return null for non-Buckaroo payment methods');
-    }
-
-    /**
-     * Test what happens when the payment method is Buckaroo.
-     */
-    public function testExecuteIsBuckaroo()
-    {
-        $observerMock = $this->getMockBuilder(Observer::class)
-            ->onlyMethods(['getEvent'])
-            ->addMethods(['getPayment', 'getMethod', 'getOrder', 'getStore', 'setStatus'])
+        $observerMock = $this->getFakeMock(ObserverStub::class)
+            ->onlyMethods(['getPayment'])
             ->getMock();
-        $observerMock->method('getPayment')->willReturnSelf();
-        $observerMock->method('getMethod')->willReturn('buckaroo_magento2');
-        $observerMock->method('getOrder')->willReturnSelf();
-        $observerMock->method('getStore')->willReturnSelf();
-        $observerMock->method('setStatus')->willReturn('buckaroo_magento2_pending_paymen');
+        $observerMock->method('getPayment')->willReturn($paymentMock);
 
         $accountMock = $this->getFakeMock(Account::class)
             ->onlyMethods(['getOrderStatusNew', 'getCreateOrderBeforeTransaction'])
             ->getMock();
-        $accountMock
-            ->method('getOrderStatusNew')
-            ->willReturn('buckaroo_magento2_pending_paymen');
-        $accountMock->method('getCreateOrderBeforeTransaction')->willReturn(0);
+        $accountMock->expects($this->never())->method('getOrderStatusNew');
+        $accountMock->expects($this->never())->method('getCreateOrderBeforeTransaction');
 
-        $instance = $this->getInstance(['accountConfig' => $accountMock]);
-        $result = $instance->execute($observerMock);
+        $instance = $this->getInstance(['account' => $accountMock]);
+        $instance->execute($observerMock);
+    }
 
-        // Add assertion to verify method execution for Buckaroo payments
-        $this->assertNull($result, 'Execute should handle Buckaroo payment method and update order status');
+    /**
+     * When the configured new status is one of the allowed statuses and the
+     * order is still 'pending', the observer must set that status on the
+     * order and add the matching status history comment.
+     */
+    public function testExecuteSetsAllowedConfiguredStatusOnPendingOrder()
+    {
+        $newStatus = 'pending_payment';
+
+        $orderMock = $this->getFakeMock(Order::class)
+            ->onlyMethods(['getStore', 'getStatus', 'setStatus', 'addCommentToStatusHistory'])
+            ->getMock();
+        $orderMock->method('getStatus')->willReturn('pending');
+        $orderMock->expects($this->once())
+            ->method('setStatus')
+            ->with($newStatus)
+            ->willReturnSelf();
+        $orderMock->expects($this->once())
+            ->method('addCommentToStatusHistory')
+            ->with(
+                'Order status updated by Buckaroo payment placement to: ' . $newStatus,
+                $newStatus
+            );
+
+        $observerMock = $this->createObserverForBuckarooPayment($orderMock);
+        $accountMock = $this->createAccountMock($newStatus, false);
+
+        $instance = $this->getInstance(['account' => $accountMock]);
+        $instance->execute($observerMock);
+    }
+
+    /**
+     * When the configured new status is processor-managed (e.g. 'processing'),
+     * the observer must NOT change the order status and only add an
+     * informational history comment.
+     */
+    public function testExecuteProcessorManagedStatusOnlyAddsComment()
+    {
+        $orderMock = $this->getFakeMock(Order::class)
+            ->onlyMethods(['getStore', 'getStatus', 'setStatus', 'addCommentToStatusHistory'])
+            ->getMock();
+        $orderMock->method('getStatus')->willReturn('pending');
+        $orderMock->expects($this->never())->method('setStatus');
+        $orderMock->expects($this->once())
+            ->method('addCommentToStatusHistory')
+            ->with('Buckaroo payment placed. Status will be updated by payment processor response.');
+
+        $observerMock = $this->createObserverForBuckarooPayment($orderMock);
+        $accountMock = $this->createAccountMock('processing', false);
+
+        $instance = $this->getInstance(['account' => $accountMock]);
+        $instance->execute($observerMock);
+    }
+
+    /**
+     * When "create order before transaction" is enabled, the observer must
+     * leave the order untouched even for a Buckaroo payment.
+     */
+    public function testExecuteCreateOrderBeforeTransactionLeavesOrderUntouched()
+    {
+        $orderMock = $this->getFakeMock(Order::class)
+            ->onlyMethods(['getStore', 'getStatus', 'setStatus', 'addCommentToStatusHistory'])
+            ->getMock();
+        $orderMock->method('getStatus')->willReturn('pending');
+        $orderMock->expects($this->never())->method('setStatus');
+        $orderMock->expects($this->never())->method('addCommentToStatusHistory');
+
+        $observerMock = $this->createObserverForBuckarooPayment($orderMock);
+        $accountMock = $this->createAccountMock('pending_payment', true);
+
+        $instance = $this->getInstance(['account' => $accountMock]);
+        $instance->execute($observerMock);
+    }
+
+    /**
+     * Build an observer mock exposing a Buckaroo payment for the given order.
+     *
+     * @param \PHPUnit\Framework\MockObject\MockObject $orderMock
+     *
+     * @return \PHPUnit\Framework\MockObject\MockObject
+     */
+    private function createObserverForBuckarooPayment($orderMock)
+    {
+        $paymentMock = $this->getFakeMock(Payment::class)
+            ->onlyMethods(['getMethod', 'getOrder'])
+            ->getMock();
+        $paymentMock->method('getMethod')->willReturn('buckaroo_magento2_ideal');
+        $paymentMock->method('getOrder')->willReturn($orderMock);
+
+        $observerMock = $this->getFakeMock(ObserverStub::class)
+            ->onlyMethods(['getPayment'])
+            ->getMock();
+        $observerMock->method('getPayment')->willReturn($paymentMock);
+
+        return $observerMock;
+    }
+
+    /**
+     * Build an Account config mock with the given new-status configuration.
+     *
+     * @param string $newStatus
+     * @param bool   $createOrderBeforeTransaction
+     *
+     * @return \PHPUnit\Framework\MockObject\MockObject
+     */
+    private function createAccountMock(string $newStatus, bool $createOrderBeforeTransaction)
+    {
+        $accountMock = $this->getFakeMock(Account::class)
+            ->onlyMethods(['getOrderStatusNew', 'getCreateOrderBeforeTransaction'])
+            ->getMock();
+        $accountMock->method('getOrderStatusNew')->willReturn($newStatus);
+        $accountMock->method('getCreateOrderBeforeTransaction')->willReturn($createOrderBeforeTransaction);
+
+        return $accountMock;
     }
 }

--- a/Test/Unit/Observer/VoidCm3PaymentTest.php
+++ b/Test/Unit/Observer/VoidCm3PaymentTest.php
@@ -32,22 +32,15 @@ class VoidCm3PaymentTest extends BaseTest
 
     public function testExecuteNotBuckaroo()
     {
-        $paymentMock = $this->getFakeMock(Payment::class)
-            ->onlyMethods([
-                'getMethod',
-                'getAuthorizationTransaction',
-                'getAdditionalInformation',
-                'getMethodInstance'
-            ])
-            ->addMethods(['createCreditNoteRequest'])
-            ->getMock();
+        $paymentMock = $this->getFakeMock(\Buckaroo\Magento2\Test\Unit\Stubs\PaymentStub::class)
+            ->onlyMethods(['getMethod', 'getAuthorizationTransaction', 'getAdditionalInformation', 'getMethodInstance', 'createCreditNoteRequest'])->getMock();
         $paymentMock->method('getMethod')->willReturn('fake_method');
         $paymentMock->expects($this->never())->method('getAuthorizationTransaction');
         $paymentMock->expects($this->never())->method('getAdditionalInformation');
         $paymentMock->expects($this->never())->method('getMethodInstance');
         $paymentMock->expects($this->never())->method('createCreditNoteRequest');
 
-        $observerMock = $this->getFakeMock(Observer::class)->addMethods(['getPayment'])->getMock();
+        $observerMock = $this->getFakeMock(\Buckaroo\Magento2\Test\Unit\Stubs\ObserverStub::class)->onlyMethods(['getPayment'])->getMock();
         $observerMock->method('getPayment')->willReturn($paymentMock);
 
         $instance = $this->getInstance();
@@ -56,15 +49,8 @@ class VoidCm3PaymentTest extends BaseTest
 
     public function testExecuteNoInvoiceKey()
     {
-        $paymentMock = $this->getFakeMock(Payment::class)
-            ->onlyMethods([
-                'getMethod',
-                'getAuthorizationTransaction',
-                'getAdditionalInformation',
-                'getMethodInstance'
-            ])
-            ->addMethods(['createCreditNoteRequest'])
-            ->getMock();
+        $paymentMock = $this->getFakeMock(\Buckaroo\Magento2\Test\Unit\Stubs\PaymentStub::class)
+            ->onlyMethods(['getMethod', 'getAuthorizationTransaction', 'getAdditionalInformation', 'getMethodInstance', 'createCreditNoteRequest'])->getMock();
         $paymentMock->method('getMethod')->willReturn('buckaroo_magento2_method');
         $paymentMock->method('getAuthorizationTransaction')->willReturn(false);
         $paymentMock->method('getAdditionalInformation')
@@ -73,7 +59,7 @@ class VoidCm3PaymentTest extends BaseTest
         $paymentMock->expects($this->never())->method('getMethodInstance');
         $paymentMock->expects($this->never())->method('createCreditNoteRequest');
 
-        $observerMock = $this->getFakeMock(Observer::class)->addMethods(['getPayment'])->getMock();
+        $observerMock = $this->getFakeMock(\Buckaroo\Magento2\Test\Unit\Stubs\ObserverStub::class)->onlyMethods(['getPayment'])->getMock();
         $observerMock->method('getPayment')->willReturn($paymentMock);
 
         $instance = $this->getInstance();
@@ -83,12 +69,11 @@ class VoidCm3PaymentTest extends BaseTest
     public function testExecuteCreditNoteMethodCalled()
     {
         // Create a method instance mock that has the createCreditNoteRequest method
-        $methodInstanceMock = $this->getMockBuilder(\stdClass::class)
-            ->addMethods(['createCreditNoteRequest'])
+        $methodInstanceMock = $this->getMockBuilder(\Buckaroo\Magento2\Test\Unit\Stubs\StdObjectStub::class)
             ->getMock();
         $methodInstanceMock->expects($this->never())->method('createCreditNoteRequest');
 
-        $voidCommandMock = $this->getFakeMock(\Magento\Payment\Gateway\CommandInterface::class)->onlyMethods(['execute'])->getMockForAbstractClass();
+        $voidCommandMock = $this->getFakeMock(\Magento\Payment\Gateway\CommandInterface::class)->getMock();
         $voidCommandMock->expects($this->once())->method('execute')->with($this->arrayHasKey('payment'));
 
         $paymentMock = $this->getFakeMock(Payment::class)
@@ -106,7 +91,7 @@ class VoidCm3PaymentTest extends BaseTest
             ->willReturn('key');
         $paymentMock->method('getMethodInstance')->willReturn($methodInstanceMock);
 
-        $observerMock = $this->getFakeMock(Observer::class)->addMethods(['getPayment'])->getMock();
+        $observerMock = $this->getFakeMock(\Buckaroo\Magento2\Test\Unit\Stubs\ObserverStub::class)->onlyMethods(['getPayment'])->getMock();
         $observerMock->method('getPayment')->willReturn($paymentMock);
 
         $instance = $this->getInstance(['voidCommand' => $voidCommandMock]);

--- a/Test/Unit/Plugin/AddExtendReservationButtonTest.php
+++ b/Test/Unit/Plugin/AddExtendReservationButtonTest.php
@@ -97,7 +97,7 @@ class AddExtendReservationButtonTest extends TestCase
         // Assert
         $this->buttonListMock->expects($this->once())
             ->method('add')
-            ->with('extendKlarnaReservationButton', $this->isArray(), -1);
+            ->with('extendKlarnaReservationButton', $this->callback('is_array'), -1);
 
         // Act
         $this->plugin->beforePushButtons($this->toolbarMock, $contextMock, $this->buttonListMock);

--- a/Test/Unit/Plugin/AddExtendReservationButtonTest.php
+++ b/Test/Unit/Plugin/AddExtendReservationButtonTest.php
@@ -97,7 +97,7 @@ class AddExtendReservationButtonTest extends TestCase
         // Assert
         $this->buttonListMock->expects($this->once())
             ->method('add')
-            ->with('extendKlarnaReservationButton', $this->isType('array'), -1);
+            ->with('extendKlarnaReservationButton', $this->isArray(), -1);
 
         // Act
         $this->plugin->beforePushButtons($this->toolbarMock, $contextMock, $this->buttonListMock);
@@ -171,10 +171,8 @@ class AddExtendReservationButtonTest extends TestCase
      */
     private function createContextMock(?string $orderId, string $fullActionName)
     {
-        $requestMock = $this->getMockBuilder(RequestInterface::class)
-            ->onlyMethods(['getParam'])
-            ->addMethods(['getFullActionName'])
-            ->getMockForAbstractClass();
+        $requestMock = $this->getMockBuilder(\Buckaroo\Magento2\Test\Unit\Stubs\RequestInterfaceStub::class)
+            ->getMock();
         $requestMock->method('getParam')->with('order_id')->willReturn($orderId);
         $requestMock->method('getFullActionName')->willReturn($fullActionName);
 

--- a/Test/Unit/Service/CreditManagement/ServiceParameters/CreateCombinedInvoiceTest.php
+++ b/Test/Unit/Service/CreditManagement/ServiceParameters/CreateCombinedInvoiceTest.php
@@ -21,6 +21,8 @@
 
 namespace Buckaroo\Magento2\Test\Unit\Service\CreditManagement\ServiceParameters;
 
+
+use PHPUnit\Framework\Attributes\DataProvider;
 use Magento\Sales\Model\Order;
 use Magento\Sales\Model\Order\Address;
 use Magento\Sales\Model\Order\Payment;
@@ -146,8 +148,8 @@ class CreateCombinedInvoiceTest extends BaseTest
      * @param $address
      * @param $expected
      *
-     * @dataProvider getCmAddressProvider
      */
+    #[DataProvider('getCmAddressProvider')]
     public function testGetCmAddress($address, $expected)
     {
         $instance = $this->getInstance();

--- a/Test/Unit/Service/CreditManagement/ServiceParametersTest.php
+++ b/Test/Unit/Service/CreditManagement/ServiceParametersTest.php
@@ -21,6 +21,8 @@
 
 namespace Buckaroo\Magento2\Test\Unit\Service\CreditManagement\ServiceParameters;
 
+
+use PHPUnit\Framework\Attributes\DataProvider;
 use Magento\Sales\Model\Order\Payment;
 use Buckaroo\Magento2\Service\CreditManagement\ServiceParameters;
 use Buckaroo\Magento2\Test\BaseTest;
@@ -122,8 +124,8 @@ class ServiceParametersTest extends BaseTest
      * @param $filter
      * @param $expected
      *
-     * @dataProvider serviceParametersGetProvider
      */
+    #[DataProvider('serviceParametersGetProvider')]
     public function testGetCreateCombinedInvoice($requestParameters, $filter, $expected)
     {
         $infoInstanceMock = $this->getFakeMock(Payment::class, true);
@@ -146,8 +148,8 @@ class ServiceParametersTest extends BaseTest
      * @param $filter
      * @param $expected
      *
-     * @dataProvider serviceParametersGetProvider
      */
+    #[DataProvider('serviceParametersGetProvider')]
     public function testGetCreateCreditNote($requestParameters, $filter, $expected)
     {
         $infoInstanceMock = $this->getFakeMock(Payment::class, true);

--- a/Test/Unit/Service/Culture/CultureCodeResolverTest.php
+++ b/Test/Unit/Service/Culture/CultureCodeResolverTest.php
@@ -21,6 +21,8 @@ declare(strict_types=1);
 
 namespace Buckaroo\Magento2\Test\Unit\Service\Culture;
 
+
+use PHPUnit\Framework\Attributes\DataProvider;
 use Buckaroo\Magento2\Service\Culture\CultureCodeResolver;
 use PHPUnit\Framework\TestCase;
 
@@ -36,9 +38,7 @@ class CultureCodeResolverTest extends TestCase
         $this->resolver = new CultureCodeResolver();
     }
 
-    /**
-     * @dataProvider resolveProvider
-     */
+    #[DataProvider('resolveProvider')]
     public function testResolve(?string $country, ?string $localeHint, string $expected): void
     {
         $this->assertSame($expected, $this->resolver->resolve($country, $localeHint));

--- a/Test/Unit/Service/Formatter/Address/PhoneFormatterTest.php
+++ b/Test/Unit/Service/Formatter/Address/PhoneFormatterTest.php
@@ -21,6 +21,8 @@
 
 namespace Buckaroo\Magento2\Test\Unit\Service\Formatter\Address;
 
+
+use PHPUnit\Framework\Attributes\DataProvider;
 use Buckaroo\Magento2\Service\Formatter\Address\PhoneFormatter;
 use Buckaroo\Magento2\Test\BaseTest;
 
@@ -144,8 +146,8 @@ class PhoneFormatterTest extends BaseTest
      * @param $country
      * @param $expected
      *
-     * @dataProvider formatProvider
      */
+    #[DataProvider('formatProvider')]
     public function testFormat($number, $country, $expected)
     {
         $instance = $this->getInstance();

--- a/Test/Unit/Service/Formatter/Address/StreetFormatterTest.php
+++ b/Test/Unit/Service/Formatter/Address/StreetFormatterTest.php
@@ -21,6 +21,8 @@
 
 namespace Buckaroo\Magento2\Test\Unit\Service\Formatter\Address;
 
+
+use PHPUnit\Framework\Attributes\DataProvider;
 use Buckaroo\Magento2\Service\Formatter\Address\StreetFormatter;
 use Buckaroo\Magento2\Test\BaseTest;
 
@@ -73,8 +75,8 @@ class StreetFormatterTest extends BaseTest
      * @param $street
      * @param $expected
      *
-     * @dataProvider formatProvider
      */
+    #[DataProvider('formatProvider')]
     public function testFormat($street, $expected)
     {
         $instance = $this->getInstance();

--- a/Test/Unit/Service/OauthTokenServiceTest.php
+++ b/Test/Unit/Service/OauthTokenServiceTest.php
@@ -77,7 +77,7 @@ class OauthTokenServiceTest extends BaseTest
         $cache->expects($this->once())->method('load')->willReturn(false);
         $cache->expects($this->once())
             ->method('save')
-            ->with('encrypted-cache-payload', $this->isType('string'), [], 3540);
+            ->with('encrypted-cache-payload', $this->isString(), [], 3540);
 
         $curl = $this->createMock(Curl::class);
         $curl->expects($this->once())->method('setTimeout');

--- a/Test/Unit/Service/OauthTokenServiceTest.php
+++ b/Test/Unit/Service/OauthTokenServiceTest.php
@@ -77,7 +77,7 @@ class OauthTokenServiceTest extends BaseTest
         $cache->expects($this->once())->method('load')->willReturn(false);
         $cache->expects($this->once())
             ->method('save')
-            ->with('encrypted-cache-payload', $this->isString(), [], 3540);
+            ->with('encrypted-cache-payload', $this->callback('is_string'), [], 3540);
 
         $curl = $this->createMock(Curl::class);
         $curl->expects($this->once())->method('setTimeout');

--- a/Test/Unit/Service/Sales/Pdf/BuckarooFeeTest.php
+++ b/Test/Unit/Service/Sales/Pdf/BuckarooFeeTest.php
@@ -21,6 +21,8 @@
 
 namespace Buckaroo\Magento2\Test\Unit\Service\Sales\Pdf;
 
+
+use PHPUnit\Framework\Attributes\DataProvider;
 use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Sales\Model\Order;
 use Buckaroo\Magento2\Helper\PaymentFee;
@@ -88,11 +90,11 @@ class BuckarooFeeTest extends BaseTest
      * @param $displayType
      * @param $expected
      *
-     * @dataProvider getTotalsForDisplayProvider
      */
+    #[DataProvider('getTotalsForDisplayProvider')]
     public function testGetTotalsForDisplay($amountExclTax, $amountInclTax, $label, $displayType, $expected)
     {
-        $scopeInterfaceMock = $this->getMockForAbstractClass(ScopeConfigInterface::class);
+        $scopeInterfaceMock = $this->createMock(ScopeConfigInterface::class);
         $scopeInterfaceMock->method('getValue')->willReturn($displayType);
 
         $paymentFeeMock = $this->getFakeMock(PaymentFee::class)->onlyMethods(['getBuckarooPaymentFeeLabel'])->getMock();

--- a/Test/Unit/Service/Sales/Quote/RecreateTest.php
+++ b/Test/Unit/Service/Sales/Quote/RecreateTest.php
@@ -76,10 +76,8 @@ class RecreateTest extends \Buckaroo\Magento2\Test\BaseTest
 
         $this->cartRepository = $this->getFakeMock(CartRepositoryInterface::class)->getMock();
         $this->cart = $this->getFakeMock(Cart::class)->getMock();
-        $this->checkoutSession = $this->getFakeMock(CheckoutSession::class, false)
-            ->addMethods(['unsLastRealOrderId', 'unsLastOrderId', 'unsLastSuccessQuoteId', 'unsRedirectUrl', 'unsLastQuoteId'])
-            ->onlyMethods(['replaceQuote', 'setQuoteId'])
-            ->getMock();
+        $this->checkoutSession = $this->getFakeMock(\Buckaroo\Magento2\Test\Unit\Stubs\SessionStub2::class, false)
+            ->onlyMethods(['replaceQuote', 'setQuoteId', 'unsLastRealOrderId', 'unsLastOrderId', 'unsLastSuccessQuoteId', 'unsRedirectUrl', 'unsLastQuoteId'])->getMock();
         $this->quoteFactory = $this->getFakeMock(QuoteFactory::class)->getMock();
         $this->productFactory = $this->getFakeMock(ProductFactory::class)->getMock();
         $this->messageManager = $this->getFakeMock(ManagerInterface::class)->getMock();
@@ -170,19 +168,15 @@ class RecreateTest extends \Buckaroo\Magento2\Test\BaseTest
         $oldQuote = $this->getFakeMock(Quote::class, false)
             ->onlyMethods(['load', 'getId', 'getPayment', 'setIsActive', 'save'])
             ->getMock();
-        $newQuote = $this->getFakeMock(Quote::class, false)
-            ->onlyMethods(['setStore', 'setStoreId', 'getBillingAddress', 'getShippingAddress', 'setIsActive', 'collectTotals', 'save', 'addProduct', 'setCustomerIsGuest', 'getPayment', 'getCustomerIsGuest'])
-            ->addMethods(['setCustomerId', 'setCustomerEmail', 'setCustomerFirstname', 'setCustomerLastname', 'getCustomerId', 'getCustomerEmail', 'getCustomerFirstname', 'getCustomerLastname'])
-            ->getMock();
+        $newQuote = $this->getFakeMock(\Buckaroo\Magento2\Test\Unit\Stubs\QuoteStub::class, false)
+            ->onlyMethods(['setStore', 'setStoreId', 'getBillingAddress', 'getShippingAddress', 'setIsActive', 'collectTotals', 'save', 'addProduct', 'setCustomerIsGuest', 'getPayment', 'getCustomerIsGuest', 'setCustomerId', 'setCustomerEmail', 'setCustomerFirstname', 'setCustomerLastname', 'getCustomerId', 'getCustomerEmail', 'getCustomerFirstname', 'getCustomerLastname'])->getMock();
         $store = $this->getFakeMock(Store::class)->getMock();
         $billingAddress = $this->getFakeMock(Address::class)->getMock();
         $shippingAddress = $this->getFakeMock(Address::class)->getMock();
-        $quoteBillingAddress = $this->getFakeMock(\Magento\Quote\Model\Quote\Address::class)
-            ->addMethods(['importOrderAddress'])
-            ->getMock();
-        $quoteShippingAddress = $this->getFakeMock(\Magento\Quote\Model\Quote\Address::class)
-            ->addMethods(['importOrderAddress', 'setShippingMethod', 'setCollectShippingRates'])
-            ->getMock();
+        $quoteBillingAddress = $this->getFakeMock(\Buckaroo\Magento2\Test\Unit\Stubs\AddressStub::class)
+            ->onlyMethods(['importOrderAddress'])->getMock();
+        $quoteShippingAddress = $this->getFakeMock(\Buckaroo\Magento2\Test\Unit\Stubs\AddressStub::class)
+            ->onlyMethods(['importOrderAddress', 'setShippingMethod', 'setCollectShippingRates'])->getMock();
 
         // Setup order data
         $order->method('getIncrementId')->willReturn('000000001');
@@ -296,10 +290,8 @@ class RecreateTest extends \Buckaroo\Magento2\Test\BaseTest
     {
         $order = $this->getFakeMock(Order::class)->getMock();
         $oldQuote = $this->getFakeMock(Quote::class)->getMock();
-        $newQuote = $this->getFakeMock(Quote::class, false)
-            ->onlyMethods(['setStore', 'setStoreId', 'getBillingAddress', 'getShippingAddress', 'setIsActive', 'collectTotals', 'save', 'setCustomerIsGuest', 'getCustomerIsGuest'])
-            ->addMethods(['setCustomerEmail', 'setCustomerFirstname', 'setCustomerLastname', 'getCustomerId', 'getCustomerEmail', 'getCustomerFirstname', 'getCustomerLastname'])
-            ->getMock();
+        $newQuote = $this->getFakeMock(\Buckaroo\Magento2\Test\Unit\Stubs\QuoteStub::class, false)
+            ->onlyMethods(['setStore', 'setStoreId', 'getBillingAddress', 'getShippingAddress', 'setIsActive', 'collectTotals', 'save', 'setCustomerIsGuest', 'getCustomerIsGuest', 'setCustomerEmail', 'setCustomerFirstname', 'setCustomerLastname', 'getCustomerId', 'getCustomerEmail', 'getCustomerFirstname', 'getCustomerLastname'])->getMock();
         $store = $this->getFakeMock(Store::class)->getMock();
 
         // Setup guest order

--- a/Test/Unit/Service/Sales/Transaction/CancelTest.php
+++ b/Test/Unit/Service/Sales/Transaction/CancelTest.php
@@ -21,6 +21,8 @@
 
 namespace Buckaroo\Magento2\Test\Unit\Service\Sales\Transaction;
 
+
+use PHPUnit\Framework\Attributes\DataProvider;
 use Magento\Sales\Api\OrderPaymentRepositoryInterface;
 use Magento\Sales\Model\Order;
 use Magento\Sales\Model\Order\Payment;
@@ -69,16 +71,15 @@ class CancelTest extends BaseTest
      * @param $orderCancel
      * @param $expectedCallCount
      *
-     * @dataProvider cancelProvider
      */
+    #[DataProvider('cancelProvider')]
     public function testCancel($accountCancel, $orderCancel, $expectedCallCount)
     {
         $paymentMock = $this->getFakeMock(Payment::class)->onlyMethods(['getMethodInstance', 'cancel'])->getMock();
         $paymentMock->method('getMethodInstance')->willReturnSelf();
 
         $paymentRepositoryMock = $this->getFakeMock(OrderPaymentRepositoryInterface::class)
-            ->onlyMethods(['get'])
-            ->getMockForAbstractClass();
+            ->getMock();
         $paymentRepositoryMock->method('get')->willReturn($paymentMock);
 
         $accountMock = $this->getFakeMock(Account::class)->onlyMethods(['getCancelOnFailed'])->getMock();
@@ -123,14 +124,14 @@ class CancelTest extends BaseTest
      * @param $method
      * @param $expectedCallCount
      *
-     * @dataProvider cancelOrderProvider
      */
+    #[DataProvider('cancelOrderProvider')]
     public function testCancelOrder($method, $expectedCallCount)
     {
         $methodInstanceMock = $this->getMockBuilder(\Magento\Payment\Model\Method\AbstractMethod::class)
             ->disableOriginalConstructor()
             ->onlyMethods(['getCode'])
-            ->getMockForAbstractClass();
+            ->getMock();
         $methodInstanceMock->method('getCode')->willReturn($method);
         $paymentMock = $this->getFakeMock(Payment::class)
             ->onlyMethods(['getMethodInstance', 'setAdditionalInformation', 'save'])
@@ -175,8 +176,8 @@ class CancelTest extends BaseTest
      * @param $state
      * @param $expectedParameter
      *
-     * @dataProvider updateStatusProvider
      */
+    #[DataProvider('updateStatusProvider')]
     public function testUpdateStatus($state, $expectedParameter)
     {
         $orderMock = $this->getFakeMock(Order::class)
@@ -208,8 +209,7 @@ class CancelTest extends BaseTest
         $paymentMock->method('cancel')->with($paymentMock);
 
         $paymentRepositoryMock = $this->getFakeMock(OrderPaymentRepositoryInterface::class)
-            ->onlyMethods(['get'])
-            ->getMockForAbstractClass();
+            ->getMock();
         $paymentRepositoryMock->method('get')->with(123)->willReturn($paymentMock);
 
         $instance = $this->getInstance(['orderPaymentRepository' => $paymentRepositoryMock]);

--- a/Test/Unit/Service/Software/DataTest.php
+++ b/Test/Unit/Service/Software/DataTest.php
@@ -21,6 +21,8 @@
 
 namespace Buckaroo\Magento2\Test\Unit\Service\Software;
 
+
+use PHPUnit\Framework\Attributes\DataProvider;
 use Magento\Framework\App\ProductMetadataInterface;
 use Magento\Framework\Module\ModuleListInterface;
 use Buckaroo\Magento2\Service\Software\Data;
@@ -72,8 +74,8 @@ class DataTest extends BaseTest
      * @param $module
      * @param $expected
      *
-     * @dataProvider getProvider
      */
+    #[DataProvider('getProvider')]
     public function testGet($name, $edition, $version, $module, $expected)
     {
         $productMetadataMock = $this->getFakeMock(ProductMetadataInterface::class)->getMock();

--- a/Test/Unit/Service/TransactionCurrencyResolverTest.php
+++ b/Test/Unit/Service/TransactionCurrencyResolverTest.php
@@ -21,6 +21,8 @@ declare(strict_types=1);
 
 namespace Buckaroo\Magento2\Test\Unit\Service;
 
+
+use PHPUnit\Framework\Attributes\DataProvider;
 use Buckaroo\Magento2\Exception;
 use Buckaroo\Magento2\Model\ConfigProvider\Factory;
 use Buckaroo\Magento2\Model\ConfigProvider\Method\AbstractConfigProvider;
@@ -62,7 +64,6 @@ class TransactionCurrencyResolverTest extends TestCase
     }
 
     /**
-     * @dataProvider resolveDataProvider
      *
      * @param string      $orderCurrency
      * @param array       $allowedCurrencies
@@ -70,6 +71,7 @@ class TransactionCurrencyResolverTest extends TestCase
      *
      * @throws Exception
      */
+    #[DataProvider('resolveDataProvider')]
     public function testResolve(
         string $orderCurrency,
         array $allowedCurrencies,
@@ -151,7 +153,7 @@ class TransactionCurrencyResolverTest extends TestCase
         $configProviderMock = $this->getMockBuilder(AbstractConfigProvider::class)
             ->disableOriginalConstructor()
             ->onlyMethods(['getAllowedCurrencies'])
-            ->getMockForAbstractClass();
+            ->getMock();
         $configProviderMock->method('getAllowedCurrencies')->willReturn($allowedCurrencies);
 
         $this->configProviderMethodFactoryMock->method('get')

--- a/Test/Unit/Stubs/AbstractResourceStub.php
+++ b/Test/Unit/Stubs/AbstractResourceStub.php
@@ -5,6 +5,8 @@ namespace Buckaroo\Magento2\Test\Unit\Stubs;
 /**
  * PHPUnit 12 replacement for MockBuilder::addMethods() on \Magento\Framework\Model\ResourceModel\AbstractResource.
  * Declares the magic methods tests need to configure on their doubles.
+ *
+ * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  */
 class AbstractResourceStub extends \Magento\Framework\Model\ResourceModel\AbstractResource
 {

--- a/Test/Unit/Stubs/AbstractResourceStub.php
+++ b/Test/Unit/Stubs/AbstractResourceStub.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Buckaroo\Magento2\Test\Unit\Stubs;
+
+/**
+ * PHPUnit 12 replacement for MockBuilder::addMethods() on \Magento\Framework\Model\ResourceModel\AbstractResource.
+ * Declares the magic methods tests need to configure on their doubles.
+ */
+class AbstractResourceStub extends \Magento\Framework\Model\ResourceModel\AbstractResource
+{
+    public function save(...$args)
+    {
+        return null;
+    }
+
+    protected function _construct()
+    {
+    }
+
+    public function getConnection()
+    {
+        return null;
+    }
+}

--- a/Test/Unit/Stubs/AccountStub.php
+++ b/Test/Unit/Stubs/AccountStub.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Buckaroo\Magento2\Test\Unit\Stubs;
+
+/**
+ * PHPUnit 12 replacement for MockBuilder::addMethods() on \Buckaroo\Magento2\Model\ConfigProvider\Account.
+ * Declares the magic methods tests need to configure on their doubles.
+ */
+class AccountStub extends \Buckaroo\Magento2\Model\ConfigProvider\Account
+{
+    public function getMerchantGuid(...$args)
+    {
+        return null;
+    }
+}

--- a/Test/Unit/Stubs/AccountStub.php
+++ b/Test/Unit/Stubs/AccountStub.php
@@ -5,6 +5,8 @@ namespace Buckaroo\Magento2\Test\Unit\Stubs;
 /**
  * PHPUnit 12 replacement for MockBuilder::addMethods() on \Buckaroo\Magento2\Model\ConfigProvider\Account.
  * Declares the magic methods tests need to configure on their doubles.
+ *
+ * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  */
 class AccountStub extends \Buckaroo\Magento2\Model\ConfigProvider\Account
 {

--- a/Test/Unit/Stubs/AddressStub.php
+++ b/Test/Unit/Stubs/AddressStub.php
@@ -5,6 +5,8 @@ namespace Buckaroo\Magento2\Test\Unit\Stubs;
 /**
  * PHPUnit 12 replacement for MockBuilder::addMethods() on \Magento\Quote\Model\Quote\Address.
  * Declares the magic methods tests need to configure on their doubles.
+ *
+ * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  */
 class AddressStub extends \Magento\Quote\Model\Quote\Address
 {

--- a/Test/Unit/Stubs/AddressStub.php
+++ b/Test/Unit/Stubs/AddressStub.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Buckaroo\Magento2\Test\Unit\Stubs;
+
+/**
+ * PHPUnit 12 replacement for MockBuilder::addMethods() on \Magento\Quote\Model\Quote\Address.
+ * Declares the magic methods tests need to configure on their doubles.
+ */
+class AddressStub extends \Magento\Quote\Model\Quote\Address
+{
+    public function getAddress(...$args)
+    {
+        return null;
+    }
+
+    public function importOrderAddress(...$args)
+    {
+        return null;
+    }
+
+    public function setCollectShippingRates(...$args)
+    {
+        return $this;
+    }
+
+    public function setShippingMethod(...$args)
+    {
+        return $this;
+    }
+
+    public function setShouldIgnoreValidation(...$args)
+    {
+        return $this;
+    }
+}

--- a/Test/Unit/Stubs/BuckarooAdapterStub.php
+++ b/Test/Unit/Stubs/BuckarooAdapterStub.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Buckaroo\Magento2\Test\Unit\Stubs;
+
+/**
+ * PHPUnit 12 replacement for MockBuilder::addMethods() on \Buckaroo\Magento2\Model\Method\BuckarooAdapter.
+ * Declares the magic methods tests need to configure on their doubles.
+ */
+class BuckarooAdapterStub extends \Buckaroo\Magento2\Model\Method\BuckarooAdapter
+{
+    public function getBuckarooPaymentMethodCode(...$args)
+    {
+        return null;
+    }
+}

--- a/Test/Unit/Stubs/BuckarooAdapterStub.php
+++ b/Test/Unit/Stubs/BuckarooAdapterStub.php
@@ -5,6 +5,8 @@ namespace Buckaroo\Magento2\Test\Unit\Stubs;
 /**
  * PHPUnit 12 replacement for MockBuilder::addMethods() on \Buckaroo\Magento2\Model\Method\BuckarooAdapter.
  * Declares the magic methods tests need to configure on their doubles.
+ *
+ * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  */
 class BuckarooAdapterStub extends \Buckaroo\Magento2\Model\Method\BuckarooAdapter
 {

--- a/Test/Unit/Stubs/BuckarooFeeStub.php
+++ b/Test/Unit/Stubs/BuckarooFeeStub.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Buckaroo\Magento2\Test\Unit\Stubs;
+
+/**
+ * PHPUnit 12 replacement for MockBuilder::addMethods() on \Buckaroo\Magento2\Model\ConfigProvider\BuckarooFee.
+ * Declares the magic methods tests need to configure on their doubles.
+ */
+class BuckarooFeeStub extends \Buckaroo\Magento2\Model\ConfigProvider\BuckarooFee
+{
+    public function getPaymentFeeTax(...$args)
+    {
+        return null;
+    }
+
+    public function getTaxClass(...$args)
+    {
+        return null;
+    }
+}

--- a/Test/Unit/Stubs/BuckarooFeeStub.php
+++ b/Test/Unit/Stubs/BuckarooFeeStub.php
@@ -5,6 +5,8 @@ namespace Buckaroo\Magento2\Test\Unit\Stubs;
 /**
  * PHPUnit 12 replacement for MockBuilder::addMethods() on \Buckaroo\Magento2\Model\ConfigProvider\BuckarooFee.
  * Declares the magic methods tests need to configure on their doubles.
+ *
+ * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  */
 class BuckarooFeeStub extends \Buckaroo\Magento2\Model\ConfigProvider\BuckarooFee
 {

--- a/Test/Unit/Stubs/CreditmemoStub.php
+++ b/Test/Unit/Stubs/CreditmemoStub.php
@@ -5,6 +5,8 @@ namespace Buckaroo\Magento2\Test\Unit\Stubs;
 /**
  * PHPUnit 12 replacement for MockBuilder::addMethods() on \Magento\Sales\Model\Order\Creditmemo.
  * Declares the magic methods tests need to configure on their doubles.
+ *
+ * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  */
 class CreditmemoStub extends \Magento\Sales\Model\Order\Creditmemo
 {

--- a/Test/Unit/Stubs/CreditmemoStub.php
+++ b/Test/Unit/Stubs/CreditmemoStub.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Buckaroo\Magento2\Test\Unit\Stubs;
+
+/**
+ * PHPUnit 12 replacement for MockBuilder::addMethods() on \Magento\Sales\Model\Order\Creditmemo.
+ * Declares the magic methods tests need to configure on their doubles.
+ */
+class CreditmemoStub extends \Magento\Sales\Model\Order\Creditmemo
+{
+    public function getBaseBuckarooFee(...$args)
+    {
+        return null;
+    }
+
+    public function getBuckarooFee(...$args)
+    {
+        return null;
+    }
+
+    public function setBaseBuckarooFee(...$args)
+    {
+        return $this;
+    }
+
+    public function setBuckarooFee(...$args)
+    {
+        return $this;
+    }
+}

--- a/Test/Unit/Stubs/DataStub.php
+++ b/Test/Unit/Stubs/DataStub.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Buckaroo\Magento2\Test\Unit\Stubs;
+
+/**
+ * PHPUnit 12 replacement for MockBuilder::addMethods() on \Buckaroo\Magento2\Helper\Data.
+ * Declares the magic methods tests need to configure on their doubles.
+ */
+class DataStub extends \Buckaroo\Magento2\Helper\Data
+{
+    public function setRestoreQuoteLastOrder(...$args)
+    {
+        return $this;
+    }
+}

--- a/Test/Unit/Stubs/DataStub.php
+++ b/Test/Unit/Stubs/DataStub.php
@@ -7,6 +7,7 @@ namespace Buckaroo\Magento2\Test\Unit\Stubs;
  * Declares the magic methods tests need to configure on their doubles.
  *
  * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+ * @SuppressWarnings(PHPMD.CookieAndSessionMisuse)
  */
 class DataStub extends \Buckaroo\Magento2\Helper\Data
 {

--- a/Test/Unit/Stubs/DataStub.php
+++ b/Test/Unit/Stubs/DataStub.php
@@ -5,6 +5,8 @@ namespace Buckaroo\Magento2\Test\Unit\Stubs;
 /**
  * PHPUnit 12 replacement for MockBuilder::addMethods() on \Buckaroo\Magento2\Helper\Data.
  * Declares the magic methods tests need to configure on their doubles.
+ *
+ * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  */
 class DataStub extends \Buckaroo\Magento2\Helper\Data
 {

--- a/Test/Unit/Stubs/FactoryStub.php
+++ b/Test/Unit/Stubs/FactoryStub.php
@@ -5,6 +5,8 @@ namespace Buckaroo\Magento2\Test\Unit\Stubs;
 /**
  * PHPUnit 12 replacement for MockBuilder::addMethods() on \Buckaroo\Magento2\Model\ConfigProvider\Factory.
  * Declares the magic methods tests need to configure on their doubles.
+ *
+ * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  */
 class FactoryStub extends \Buckaroo\Magento2\Model\ConfigProvider\Factory
 {

--- a/Test/Unit/Stubs/FactoryStub.php
+++ b/Test/Unit/Stubs/FactoryStub.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Buckaroo\Magento2\Test\Unit\Stubs;
+
+/**
+ * PHPUnit 12 replacement for MockBuilder::addMethods() on \Buckaroo\Magento2\Model\ConfigProvider\Factory.
+ * Declares the magic methods tests need to configure on their doubles.
+ */
+class FactoryStub extends \Buckaroo\Magento2\Model\ConfigProvider\Factory
+{
+    public function getPaymentFee(...$args)
+    {
+        return null;
+    }
+}

--- a/Test/Unit/Stubs/InvoiceItemStub.php
+++ b/Test/Unit/Stubs/InvoiceItemStub.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Buckaroo\Magento2\Test\Unit\Stubs;
+
+/**
+ * PHPUnit 12 replacement for MockBuilder::addMethods() on \Magento\Sales\Model\Order\Invoice\Item.
+ * Declares the magic methods tests need to configure on their doubles.
+ */
+class InvoiceItemStub extends \Magento\Sales\Model\Order\Invoice\Item
+{
+    public function hasParentItemId(...$args)
+    {
+        return null;
+    }
+
+    public function getWeeeTaxAppliedAmount(...$args)
+    {
+        return null;
+    }
+}

--- a/Test/Unit/Stubs/InvoiceItemStub.php
+++ b/Test/Unit/Stubs/InvoiceItemStub.php
@@ -5,6 +5,8 @@ namespace Buckaroo\Magento2\Test\Unit\Stubs;
 /**
  * PHPUnit 12 replacement for MockBuilder::addMethods() on \Magento\Sales\Model\Order\Invoice\Item.
  * Declares the magic methods tests need to configure on their doubles.
+ *
+ * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  */
 class InvoiceItemStub extends \Magento\Sales\Model\Order\Invoice\Item
 {

--- a/Test/Unit/Stubs/InvoiceStub.php
+++ b/Test/Unit/Stubs/InvoiceStub.php
@@ -5,6 +5,8 @@ namespace Buckaroo\Magento2\Test\Unit\Stubs;
 /**
  * PHPUnit 12 replacement for MockBuilder::addMethods() on \Magento\Sales\Model\Order\Invoice.
  * Declares the magic methods tests need to configure on their doubles.
+ *
+ * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  */
 class InvoiceStub extends \Magento\Sales\Model\Order\Invoice
 {

--- a/Test/Unit/Stubs/InvoiceStub.php
+++ b/Test/Unit/Stubs/InvoiceStub.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Buckaroo\Magento2\Test\Unit\Stubs;
+
+/**
+ * PHPUnit 12 replacement for MockBuilder::addMethods() on \Magento\Sales\Model\Order\Invoice.
+ * Declares the magic methods tests need to configure on their doubles.
+ */
+class InvoiceStub extends \Magento\Sales\Model\Order\Invoice
+{
+    public function getBaseBuckarooFee(...$args)
+    {
+        return null;
+    }
+
+    public function getBaseBuckarooFeeInclTax(...$args)
+    {
+        return null;
+    }
+
+    public function getBuckarooFee(...$args)
+    {
+        return null;
+    }
+
+    public function getBuckarooFeeBaseTaxAmount(...$args)
+    {
+        return null;
+    }
+
+    public function getBuckarooFeeInclTax(...$args)
+    {
+        return null;
+    }
+
+    public function getBuckarooFeeTaxAmount(...$args)
+    {
+        return null;
+    }
+}

--- a/Test/Unit/Stubs/ObserverStub.php
+++ b/Test/Unit/Stubs/ObserverStub.php
@@ -5,6 +5,8 @@ namespace Buckaroo\Magento2\Test\Unit\Stubs;
 /**
  * PHPUnit 12 replacement for MockBuilder::addMethods() on \Magento\Framework\Event\Observer.
  * Declares the magic methods tests need to configure on their doubles.
+ *
+ * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  */
 class ObserverStub extends \Magento\Framework\Event\Observer
 {

--- a/Test/Unit/Stubs/ObserverStub.php
+++ b/Test/Unit/Stubs/ObserverStub.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace Buckaroo\Magento2\Test\Unit\Stubs;
+
+/**
+ * PHPUnit 12 replacement for MockBuilder::addMethods() on \Magento\Framework\Event\Observer.
+ * Declares the magic methods tests need to configure on their doubles.
+ */
+class ObserverStub extends \Magento\Framework\Event\Observer
+{
+    public function getBaseBuckarooFee(...$args)
+    {
+        return null;
+    }
+
+    public function getBaseBuckarooFeeInclTax(...$args)
+    {
+        return null;
+    }
+
+    public function getBuckarooFee(...$args)
+    {
+        return null;
+    }
+
+    public function getBuckarooFeeBaseTaxAmount(...$args)
+    {
+        return null;
+    }
+
+    public function getBuckarooFeeInclTax(...$args)
+    {
+        return null;
+    }
+
+    public function getBuckarooFeeTaxAmount(...$args)
+    {
+        return null;
+    }
+
+    public function getInvoice(...$args)
+    {
+        return null;
+    }
+
+    public function getMethod(...$args)
+    {
+        return null;
+    }
+
+    public function getOrder(...$args)
+    {
+        return null;
+    }
+
+    public function getPayment(...$args)
+    {
+        return null;
+    }
+
+    public function getQuote(...$args)
+    {
+        return null;
+    }
+
+    public function getStore(...$args)
+    {
+        return null;
+    }
+
+    public function setStatus(...$args)
+    {
+        return $this;
+    }
+}

--- a/Test/Unit/Stubs/OrderAdapterInterfaceStub.php
+++ b/Test/Unit/Stubs/OrderAdapterInterfaceStub.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Buckaroo\Magento2\Test\Unit\Stubs;
+
+/**
+ * PHPUnit 12 replacement for MockBuilder::addMethods() on \Magento\Payment\Gateway\Data\OrderAdapterInterface.
+ * Declares the magic methods tests need to configure on their doubles.
+ */
+interface OrderAdapterInterfaceStub extends \Magento\Payment\Gateway\Data\OrderAdapterInterface
+{
+    public function getOrder(...$args);
+}

--- a/Test/Unit/Stubs/OrderAdapterInterfaceStub.php
+++ b/Test/Unit/Stubs/OrderAdapterInterfaceStub.php
@@ -5,6 +5,8 @@ namespace Buckaroo\Magento2\Test\Unit\Stubs;
 /**
  * PHPUnit 12 replacement for MockBuilder::addMethods() on \Magento\Payment\Gateway\Data\OrderAdapterInterface.
  * Declares the magic methods tests need to configure on their doubles.
+ *
+ * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  */
 interface OrderAdapterInterfaceStub extends \Magento\Payment\Gateway\Data\OrderAdapterInterface
 {

--- a/Test/Unit/Stubs/OrderStub.php
+++ b/Test/Unit/Stubs/OrderStub.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace Buckaroo\Magento2\Test\Unit\Stubs;
+
+/**
+ * PHPUnit 12 replacement for MockBuilder::addMethods() on \Magento\Sales\Model\Order.
+ * Declares the magic methods tests need to configure on their doubles.
+ */
+class OrderStub extends \Magento\Sales\Model\Order
+{
+    public function getBaseBuckarooFeeInclTaxInvoiced(...$args)
+    {
+        return null;
+    }
+
+    public function getBaseBuckarooFeeInvoiced(...$args)
+    {
+        return null;
+    }
+
+    public function getBaseBuckarooFeeRefunded(...$args)
+    {
+        return null;
+    }
+
+    public function getBuckarooDatarequestKey(...$args)
+    {
+        return null;
+    }
+
+    public function getBuckarooFeeBaseTaxAmountInvoiced(...$args)
+    {
+        return null;
+    }
+
+    public function getBuckarooFeeBaseTaxAmountRefunded(...$args)
+    {
+        return null;
+    }
+
+    public function getBuckarooFeeInclTaxInvoiced(...$args)
+    {
+        return null;
+    }
+
+    public function getBuckarooFeeInvoiced(...$args)
+    {
+        return null;
+    }
+
+    public function getBuckarooFeeRefunded(...$args)
+    {
+        return null;
+    }
+
+    public function getBuckarooFeeTaxAmountInvoiced(...$args)
+    {
+        return null;
+    }
+
+    public function getBuckarooReservationNumber(...$args)
+    {
+        return null;
+    }
+
+    public function setBaseBuckarooFee(...$args)
+    {
+        return $this;
+    }
+
+    public function setBaseBuckarooFeeInclTax(...$args)
+    {
+        return $this;
+    }
+
+    public function setBaseBuckarooFeeInclTaxInvoiced(...$args)
+    {
+        return $this;
+    }
+
+    public function setBaseBuckarooFeeInvoiced(...$args)
+    {
+        return $this;
+    }
+
+    public function setBaseBuckarooFeeRefunded(...$args)
+    {
+        return $this;
+    }
+
+    public function setBuckarooFee(...$args)
+    {
+        return $this;
+    }
+
+    public function setBuckarooFeeBaseTaxAmount(...$args)
+    {
+        return $this;
+    }
+
+    public function setBuckarooFeeBaseTaxAmountInvoiced(...$args)
+    {
+        return $this;
+    }
+
+    public function setBuckarooFeeBaseTaxAmountRefunded(...$args)
+    {
+        return $this;
+    }
+
+    public function setBuckarooFeeInclTax(...$args)
+    {
+        return $this;
+    }
+
+    public function setBuckarooFeeInclTaxInvoiced(...$args)
+    {
+        return $this;
+    }
+
+    public function setBuckarooFeeInvoiced(...$args)
+    {
+        return $this;
+    }
+
+    public function setBuckarooFeeRefunded(...$args)
+    {
+        return $this;
+    }
+
+    public function setBuckarooFeeTaxAmount(...$args)
+    {
+        return $this;
+    }
+
+    public function setBuckarooFeeTaxAmountInvoiced(...$args)
+    {
+        return $this;
+    }
+
+    public function setBuckarooReservationNumber(...$args)
+    {
+        return $this;
+    }
+}

--- a/Test/Unit/Stubs/OrderStub.php
+++ b/Test/Unit/Stubs/OrderStub.php
@@ -5,6 +5,8 @@ namespace Buckaroo\Magento2\Test\Unit\Stubs;
 /**
  * PHPUnit 12 replacement for MockBuilder::addMethods() on \Magento\Sales\Model\Order.
  * Declares the magic methods tests need to configure on their doubles.
+ *
+ * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  */
 class OrderStub extends \Magento\Sales\Model\Order
 {

--- a/Test/Unit/Stubs/PaymentStub.php
+++ b/Test/Unit/Stubs/PaymentStub.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Buckaroo\Magento2\Test\Unit\Stubs;
+
+/**
+ * PHPUnit 12 replacement for MockBuilder::addMethods() on \Magento\Sales\Model\Order\Payment.
+ * Declares the magic methods tests need to configure on their doubles.
+ */
+class PaymentStub extends \Magento\Sales\Model\Order\Payment
+{
+    public function canProcessPostData(...$args)
+    {
+        return null;
+    }
+
+    public function createCreditNoteRequest(...$args)
+    {
+        return null;
+    }
+
+    public function processCustomPostData(...$args)
+    {
+        return null;
+    }
+}

--- a/Test/Unit/Stubs/PaymentStub.php
+++ b/Test/Unit/Stubs/PaymentStub.php
@@ -5,6 +5,8 @@ namespace Buckaroo\Magento2\Test\Unit\Stubs;
 /**
  * PHPUnit 12 replacement for MockBuilder::addMethods() on \Magento\Sales\Model\Order\Payment.
  * Declares the magic methods tests need to configure on their doubles.
+ *
+ * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  */
 class PaymentStub extends \Magento\Sales\Model\Order\Payment
 {

--- a/Test/Unit/Stubs/PushRequestInterfaceStub.php
+++ b/Test/Unit/Stubs/PushRequestInterfaceStub.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Buckaroo\Magento2\Test\Unit\Stubs;
+
+/**
+ * PHPUnit 12 replacement for MockBuilder::addMethods() on \Buckaroo\Magento2\Api\Data\PushRequestInterface.
+ * Declares the magic methods tests need to configure on their doubles.
+ */
+interface PushRequestInterfaceStub extends \Buckaroo\Magento2\Api\Data\PushRequestInterface
+{
+    public function getAmountCredit(...$args);
+
+    public function getData(...$args);
+
+    public function getEventparametersStatuscode(...$args);
+
+    public function getEventparametersTransactionstatuscode(...$args);
+
+    public function getInvoicekey(...$args);
+
+    public function getOriginalRequest(...$args);
+
+    public function getPrimaryService(...$args);
+
+    public function getRelatedtransactionRefund(...$args);
+
+    public function getSchemekey(...$args);
+
+    public function getServiceCreditmanagement3Invoicekey(...$args);
+
+    public function getServiceKlarnakpAutopaytransactionkey(...$args);
+
+    public function getServiceKlarnakpCaptureid(...$args);
+
+    public function getServiceKlarnakpReservationnumber(...$args);
+
+    public function hasAdditionalInformation(...$args);
+
+    public function hasPostData(...$args);
+}

--- a/Test/Unit/Stubs/PushRequestInterfaceStub.php
+++ b/Test/Unit/Stubs/PushRequestInterfaceStub.php
@@ -5,6 +5,8 @@ namespace Buckaroo\Magento2\Test\Unit\Stubs;
 /**
  * PHPUnit 12 replacement for MockBuilder::addMethods() on \Buckaroo\Magento2\Api\Data\PushRequestInterface.
  * Declares the magic methods tests need to configure on their doubles.
+ *
+ * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  */
 interface PushRequestInterfaceStub extends \Buckaroo\Magento2\Api\Data\PushRequestInterface
 {

--- a/Test/Unit/Stubs/QuoteStub.php
+++ b/Test/Unit/Stubs/QuoteStub.php
@@ -5,6 +5,8 @@ namespace Buckaroo\Magento2\Test\Unit\Stubs;
 /**
  * PHPUnit 12 replacement for MockBuilder::addMethods() on \Magento\Quote\Model\Quote.
  * Declares the magic methods tests need to configure on their doubles.
+ *
+ * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  */
 class QuoteStub extends \Magento\Quote\Model\Quote
 {

--- a/Test/Unit/Stubs/QuoteStub.php
+++ b/Test/Unit/Stubs/QuoteStub.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace Buckaroo\Magento2\Test\Unit\Stubs;
+
+/**
+ * PHPUnit 12 replacement for MockBuilder::addMethods() on \Magento\Quote\Model\Quote.
+ * Declares the magic methods tests need to configure on their doubles.
+ */
+class QuoteStub extends \Magento\Quote\Model\Quote
+{
+    public function getBaseBuckarooFee(...$args)
+    {
+        return null;
+    }
+
+    public function getBaseBuckarooFeeInclTax(...$args)
+    {
+        return null;
+    }
+
+    public function getBuckarooFee(...$args)
+    {
+        return null;
+    }
+
+    public function getBuckarooFeeBaseTaxAmount(...$args)
+    {
+        return null;
+    }
+
+    public function getBuckarooFeeInclTax(...$args)
+    {
+        return null;
+    }
+
+    public function getBuckarooFeeTaxAmount(...$args)
+    {
+        return null;
+    }
+
+    public function getCustomerEmail(...$args)
+    {
+        return null;
+    }
+
+    public function getCustomerFirstname(...$args)
+    {
+        return null;
+    }
+
+    public function getCustomerId(...$args)
+    {
+        return null;
+    }
+
+    public function getCustomerLastname(...$args)
+    {
+        return null;
+    }
+
+    public function getGiftCardsAmount(...$args)
+    {
+        return null;
+    }
+
+    public function getGrandTotal(...$args)
+    {
+        return null;
+    }
+
+    public function getQuoteCurrencyCode(...$args)
+    {
+        return null;
+    }
+
+    public function getRewardCurrencyAmount(...$args)
+    {
+        return null;
+    }
+
+    public function setBaseBuckarooFee(...$args)
+    {
+        return $this;
+    }
+
+    public function setBuckarooFee(...$args)
+    {
+        return $this;
+    }
+
+    public function setCustomerEmail(...$args)
+    {
+        return $this;
+    }
+
+    public function setCustomerFirstname(...$args)
+    {
+        return $this;
+    }
+
+    public function setCustomerId(...$args)
+    {
+        return $this;
+    }
+
+    public function setCustomerLastname(...$args)
+    {
+        return $this;
+    }
+}

--- a/Test/Unit/Stubs/RequestInterfaceStub.php
+++ b/Test/Unit/Stubs/RequestInterfaceStub.php
@@ -5,6 +5,8 @@ namespace Buckaroo\Magento2\Test\Unit\Stubs;
 /**
  * PHPUnit 12 replacement for MockBuilder::addMethods() on \Magento\Framework\App\RequestInterface.
  * Declares the magic methods tests need to configure on their doubles.
+ *
+ * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  */
 interface RequestInterfaceStub extends \Magento\Framework\App\RequestInterface
 {

--- a/Test/Unit/Stubs/RequestInterfaceStub.php
+++ b/Test/Unit/Stubs/RequestInterfaceStub.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Buckaroo\Magento2\Test\Unit\Stubs;
+
+/**
+ * PHPUnit 12 replacement for MockBuilder::addMethods() on \Magento\Framework\App\RequestInterface.
+ * Declares the magic methods tests need to configure on their doubles.
+ */
+interface RequestInterfaceStub extends \Magento\Framework\App\RequestInterface
+{
+    public function getFullActionName(...$args);
+}

--- a/Test/Unit/Stubs/SessionStub.php
+++ b/Test/Unit/Stubs/SessionStub.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Buckaroo\Magento2\Test\Unit\Stubs;
+
+/**
+ * PHPUnit 12 replacement for MockBuilder::addMethods() on \Magento\Backend\Model\Session.
+ * Declares the magic methods tests need to configure on their doubles.
+ */
+class SessionStub extends \Magento\Backend\Model\Session
+{
+    public function getFormData(...$args)
+    {
+        return null;
+    }
+}

--- a/Test/Unit/Stubs/SessionStub.php
+++ b/Test/Unit/Stubs/SessionStub.php
@@ -5,6 +5,8 @@ namespace Buckaroo\Magento2\Test\Unit\Stubs;
 /**
  * PHPUnit 12 replacement for MockBuilder::addMethods() on \Magento\Backend\Model\Session.
  * Declares the magic methods tests need to configure on their doubles.
+ *
+ * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  */
 class SessionStub extends \Magento\Backend\Model\Session
 {

--- a/Test/Unit/Stubs/SessionStub.php
+++ b/Test/Unit/Stubs/SessionStub.php
@@ -7,6 +7,7 @@ namespace Buckaroo\Magento2\Test\Unit\Stubs;
  * Declares the magic methods tests need to configure on their doubles.
  *
  * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+ * @SuppressWarnings(PHPMD.CookieAndSessionMisuse)
  */
 class SessionStub extends \Magento\Backend\Model\Session
 {

--- a/Test/Unit/Stubs/SessionStub2.php
+++ b/Test/Unit/Stubs/SessionStub2.php
@@ -5,6 +5,8 @@ namespace Buckaroo\Magento2\Test\Unit\Stubs;
 /**
  * PHPUnit 12 replacement for MockBuilder::addMethods() on \Magento\Checkout\Model\Session.
  * Declares the magic methods tests need to configure on their doubles.
+ *
+ * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  */
 class SessionStub2 extends \Magento\Checkout\Model\Session
 {

--- a/Test/Unit/Stubs/SessionStub2.php
+++ b/Test/Unit/Stubs/SessionStub2.php
@@ -7,6 +7,7 @@ namespace Buckaroo\Magento2\Test\Unit\Stubs;
  * Declares the magic methods tests need to configure on their doubles.
  *
  * @SuppressWarnings(PHPMD.UnusedFormalParameter)
+ * @SuppressWarnings(PHPMD.CookieAndSessionMisuse)
  */
 class SessionStub2 extends \Magento\Checkout\Model\Session
 {

--- a/Test/Unit/Stubs/SessionStub2.php
+++ b/Test/Unit/Stubs/SessionStub2.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace Buckaroo\Magento2\Test\Unit\Stubs;
+
+/**
+ * PHPUnit 12 replacement for MockBuilder::addMethods() on \Magento\Checkout\Model\Session.
+ * Declares the magic methods tests need to configure on their doubles.
+ */
+class SessionStub2 extends \Magento\Checkout\Model\Session
+{
+    public function getLastOrderId(...$args)
+    {
+        return null;
+    }
+
+    public function getLastQuoteId(...$args)
+    {
+        return null;
+    }
+
+    public function getLastRealOrderId(...$args)
+    {
+        return null;
+    }
+
+    public function getLastSuccessQuoteId(...$args)
+    {
+        return null;
+    }
+
+    public function setLastOrderId(...$args)
+    {
+        return $this;
+    }
+
+    public function setLastOrderStatus(...$args)
+    {
+        return $this;
+    }
+
+    public function setLastQuoteId(...$args)
+    {
+        return $this;
+    }
+
+    public function setLastRealOrderId(...$args)
+    {
+        return $this;
+    }
+
+    public function setLastSuccessQuoteId(...$args)
+    {
+        return $this;
+    }
+
+    public function setRestoreQuoteLastOrder(...$args)
+    {
+        return $this;
+    }
+
+    public function unsLastOrderId(...$args)
+    {
+        return null;
+    }
+
+    public function unsLastQuoteId(...$args)
+    {
+        return null;
+    }
+
+    public function unsLastRealOrderId(...$args)
+    {
+        return null;
+    }
+
+    public function unsLastSuccessQuoteId(...$args)
+    {
+        return null;
+    }
+
+    public function unsRedirectUrl(...$args)
+    {
+        return null;
+    }
+}

--- a/Test/Unit/Stubs/StdObjectStub.php
+++ b/Test/Unit/Stubs/StdObjectStub.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Buckaroo\Magento2\Test\Unit\Stubs;
+
+/**
+ * PHPUnit 12 replacement for MockBuilder::addMethods() on \stdClass.
+ * Declares the magic methods tests need to configure on their doubles.
+ */
+class StdObjectStub
+{
+    public function createCreditNoteRequest(...$args)
+    {
+        return null;
+    }
+
+    public function getAmount(...$args)
+    {
+        return null;
+    }
+
+    public function getRoundedAmount(...$args)
+    {
+        return null;
+    }
+
+    public function setProductClassId(...$args)
+    {
+        return $this;
+    }
+}

--- a/Test/Unit/Stubs/StdObjectStub.php
+++ b/Test/Unit/Stubs/StdObjectStub.php
@@ -5,6 +5,8 @@ namespace Buckaroo\Magento2\Test\Unit\Stubs;
 /**
  * PHPUnit 12 replacement for MockBuilder::addMethods() on \stdClass.
  * Declares the magic methods tests need to configure on their doubles.
+ *
+ * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  */
 class StdObjectStub
 {

--- a/Test/Unit/Stubs/TotalStub.php
+++ b/Test/Unit/Stubs/TotalStub.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Buckaroo\Magento2\Test\Unit\Stubs;
+
+/**
+ * PHPUnit 12 replacement for MockBuilder::addMethods() on \Magento\Quote\Model\Quote\Address\Total.
+ * Declares the magic methods tests need to configure on their doubles.
+ */
+class TotalStub extends \Magento\Quote\Model\Quote\Address\Total
+{
+    public function getBaseBuckarooFee(...$args)
+    {
+        return null;
+    }
+
+    public function getBaseBuckarooFeeInclTax(...$args)
+    {
+        return null;
+    }
+
+    public function getBaseGrandTotal(...$args)
+    {
+        return null;
+    }
+
+    public function getBuckarooFee(...$args)
+    {
+        return null;
+    }
+
+    public function getBuckarooFeeBaseTaxAmount(...$args)
+    {
+        return null;
+    }
+
+    public function getBuckarooFeeInclTax(...$args)
+    {
+        return null;
+    }
+
+    public function getBuckarooFeeTaxAmount(...$args)
+    {
+        return null;
+    }
+
+    public function getGrandTotal(...$args)
+    {
+        return null;
+    }
+
+    public function setBaseBuckarooFee(...$args)
+    {
+        return $this;
+    }
+
+    public function setBaseGrandTotal(...$args)
+    {
+        return $this;
+    }
+
+    public function setBuckarooFee(...$args)
+    {
+        return $this;
+    }
+
+    public function setGrandTotal(...$args)
+    {
+        return $this;
+    }
+}

--- a/Test/Unit/Stubs/TotalStub.php
+++ b/Test/Unit/Stubs/TotalStub.php
@@ -5,6 +5,8 @@ namespace Buckaroo\Magento2\Test\Unit\Stubs;
 /**
  * PHPUnit 12 replacement for MockBuilder::addMethods() on \Magento\Quote\Model\Quote\Address\Total.
  * Declares the magic methods tests need to configure on their doubles.
+ *
+ * @SuppressWarnings(PHPMD.UnusedFormalParameter)
  */
 class TotalStub extends \Magento\Quote\Model\Quote\Address\Total
 {

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "buckaroo/magento2",
     "description": "Buckaroo Magento 2 extension",
     "require": {
-        "php": "^8.1 || ^8.2 || ^8.3 || ^8.4",
+        "php": "^8.1 || ^8.2 || ^8.3 || ^8.4 || ^8.5",
         "magento/module-payment": ">=100.3.3",
         "magento/framework": ">=103.0.0",
         "magento/module-backend": "^102.0",
@@ -61,7 +61,7 @@
         "squizlabs/php_codesniffer": "^3.7",
         "phpmd/phpmd": "^2.15",
         "phpstan/phpstan": "^1.10",
-        "phpunit/phpunit": "^9.5 || ^10.5",
+        "phpunit/phpunit": "^10.5 || ^11.5 || ^12.5",
         "magento/magento-coding-standard": "^40"
     },
     "repositories": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -45,6 +45,8 @@ parameters:
         # Ignore all Adobe Commerce gift card related classes in our service
         - '#.*GiftCardRefundService\.php.*Class Magento\\GiftCardAccount\\.*not found#'
         - '#.*Magento\\GiftCardAccount\\.*not found.*#'
+        # PHPUnit 12.4+ attribute; CI analyses against Magento's bundled PHPUnit 10 where it does not exist
+        - '#Attribute class PHPUnit\\Framework\\Attributes\\AllowMockObjectsWithoutExpectations does not exist#'
 
 
 services:


### PR DESCRIPTION
add support for PHP 8.5 and update PHPUnit version to ^10.5 || ^11.5 || ^12.5