### PR TITLE
Bti 1224 hosted fields payment form fails to initialize on subsequent checkout attempts

### DIFF
--- a/Service/Creditcard/HostedFieldsTokenClient.php
+++ b/Service/Creditcard/HostedFieldsTokenClient.php
@@ -26,13 +26,14 @@ use Buckaroo\Magento2\Service\OauthTokenService;
 /**
  * Fetches OAuth access tokens for Hosted Fields (credit card) from Buckaroo's auth API.
  *
- * Thin adapter around the shared OauthTokenService, which adds server-side
- * (encrypted) token caching and a request timeout. Kept as a separate class so
+ * Thin adapter around the shared OauthTokenService. Kept as a separate class so
  * existing integrations against this contract keep working.
  */
 class HostedFieldsTokenClient
 {
     private const SCOPE = 'hostedfields:save';
+
+    private const USE_CACHE = false;
 
     /**
      * @var OauthTokenService
@@ -48,11 +49,12 @@ class HostedFieldsTokenClient
     }
 
     /**
-     * Fetch an OAuth access token using the client-credentials grant.
+     * Fetch a fresh OAuth access token using the client-credentials grant.
      *
-     * Served from the shared server-side cache when a still-valid token exists;
-     * expires_in is the remaining lifetime, so the frontend refresh scheduling
-     * keeps working with cached tokens.
+     * Never served from cache (see self::USE_CACHE): each checkout needs its own
+     * token so it gets its own hosted-fields session. expires_in is the token
+     * lifetime minus a safety margin, so the frontend refresh scheduling can use
+     * it as-is.
      *
      * @param string $clientId
      * @param string $clientSecret
@@ -61,6 +63,6 @@ class HostedFieldsTokenClient
      */
     public function fetchToken(string $clientId, string $clientSecret): ?array
     {
-        return $this->tokenService->getToken($clientId, $clientSecret, self::SCOPE);
+        return $this->tokenService->getToken($clientId, $clientSecret, self::SCOPE, self::USE_CACHE);
     }
 }

--- a/Service/OauthTokenService.php
+++ b/Service/OauthTokenService.php
@@ -31,9 +31,9 @@ use Magento\Framework\HTTP\Client\Curl;
  * Fetches OAuth client-credentials access tokens from Buckaroo's auth API with a
  * server-side encrypted cache.
  *
