### PR TITLE
Bti 1366 pay link order paid in multiple parts is not recorded as a split payment blocking online refunds

### DIFF
--- a/Block/AdminInfo.php
+++ b/Block/AdminInfo.php
@@ -375,7 +375,7 @@ class AdminInfo extends ConfigurableInfo
      */
     public function getPaymentLogo(string $method): string
     {
-        return $this->logoService->getPayment($method);
+         return $this->logoService->getPaymentByServiceCode($method);
     }
 
     /**

--- a/Block/AdminInfo.php
+++ b/Block/AdminInfo.php
@@ -375,7 +375,7 @@ class AdminInfo extends ConfigurableInfo
      */
     public function getPaymentLogo(string $method): string
     {
-         return $this->logoService->getPaymentByServiceCode($method);
+        return $this->logoService->getPaymentByServiceCode($method);
     }
 
     /**

--- a/Block/Info.php
+++ b/Block/Info.php
@@ -336,7 +336,7 @@ class Info extends \Magento\Payment\Block\Info
      */
     public function getPaymentLogo(string $method): string
     {
-        return $this->logoService->getPayment($method);
+        return $this->logoService->getPaymentByServiceCode($method);
     }
 
     /**

--- a/Model/PaymentMethodCodeResolver.php
+++ b/Model/PaymentMethodCodeResolver.php
@@ -22,6 +22,7 @@ declare(strict_types=1);
 namespace Buckaroo\Magento2\Model;
 
 use Buckaroo\Magento2\Model\ConfigProvider\Method\Creditcard;
+use Buckaroo\Magento2\Model\ResourceModel\Giftcard\Collection as GiftcardCollection;
 use Magento\Payment\Helper\Data as PaymentHelper;
 
 /**
@@ -50,6 +51,11 @@ class PaymentMethodCodeResolver
     private const CREDITCARD_METHOD_CODE = 'creditcard';
 
     /**
+     * The method that handles every giftcard brand.
+     */
+    private const GIFTCARDS_METHOD_CODE = 'giftcards';
+
+    /**
      * @var Creditcard
      */
     private Creditcard $creditcardConfig;
@@ -60,22 +66,30 @@ class PaymentMethodCodeResolver
     private PaymentHelper $paymentHelper;
 
     /**
+     * @var GiftcardCollection
+     */
+    private GiftcardCollection $giftcardCollection;
+
+    /**
      * @var array
      */
     private array $serviceToMethod;
 
     /**
-     * @param Creditcard    $creditcardConfig
-     * @param PaymentHelper $paymentHelper
-     * @param array         $serviceToMethod
+     * @param Creditcard         $creditcardConfig
+     * @param PaymentHelper      $paymentHelper
+     * @param GiftcardCollection $giftcardCollection
+     * @param array              $serviceToMethod
      */
     public function __construct(
         Creditcard $creditcardConfig,
         PaymentHelper $paymentHelper,
+        GiftcardCollection $giftcardCollection,
         array $serviceToMethod = []
     ) {
         $this->creditcardConfig = $creditcardConfig;
         $this->paymentHelper = $paymentHelper;
+        $this->giftcardCollection = $giftcardCollection;
         $this->serviceToMethod = $serviceToMethod;
     }
 
@@ -111,7 +125,27 @@ class PaymentMethodCodeResolver
             return self::METHOD_CODE_PREFIX . self::CREDITCARD_METHOD_CODE;
         }
 
+        if ($this->isGiftcardBrand($serviceCode)) {
+            return self::METHOD_CODE_PREFIX . self::GIFTCARDS_METHOD_CODE;
+        }
+
         return null;
