### PR TITLE
Bti 1241 fix dont save order upon success push to skip the order re save in update order status

### DIFF
--- a/Model/Push/DefaultProcessor.php
+++ b/Model/Push/DefaultProcessor.php
@@ -1103,10 +1103,10 @@ class DefaultProcessor implements PushProcessorInterface
         $this->orderRequestService->updateOrderStatus(
             Order::STATE_PROCESSING,
             $newStatus,
-            $description,
-            false,
-            $this->dontSaveOrderUponSuccessPush
+            $description
         );
+        // updateOrderStatus persisted the order; skip the final save in processPush
+        $this->dontSaveOrderUponSuccessPush = true;
 
         return true;
     }
@@ -1573,10 +1573,10 @@ class DefaultProcessor implements PushProcessorInterface
             $this->orderRequestService->updateOrderStatus(
                 Order::STATE_PROCESSING,
                 $newStatus,
-                $description,
-                false,
-                $this->dontSaveOrderUponSuccessPush
+                $description
             );
+            // updateOrderStatus persisted the order; skip the final save in processPush
+            $this->dontSaveOrderUponSuccessPush = true;
             $this->logger->addDebug(sprintf('[%s:%s] - CAPTURE_COMPLETE', __METHOD__, __LINE__));
             return true;
         }
@@ -1601,9 +1601,10 @@ class DefaultProcessor implements PushProcessorInterface
             $paymentDetails['state'],
             $paymentDetails['newStatus'],
             $paymentDetails['description'],
-            $paymentDetails['forceState'],
-            $this->dontSaveOrderUponSuccessPush
+            $paymentDetails['forceState']
         );
+        // updateOrderStatus persisted the order; skip the final save in processPush
+        $this->dontSaveOrderUponSuccessPush = true;
 
         return true;
     }

--- a/Service/Push/OrderRequestService.php
+++ b/Service/Push/OrderRequestService.php
@@ -314,22 +314,22 @@ class OrderRequestService
     }
 
     /**
-     * Updates the order state and add a comment.
+     * Updates the order state and status, adds the comment and saves the order once.
      *
      * @param string $orderState
      * @param string $newStatus
      * @param string $description
      * @param bool   $force
-     * @param bool   $dontSaveOrderUponSuccessPush
      *
      * @throws \Exception
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function updateOrderStatus(
         string $orderState,
         string $newStatus,
         string $description,
-        bool $force = false,
-        bool $dontSaveOrderUponSuccessPush = false
+        bool $force = false
     ): void {
         $this->logger->addDebug(sprintf(
             '[ORDER] | [Service] | [%s:%s] - Updates the order state and add a comment | data: %s',
@@ -344,26 +344,8 @@ class OrderRequestService
 
         // Always set the order state - this is crucial for admin dropdown
         $this->order->setState($orderState);
-
-        if ($this->order->getState() == $orderState || $force) {
-            if ($dontSaveOrderUponSuccessPush) {
-                $this->order->setStatus($newStatus);
-                $this->order->addCommentToStatusHistory($description)
-                    ->setIsCustomerNotified(false)
-                    ->setStatus($newStatus);
-                $this->orderRepository->save($this->order);
-            } else {
-                $this->order->addCommentToStatusHistory($description, $newStatus);
-                $this->orderRepository->save($this->order);
-            }
-        } else {
-            if ($dontSaveOrderUponSuccessPush) {
-                $this->orderCommentHistoryService->add($this->order, $description);
-            } else {
-                $this->order->addCommentToStatusHistory($description);
-                $this->orderRepository->save($this->order);
-            }
-        }
+        $this->order->addCommentToStatusHistory($description, $newStatus);
+        $this->orderRepository->save($this->order);
 
         $this->logger->addDebug(sprintf(
             '[ORDER] | [Service] | [%s:%s] - Order state and status updated successfully | finalState: %s | finalStatus: %s',


### PR DESCRIPTION
skip order re-save in updateOrderStatus when success push is triggered