- * Tokens are merchant-level (not bound to a shopper), so one cached token per
- * credential pair and scope can serve every checkout visitor until it expires.
- * Used by both Click to Pay and the Hosted Fields (credit cards) token proxies.
+ * Tokens are merchant-level (not bound to a shopper), so for scopes where the
+ * token is nothing more than a bearer credential (Click to Pay) one cached token
+ * per credential pair and scope can serve every checkout visitor until it expires.
  */
 class OauthTokenService
 {
@@ -100,16 +100,23 @@ class OauthTokenService
      * @param string $clientId
      * @param string $clientSecret
      * @param string $scope
+     * @param bool   $useCache Set to false to always mint a fresh token and leave the cache untouched
      *
      * @return array{access_token: string, expires_in: int}|null null when the token could not be obtained
      */
-    public function getToken(string $clientId, string $clientSecret, string $scope): ?array
-    {
+    public function getToken(
+        string $clientId,
+        string $clientSecret,
+        string $scope,
+        bool $useCache = true
+    ): ?array {
         $cacheKey = self::TOKEN_CACHE_ID . '_' . hash('sha256', $clientId . ':' . $clientSecret . ':' . $scope);
 
-        $cachedToken = $this->loadCachedToken($cacheKey);
-        if ($cachedToken !== null) {
-            return $cachedToken;
+        if ($useCache) {
+            $cachedToken = $this->loadCachedToken($cacheKey);
+            if ($cachedToken !== null) {
+                return $cachedToken;
+            }
         }
 
         $data = $this->requestToken($clientId, $clientSecret, $scope);
@@ -118,7 +125,9 @@ class OauthTokenService
         }
 
         $expiresIn = (int) ($data['expires_in'] ?? 0);
-        $this->saveCachedToken($cacheKey, (string) $data['access_token'], $expiresIn);
+        if ($useCache) {
+            $this->saveCachedToken($cacheKey, (string) $data['access_token'], $expiresIn);
+        }
 
         return [
             'access_token' => (string) $data['access_token'],

--- a/Test/Unit/Service/Creditcard/HostedFieldsTokenClientTest.php
+++ b/Test/Unit/Service/Creditcard/HostedFieldsTokenClientTest.php
@@ -1,0 +1,70 @@
+<?php
+declare(strict_types=1);
+
+/**
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the MIT License
+ * It is available through the world-wide-web at this URL:
+ * https://tldrlegal.com/license/mit-license
+ * If you are unable to obtain it through the world-wide-web, please email
+ * to support@buckaroo.nl, so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade this module to newer
+ * versions in the future. If you wish to customize this module for your
+ * needs please contact support@buckaroo.nl for more information.
+ *
+ * @copyright Copyright (c) Buckaroo B.V.
+ * @license   https://tldrlegal.com/license/mit-license
+ */
+
+namespace Buckaroo\Magento2\Test\Unit\Service\Creditcard;
+
+use Buckaroo\Magento2\Service\Creditcard\HostedFieldsTokenClient;
+use Buckaroo\Magento2\Service\OauthTokenService;
+use Buckaroo\Magento2\Test\BaseTest;
+
+class HostedFieldsTokenClientTest extends BaseTest
+{
+    protected $instanceClass = HostedFieldsTokenClient::class;
+
+    /**
+     * Every Hosted Fields checkout must receive its own access token.
+     *
+     * The Buckaroo hosted-fields API derives exactly one session per access token
+     * (POST /v1/sessions returns the same session id for the same bearer), so a
+     * shared or cached token means a shared - and after the first payment,
+     * consumed - card entry session.
+     */
+    public function testFetchTokenRequestsAnUncachedTokenForTheHostedFieldsScope(): void
+    {
+        $tokenService = $this->createMock(OauthTokenService::class);
+        $tokenService->expects($this->once())
+            ->method('getToken')
+            ->with('client-id', 'client-secret', 'hostedfields:save', false)
+            ->willReturn(['access_token' => 'fresh-token', 'expires_in' => 840]);
+
+        $instance = $this->getInstance(['tokenService' => $tokenService]);
+
+        $this->assertSame(
+            ['access_token' => 'fresh-token', 'expires_in' => 840],
+            $instance->fetchToken('client-id', 'client-secret')
+        );
+    }
+
+    /**
+     * A failed token request must surface as null so the controller can return an
+     * error payload instead of a half-built response.
+     */
+    public function testFetchTokenReturnsNullWhenTheTokenCannotBeObtained(): void
+    {
+        $tokenService = $this->createMock(OauthTokenService::class);
+        $tokenService->method('getToken')->willReturn(null);
+
+        $instance = $this->getInstance(['tokenService' => $tokenService]);
+
+        $this->assertNull($instance->fetchToken('client-id', 'client-secret'));
+    }
+}

--- a/Test/Unit/Service/OauthTokenServiceTest.php
+++ b/Test/Unit/Service/OauthTokenServiceTest.php
@@ -181,6 +181,38 @@ class OauthTokenServiceTest extends BaseTest
     }
 
     /**
+     * With caching disabled the cache must be neither read nor written, and every
+     * call must mint a brand new token. Hosted Fields relies on this: the Buckaroo
+     * hosted-fields API derives one session from one access token, so a reused
+     * token hands the shopper an already-consumed session.
+     */
+    public function testGetTokenBypassesCacheWhenCachingDisabled(): void
+    {
+        $cache = $this->createMock(CacheInterface::class);
+        $cache->expects($this->never())->method('load');
+        $cache->expects($this->never())->method('save');
+
+        $curl = $this->createMock(Curl::class);
+        $curl->expects($this->once())->method('post');
+        $curl->method('getBody')->willReturn(json_encode([
+            'access_token' => 'fresh-token',
+            'expires_in'   => 900,
+        ]));
+
+        $instance = $this->getInstance([
+            'curl'      => $curl,
+            'cache'     => $cache,
+            'encryptor' => $this->createMock(EncryptorInterface::class),
+            'logger'    => $this->createMock(BuckarooLoggerInterface::class),
+        ]);
+
+        $result = $instance->getToken('client-id', 'client-secret', 'hostedfields:save', false);
+
+        $this->assertSame('fresh-token', $result['access_token']);
+        $this->assertSame(840, $result['expires_in']);
+    }
+
+    /**
      * Different credential/scope combinations must not share a cache entry.
      */
     public function testGetTokenUsesScopeSpecificCacheKeys(): void

--- a/view/frontend/web/js/view/payment/method-renderer/creditcards.js
+++ b/view/frontend/web/js/view/payment/method-renderer/creditcards.js
@@ -87,8 +87,14 @@ define(
 
             /**
              * Called from afterRender in the template, ensuring DOM is ready.
+             *
+             * The template binds this inside a `ko if` on the selected method, so it
+             * runs again every time the shopper switches away from credit cards and
+             * back. Drop any iframes left by a previous mount first, otherwise the
+             * new session's fields are appended next to the stale ones.
              */
             initCreditCardFields: function () {
+                this.removeHostedFieldIframes();
                 this.getOAuthToken();
             },
 


### PR DESCRIPTION
ensure unique OAuth tokens for each Hosted Fields checkout session by disabling caching