### PR TITLE
BTI-1377-Credit-Management-fatals-on-Bank-Transfer-and-SEPA-and-PayPerEmail-uses-the-wrong-store-scope-creditmanagement-payperemail

### DIFF
--- a/Gateway/Request/PayPerEmailDataBuilder.php
+++ b/Gateway/Request/PayPerEmailDataBuilder.php
@@ -55,7 +55,7 @@ class PayPerEmailDataBuilder extends AbstractDataBuilder
     public function build(array $buildSubject): array
     {
         parent::initialize($buildSubject);
-        $storeId = $this->getOrder()->getStoreId();
+        $storeId = (int)$this->getOrder()->getStoreId();
         $payment = $this->getPayment();
 
         $data = [

--- a/Model/ConfigProvider/Method/Cm3ConfigProviderInterface.php
+++ b/Model/ConfigProvider/Method/Cm3ConfigProviderInterface.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the MIT License
+ * It is available through the world-wide-web at this URL:
+ * https://tldrlegal.com/license/mit-license
+ * If you are unable to obtain it through the world-wide-web, please email
+ * to support@buckaroo.nl, so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade this module to newer
+ * versions in the future. If you wish to customize this module for your
+ * needs please contact support@buckaroo.nl for more information.
+ *
+ * @copyright Copyright (c) Buckaroo B.V.
+ * @license   https://tldrlegal.com/license/mit-license
+ */
+declare(strict_types=1);
+
+namespace Buckaroo\Magento2\Model\ConfigProvider\Method;
+
+/**
+ * Configuration a payment method must expose to take part in Credit Management (CM3).
+ *
+ * Only PayPerEmail, Bank Transfer and SEPA Direct Debit offer the "Credit Management
+ * Enabled" setting, and the CM3 request builders read exactly these values. Declaring
+ * them here lets those builders depend on the capability rather than on
+ * AbstractConfigProvider, which defines none of them.
+ */
+interface Cm3ConfigProviderInterface
+{
+    /**
+     * Whether Credit Management is enabled for this payment method.
+     *
+     * @param null|int|string $store
+     *
+     * @return mixed
+     */
+    public function getActiveStatusCm3($store = null);
+
+    /**
+     * Credit Management scheme key, from Plaza > Invoices > Scheme.
+     *
+     * @param null|int|string $store
+     *
+     * @return mixed
+     */
+    public function getSchemeKey($store = null);
+
+    /**
+     * Highest Credit Management step to run.
+     *
+     * @param null|int|string $store
+     *
+     * @return mixed
+     */
+    public function getMaxStepIndex($store = null);
+
+    /**
+     * Days after the order date on which the invoice falls due.
+     *
+     * @param null|int|string $store
+     *
+     * @return mixed
+     */
+    public function getCm3DueDate($store = null);
+
+    /**
+     * Payment methods offered after the due date has passed.
+     *
+     * @param null|int|string $store
+     *
+     * @return mixed
+     */
+    public function getPaymentMethodAfterExpiry($store = null);
+
+    /**
+     * Payment methods offered on the invoice, or false when unrestricted.
+     *
+     * @param int|null $storeId
+     *
+     * @return false|mixed
+     */
+    public function getPaymentMethod(?int $storeId = null);
+}

--- a/Model/ConfigProvider/Method/PayPerEmail.php
+++ b/Model/ConfigProvider/Method/PayPerEmail.php
@@ -24,7 +24,7 @@ namespace Buckaroo\Magento2\Model\ConfigProvider\Method;
 use Buckaroo\Magento2\Exception;
 use Magento\Framework\App\Area;
 
-class PayPerEmail extends AbstractConfigProvider
+class PayPerEmail extends AbstractConfigProvider implements Cm3ConfigProviderInterface
 {
     public const CODE = 'buckaroo_magento2_payperemail';
 
@@ -69,11 +69,13 @@ class PayPerEmail extends AbstractConfigProvider
     /**
      * Sends an email to the customer with the payment procedures.
      *
+     * @param int|null $storeId
+     *
      * @return bool
      */
-    public function hasSendMail(): bool
+    public function hasSendMail(?int $storeId = null): bool
     {
-        return (bool)$this->getMethodConfigValue(self::XPATH_PAYPEREMAIL_SEND_MAIL);
+        return (bool)$this->getMethodConfigValue(self::XPATH_PAYPEREMAIL_SEND_MAIL, $storeId);
     }
 
     /**

--- a/Model/ConfigProvider/Method/SepaDirectDebit.php
+++ b/Model/ConfigProvider/Method/SepaDirectDebit.php
@@ -22,7 +22,7 @@ namespace Buckaroo\Magento2\Model\ConfigProvider\Method;
 
 use Buckaroo\Magento2\Exception;
 
-class SepaDirectDebit extends AbstractConfigProvider
+class SepaDirectDebit extends AbstractConfigProvider implements Cm3ConfigProviderInterface
 {
     public const CODE = 'buckaroo_magento2_sepadirectdebit';
 
@@ -109,5 +109,22 @@ class SepaDirectDebit extends AbstractConfigProvider
         );
 
         return $paymentFee ?: 0;
+    }
+
+    /**
+     * Payment methods offered on the invoice.
+     *
+     * This method exposes no "allowed services" setting of its own, so the config
+     * read yields nothing, and Credit Management leaves the invoice unrestricted.
+     *
+     * @param int|null $storeId
+     *
+     * @return false|mixed
+     */
+    public function getPaymentMethod(?int $storeId = null)
+    {
+        $paymentMethod = $this->getMethodConfigValue('payment_method', $storeId);
+
+        return $paymentMethod ?: false;
     }
 }

--- a/Model/ConfigProvider/Method/Transfer.php
+++ b/Model/ConfigProvider/Method/Transfer.php
@@ -23,7 +23,7 @@ namespace Buckaroo\Magento2\Model\ConfigProvider\Method;
 use Buckaroo\Magento2\Exception;
 use Buckaroo\Magento2\Model\Config\Source\TransferPaymentMethodLogo;
 
-class Transfer extends AbstractConfigProvider
+class Transfer extends AbstractConfigProvider implements Cm3ConfigProviderInterface
 {
     public const CODE = 'buckaroo_magento2_transfer';
 
@@ -184,5 +184,22 @@ class Transfer extends AbstractConfigProvider
         );
 
         return $paymentFee ?: 0;
+    }
+
+    /**
+     * Payment methods offered on the invoice.
+     *
+     * This method exposes no "allowed services" setting of its own, so the config
+     * read yields nothing, and Credit Management leaves the invoice unrestricted.
+     *
+     * @param int|null $storeId
+     *
+     * @return false|mixed
+     */
+    public function getPaymentMethod(?int $storeId = null)
+    {
+        $paymentMethod = $this->getMethodConfigValue('payment_method', $storeId);
+
+        return $paymentMethod ?: false;
     }
 }