+    }
+
+    /**
+     * Whether the service code is one of the giftcards the merchant has configured.
+     *
+     * A push names the giftcard brand it was paid with, "vvvgiftcard" or "boekenbon" and so on, never
+     * the generic "giftcard" that the PayLink settings offer. The configured giftcards are the list
+     * to check against, so a brand added there needs no second edit.
+     *
+     * @param string $serviceCode
+     *
+     * @return bool
+     */
+    private function isGiftcardBrand(string $serviceCode): bool
+    {
+        return (bool)$this->giftcardCollection->getItemByColumnValue('servicecode', $serviceCode);
     }
 
     /**

--- a/Model/Push/DefaultProcessor.php
+++ b/Model/Push/DefaultProcessor.php
@@ -321,7 +321,7 @@ class DefaultProcessor implements PushProcessorInterface
 
         $this->setOrderStatusMessage();
 
-        if ($this->isGroupTransactionPart() || $this->pushRequest->getRelatedtransactionPartialpayment()) {
+        if ($this->isPartialPaymentPush()) {
             return $this->handlePartialPaymentPush();
         }
 
@@ -1264,6 +1264,24 @@ class DefaultProcessor implements PushProcessorInterface
             [Order::STATE_NEW, Order::STATE_PENDING_PAYMENT],
             true
         );
+    }
+
+    /**
+     * Whether this push settles one part of a payment that was split across several transactions.
+     *
+     * Both conditions are needed. A push carries brq_relatedtransaction_partialpayment from the
+     * start, whereas isGroupTransactionPart() recognises a part by looking up a group transaction
+     * row, so it cannot see the first part of a split before anything has been recorded.
+     *
+     * Kept here rather than in each processor: the two used to test this differently, and a PayLink
+     * settled in parts went unrecorded because of it.
+     *
+     * @return bool
+     */
+    protected function isPartialPaymentPush(): bool
+    {
+        return $this->isGroupTransactionPart()
+            || (bool)$this->pushRequest->getRelatedtransactionPartialpayment();
     }
 
     /**
@@ -2550,9 +2568,9 @@ class DefaultProcessor implements PushProcessorInterface
      *    GroupTransactionPushProcessor, which is responsible for cancelling the order.
      *
      * @return bool
-     * @throws LocalizedException
+     * @throws LocalizedException|Exception
      */
