### PR TITLE
BTI-1238-Consolidate-duplicate-order-saves-in-success-push-flow

### DIFF
--- a/Model/Push/DefaultProcessor.php
+++ b/Model/Push/DefaultProcessor.php
@@ -1656,8 +1656,8 @@ class DefaultProcessor implements PushProcessorInterface
                 var_export($this->payment->getMethod(), true)
             ));
 
+            // Persisted by the updateOrderStatus save that follows in processSucceededPush
             $this->order->setState(Order::STATE_PROCESSING);
-            $this->order->save();
         }
     }
 

--- a/Model/Push/KlarnaKpProcessor.php
+++ b/Model/Push/KlarnaKpProcessor.php
@@ -453,8 +453,8 @@ class KlarnaKpProcessor extends DefaultProcessor
 
             // Only set to processing if not already canceled (the canUpdateOrderStatus will handle canceled->new transition)
             if ($this->order->getState() !== Order::STATE_CANCELED) {
+                // Persisted by the updateOrderStatus save that follows in processSucceededPush
                 $this->order->setState(Order::STATE_PROCESSING);
-                $this->orderRepository->save($this->order);
             }
         }
     }

--- a/Model/Push/KlarnaMorProcessor.php
+++ b/Model/Push/KlarnaMorProcessor.php
@@ -396,8 +396,8 @@ class KlarnaMorProcessor extends DefaultProcessor
             ));
 
             if ($this->order->getState() !== Order::STATE_CANCELED) {
+                // Persisted by the updateOrderStatus save that follows in processSucceededPush
                 $this->order->setState(Order::STATE_PROCESSING);
-                $this->orderRepository->save($this->order);
             }
         }
     }

--- a/Test/Unit/Model/Push/KlarnaKpProcessorTest.php
+++ b/Test/Unit/Model/Push/KlarnaKpProcessorTest.php
@@ -403,8 +403,10 @@ class KlarnaKpProcessorTest extends \Buckaroo\Magento2\Test\BaseTest
 
         $orderMock = $this->preparePushAuthorization($instance, '190', Order::STATE_NEW);
         $orderMock->expects($this->once())->method('setState')->with(Order::STATE_PROCESSING)->willReturnSelf();
+        // No intermediate save: the state is persisted by the updateOrderStatus
+        // save that follows in processSucceededPush (BTI-1238 save consolidation)
         $orderMock->expects($this->never())->method('save');
-        $this->orderRepositoryMock->expects($this->once())->method('save')->with($orderMock);
+        $this->orderRepositoryMock->expects($this->never())->method('save');
 
         $this->invoke('processSucceededPushAuthorization', $instance);
     }


### PR DESCRIPTION
consolidate duplicate order state saves in success push flow