--- a/Service/CreditManagement/ServiceParameters/CreateCombinedInvoice.php
+++ b/Service/CreditManagement/ServiceParameters/CreateCombinedInvoice.php
@@ -21,18 +21,19 @@
 namespace Buckaroo\Magento2\Service\CreditManagement\ServiceParameters;
 
 use Buckaroo\Magento2\Exception;
-use Buckaroo\Magento2\Model\ConfigProvider\Method\AbstractConfigProvider;
+use Buckaroo\Magento2\Model\ConfigProvider\Method\Cm3ConfigProviderInterface;
 use Buckaroo\Magento2\Model\ConfigProvider\Factory;
 use Buckaroo\Magento2\Service\Culture\CultureCodeResolver;
 use Buckaroo\Magento2\Model\ConfigProvider\Method\PayPerEmail;
 use Magento\Payment\Model\InfoInterface;
 use Magento\Sales\Api\Data\OrderPaymentInterface;
 use Magento\Sales\Model\Order;
+use Magento\Sales\Model\Order\Payment;
 
 class CreateCombinedInvoice
 {
     /**
-     * @var AbstractConfigProvider
+     * @var Cm3ConfigProviderInterface
      */
     private $configProvider;
 
@@ -70,10 +71,22 @@ class CreateCombinedInvoice
      */
     public function get($payment, string $configProviderType): array
     {
-        $this->configProvider = $this->configProviderMethodFactory->get($configProviderType);
+        $configProvider = $this->configProviderMethodFactory->get($configProviderType);
+
+        if (!$configProvider instanceof Cm3ConfigProviderInterface) {
+            throw new Exception(
+                __('Credit Management is not supported by payment method %1.', $configProviderType)
+            );
+        }
+
+        $this->configProvider = $configProvider;
 
         if (!$this->configProvider->getActiveStatusCm3()) {
             return [];
+        }
+
+        if (!$payment instanceof Payment) {
+            throw new Exception(__('Credit Management requires an order payment.'));
         }
 
         return [
@@ -87,13 +100,12 @@ class CreateCombinedInvoice
     /**
      * Get debtor details
      *
-     * @param OrderPaymentInterface|InfoInterface $payment
+     * @param Payment $payment
      *
      * @return array
      */
-    private function getCmRequestParameters($payment)
+    private function getCmRequestParameters(Payment $payment)
     {
-        /** @var Order $order */
         $order = $payment->getOrder();
 
         $requestParameters = [
@@ -263,13 +275,12 @@ class CreateCombinedInvoice
     /**
      * Get CM Person details
      *
-     * @param OrderPaymentInterface|InfoInterface $payment
+     * @param Payment $payment
      *
      * @return array
      */
-    private function getPersonCmParameters($payment)
+    private function getPersonCmParameters(Payment $payment)
     {
-        /** @var Order $order */
         $order = $payment->getOrder();
 
         $personParameters = [
@@ -381,28 +392,16 @@ class CreateCombinedInvoice
             return $addressData;
         }
 
-        $streetname = '';
-        $housenumber = '';
         $housenumberExtension = '';
-        if (isset($matches[1])) {
-            $streetname = $matches[1];
-        }
-
-        if (isset($matches[2])) {
-            $housenumber = $matches[2];
-        }
+        $streetname = $matches[1];
+        $housenumber = $matches[2];
 
         if (!empty($housenumber)) {
             $housenumber = trim($housenumber);
             $housenumberRegexResult = preg_match('#^([\d]+)(.*)#s', $housenumber, $matches);
             if ($housenumberRegexResult && is_array($matches)) {
-                if (isset($matches[1])) {
-                    $housenumber = $matches[1];
-                }
-
-                if (isset($matches[2])) {
-                    $housenumberExtension = trim($matches[2]);
-                }
+                $housenumber = $matches[1];
+                $housenumberExtension = trim($matches[2]);
             }
         }
 
@@ -428,7 +427,7 @@ class CreateCombinedInvoice
         $requestParameters = [];
         $company = $billingAddress->getCompany();
 
-        if (empty($company) || strlen($company) <= 0) {
+        if (empty($company)) {
             return $requestParameters;
         }
 

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -3354,6 +3354,7 @@
             <argument name="builders" xsi:type="array">
                 <item name="order_request" xsi:type="string">BuckarooOrderRequest</item>
                 <item name="payPerEmail" xsi:type="string">Buckaroo\Magento2\Gateway\Request\PayPerEmailDataBuilder</item>
+                <item name="culture" xsi:type="string">Buckaroo\Magento2\Gateway\Request\CultureDataBuilder</item>
                 <item name="additional_parameters" xsi:type="string">AdditionalParametersPayPerEmailDataBuilder</item>
                 <item name="credit_management" xsi:type="string">BuckarooDefaultCreditManagment</item>
             </argument>


### PR DESCRIPTION
CreateCombinedInvoice::getAllowedServices() calls getPaymentMethod() on the payment method's config provider, and getUngroupedCmParameters() always reaches it. Only PayPerEmail defines that method - Transfer and SepaDirectDebit do not, and neither does AbstractConfigProvider - so enabling "Credit Management Enabled" on either of those two fatals with Call to undefined method and the CM3 request is never built. Two of the three methods that offer the setting are affected.

Cm3ConfigProviderInterface now names the configuration a payment method must expose to take part in CM3, and the three methods that offer the setting implement it. Transfer and SepaDirectDebit gain the missing getPaymentMethod(); neither exposes an allowed-services field, so it returns false and the invoice is left unrestricted. CreateCombinedInvoice types its property to the capability rather than AbstractConfigProvider and fails fast with a clear message when handed a provider or payment it cannot use, instead of a TypeError deeper in the call stack.

That also clears the 15 pre-existing PHPStan errors in this file, including four isset() checks on capture groups a successful preg_match already guarantees, and a strlen() that cannot fire after empty().

PayPerEmail, all three rooted in the store id not reaching the config:

- hasSendMail() took no parameters while PayPerEmailDataBuilder passed it a store id, which PHP silently discarded, so "Send mail" was read from the current scope instead of the order's store. Same defect class as BTI-1262 point 2.
- getStoreId() returns a string on a loaded order and getPaymentMethodsAllowed() is typed ?int under strict_types, so building a PayPerEmail request for a loaded order threw a TypeError. Fine at checkout, broken on anything operating on a saved order.
- The Culture header now derives from the order's billing country. It previously fell back to the current locale, which for an admin-created PayLink is the admin locale, so a Dutch customer could be sent an English invitation.

Not addressed: isEnabledB2B() also reads the current scope, but no caller passes a store today, so it is latent rather than an active fault.