-    private function handlePartialPaymentPush(): bool
+    protected function handlePartialPaymentPush(): bool
     {
         $this->savePartGroupTransaction();
         $this->saveNewGroupTransactionIfNeeded();

--- a/Model/Push/PayPerEmailProcessor.php
+++ b/Model/Push/PayPerEmailProcessor.php
@@ -233,9 +233,8 @@ class PayPerEmailProcessor extends DefaultProcessor
 
         $this->setOrderStatusMessage();
 
-        if ($this->isGroupTransactionPart()) {
-            $this->savePartGroupTransaction();
-            return true;
+        if ($this->isPartialPaymentPush()) {
+            return $this->handlePartialPaymentPush();
         }
 
         if ($this->giftcardPartialPayment()) {

--- a/Service/LogoService.php
+++ b/Service/LogoService.php
@@ -22,6 +22,7 @@ declare(strict_types=1);
 
 namespace Buckaroo\Magento2\Service;
 
+use Buckaroo\Magento2\Model\PaymentMethodCodeResolver;
 use Magento\Framework\UrlInterface;
 use Magento\Framework\View\Asset\Repository;
 
@@ -38,19 +39,52 @@ class LogoService
     protected $baseUrl;
 
     /**
-     * @param Repository   $assetRepo
-     * @param UrlInterface $baseUrl
+     * @var PaymentMethodCodeResolver
+     */
+    private PaymentMethodCodeResolver $paymentMethodCodeResolver;
+
+    /**
+     * @param Repository                $assetRepo
+     * @param UrlInterface              $baseUrl
+     * @param PaymentMethodCodeResolver $paymentMethodCodeResolver
      */
     public function __construct(
         Repository $assetRepo,
-        UrlInterface $baseUrl
+        UrlInterface $baseUrl,
+        PaymentMethodCodeResolver $paymentMethodCodeResolver
     ) {
         $this->assetRepo = $assetRepo;
         $this->baseUrl = $baseUrl;
+        $this->paymentMethodCodeResolver = $paymentMethodCodeResolver;
     }
 
     /**
      * Get payment method logo
+     *
+     * Get the logo for a Buckaroo service code.
+     *
+     * A push reports the service that was used, which is a different vocabulary from the method
+     * codes this map is keyed on: Bancontact arrives as "bancontactmrcash" while the logo is filed
+     * under "mrcash". Translating first is what makes the lookup succeed.
+     *
+     * @param string $serviceCode
+     * @param bool   $backend
+     *
+     * @return string
+     */
+    public function getPaymentByServiceCode(string $serviceCode, bool $backend = false): string
+    {
+        $methodCode = $this->paymentMethodCodeResolver->resolve($serviceCode);
+
+        if ($methodCode !== null) {
+            $serviceCode = str_replace('buckaroo_magento2_', '', $methodCode);
+        }
+
+        return $this->getPayment($serviceCode, $backend);
+    }
+
+    /**
+     * Get the logo for a payment method code
      *
      * @param string $paymentCode
      * @param bool   $backend

--- a/Test/Unit/Model/PaymentMethodCodeResolverTest.php
+++ b/Test/Unit/Model/PaymentMethodCodeResolverTest.php
@@ -23,6 +23,7 @@ namespace Buckaroo\Magento2\Test\Unit\Model;
 
 use Buckaroo\Magento2\Model\ConfigProvider\Method\Creditcard;
 use Buckaroo\Magento2\Model\PaymentMethodCodeResolver;
+use Buckaroo\Magento2\Model\ResourceModel\Giftcard\Collection as GiftcardCollection;
 use Magento\Payment\Helper\Data as PaymentHelper;
 use PHPUnit\Framework\Attributes\DataProvider;
 
@@ -39,6 +40,7 @@ class PaymentMethodCodeResolverTest extends \Buckaroo\Magento2\Test\BaseTest
         'przelewy24'       => 'p24',
         'kbcpaymentbutton' => 'kbc',
         'in3old'           => 'capayablein3',
+        'buckaroovoucher'  => 'voucher',
     ];
 
     /**
@@ -54,8 +56,14 @@ class PaymentMethodCodeResolverTest extends \Buckaroo\Magento2\Test\BaseTest
         'buckaroo_magento2_transfer'     => [],
         'buckaroo_magento2_p24'          => [],
         'buckaroo_magento2_capayablein3' => [],
+        'buckaroo_magento2_voucher'      => [],
         'checkmo'                        => [],
     ];
+
+    /**
+     * The giftcard brands the merchant has configured.
+     */
+    private const CONFIGURED_GIFTCARDS = ['vvvgiftcard', 'boekenbon', 'fashionucadeaukaart'];
 
     private function resolver(): PaymentMethodCodeResolver
     {
@@ -72,7 +80,23 @@ class PaymentMethodCodeResolverTest extends \Buckaroo\Magento2\Test\BaseTest
         $paymentHelper = $this->getFakeMock(PaymentHelper::class)->disableOriginalConstructor()->getMock();
         $paymentHelper->method('getPaymentMethods')->willReturn(self::REGISTERED_METHODS);
 
-        return new PaymentMethodCodeResolver($creditcardConfig, $paymentHelper, self::SERVICE_TO_METHOD);
+        $giftcardCollection = $this->getFakeMock(GiftcardCollection::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $giftcardCollection->method('getItemByColumnValue')->willReturnCallback(
+            static function ($column, $value) {
+                return ($column === 'servicecode' && in_array($value, self::CONFIGURED_GIFTCARDS, true))
+                    ? new \Magento\Framework\DataObject(['servicecode' => $value])
+                    : null;
+            }
+        );
+
+        return new PaymentMethodCodeResolver(
+            $creditcardConfig,
+            $paymentHelper,
+            $giftcardCollection,
+            self::SERVICE_TO_METHOD
+        );
     }
 
     public static function serviceCodeProvider(): array
@@ -82,6 +106,10 @@ class PaymentMethodCodeResolverTest extends \Buckaroo\Magento2\Test\BaseTest
             'bancontact keeps its own method'      => ['bancontactmrcash', 'buckaroo_magento2_mrcash'],
             'giftcard is plural as a method'       => ['giftcard', 'buckaroo_magento2_giftcards'],
             'przelewy24 is p24'                    => ['przelewy24', 'buckaroo_magento2_p24'],
+            // A push names the giftcard brand, never the generic "giftcard" the settings offer.
+            'a vvv giftcard is the giftcards method' => ['vvvgiftcard', 'buckaroo_magento2_giftcards'],
+            'a boekenbon is the giftcards method'    => ['boekenbon', 'buckaroo_magento2_giftcards'],
+            'a buckaroo voucher is the voucher method' => ['buckaroovoucher', 'buckaroo_magento2_voucher'],
             'in3old is capayablein3'               => ['in3old', 'buckaroo_magento2_capayablein3'],
             // Card brands all belong to the one card method.
             'visa is a card'                       => ['visa', 'buckaroo_magento2_creditcard'],

--- a/Test/Unit/Model/Push/DefaultProcessorTest.php
+++ b/Test/Unit/Model/Push/DefaultProcessorTest.php
@@ -371,4 +371,52 @@ class DefaultProcessorTest extends \Buckaroo\Magento2\Test\BaseTest
 
         $this->assertFalse($instance->processSucceededPush('processing', 'Success'));
     }
+
+    public static function partialPaymentPushProvider(): array
+    {
+        return [
+            // A part carries its related group transaction from the very first push.
+            'a related partial payment marks it as a part' => [null, 'REL-KEY', true],
+            // An already recorded part is recognised by its group transaction row.
+            'a recorded group transaction part is a part'  => ['partialpayment', null, true],
+            'both signals present'                        => ['partialpayment', 'REL-KEY', true],
+            // Neither: an ordinary single payment.
+            'no signals is not a part'                    => [null, null, false],
+            'an empty related key is not a part'          => [null, '', false],
+            // A group transaction of another type is not a part.
+            'a non partialpayment group type is not'      => ['group', null, false],
+        ];
+    }
+
+    /**
+     * A PayLink settled in several parts went unrecorded because the processors tested this
+     * differently, so the condition lives in one place and is pinned here.
+     *
+     * @param string|null $groupTransactionType
+     * @param string|null $relatedPartialPayment
+     * @param bool        $expected
+     */
+    #[DataProvider('partialPaymentPushProvider')]
+    public function testAPushIsRecognisedAsOnePartOfASplitPayment(
+        ?string $groupTransactionType,
+        ?string $relatedPartialPayment,
+        bool $expected
+    ): void {
+        $instance = $this->getInstance();
+
+        $pushRequestMock = $this->getFakeMock(\Buckaroo\Magento2\Test\Unit\Stubs\PushRequestInterfaceStub::class)
+            ->getMock();
+        $pushRequestMock->method('getTransactions')
+            ->willReturn($groupTransactionType === null ? null : 'TRX-1');
+        $pushRequestMock->method('getRelatedtransactionPartialpayment')
+            ->willReturn($relatedPartialPayment);
+
+        // getType() is a magic getter, so a real DataObject stands in for the group transaction row.
+        $this->groupTransactionMock->method('getGroupTransactionByTrxId')
+            ->willReturn(new \Magento\Framework\DataObject(['type' => $groupTransactionType]));
+
+        $this->setProperty('pushRequest', $pushRequestMock, $instance);
+
+        $this->assertSame($expected, $this->invokeArgs('isPartialPaymentPush', [], $instance));
+    }
 }

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -4547,6 +4547,12 @@
                 disabled="false"/>
     </type>
 
+    <type name="Buckaroo\Magento2\Service\LogoService">
+        <arguments>
+            <argument name="paymentMethodCodeResolver" xsi:type="object">Buckaroo\Magento2\Model\PaymentMethodCodeResolver\Proxy</argument>
+        </arguments>
+    </type>
+
     <type name="Buckaroo\Magento2\Model\PaymentMethodCodeResolver">
         <arguments>
             <argument name="serviceToMethod" xsi:type="array">
@@ -4555,6 +4561,7 @@
                 <item name="przelewy24" xsi:type="string">p24</item>
                 <item name="kbcpaymentbutton" xsi:type="string">kbc</item>
                 <item name="in3old" xsi:type="string">capayablein3</item>
+                <item name="buckaroovoucher" xsi:type="string">voucher</item>
             </argument>
         </arguments>
     </type>


### PR DESCRIPTION
fix multiple part paylink order and update payment logo retrieval to use service code mapping