### PR TITLE
BTI-1316-Magento-2-PayLink-order-paid-with-Bancontact-gets-an-invalid-payment-method-code-blocking-online-refunds

### DIFF
--- a/Block/Info/Creditcard.php
+++ b/Block/Info/Creditcard.php
@@ -25,6 +25,7 @@ use Magento\Framework\View\Asset\Repository;
 use Magento\Framework\UrlInterface;
 use Buckaroo\Magento2\Helper\PaymentGroupTransaction;
 use Buckaroo\Magento2\Model\ConfigProvider\Method\Creditcard as ConfigProviderCreditcard;
+use Buckaroo\Magento2\Model\Method\BuckarooAdapter;
 use Buckaroo\Magento2\Model\ResourceModel\Giftcard\Collection as GiftcardCollection;
 use Buckaroo\Magento2\Service\LogoService;
 use Magento\Framework\Exception\LocalizedException;
@@ -102,15 +103,19 @@ class Creditcard extends Info
     }
 
     /**
-     * Get card code
+     * Get card code or null when the card is unknown.
      *
      * @throws LocalizedException
      *
-     * @return string
+     * @return string|null
      */
-    public function getCardCode()
+    public function getCardCode(): ?string
     {
         $cardType = $this->getCardType();
+
+        if ($cardType === null) {
+            return null;
+        }
 
         return $this->configProvider->getCardCode($cardType);
     }
@@ -120,15 +125,21 @@ class Creditcard extends Info
      *
      * @throws LocalizedException
      *
-     * @return string
+     * @return string|null
      */
-    public function getCardType()
+    public function getCardType(): ?string
     {
         if ($this->cardType === null) {
-            $this->cardType = $this->configProvider->getCardName(
-                $this->getInfo()->getAdditionalInformation('card_type')
-            );
+            $info = $this->getInfo();
+            $cardCode = $info->getAdditionalInformation('card_type');
+
+            if (empty($cardCode)) {
+                $cardCode = $info->getAdditionalInformation(BuckarooAdapter::BUCKAROO_ACTUAL_PAYMENT_METHOD);
+            }
+
+            $this->cardType = $this->configProvider->getCardName($cardCode);
         }
+
         return $this->cardType;
     }
 }

--- a/Model/ConfigProvider/Method/Creditcard.php
+++ b/Model/ConfigProvider/Method/Creditcard.php
@@ -231,41 +231,44 @@ class Creditcard extends AbstractConfigProvider
     /**
      * Get card name by card code
      *
-     * @param string $cardType
-     *
-     * @throws \InvalidArgumentException
-     *
-     * @return string
+     * @param string|null $cardType
+     * @return string|null
      */
-    public function getCardName($cardType)
+    public function getCardName($cardType): ?string
     {
+        if (empty($cardType)) {
+            return null;
+        }
+
         foreach ($this->getIssuers() as $card) {
-            if ($card['code'] == $cardType) {
+            if (strtolower((string)$card['code']) === strtolower((string)$cardType)) {
                 return $card['name'];
             }
         }
 
-        throw new \InvalidArgumentException("No card found for card type: {$cardType}");
+        return null;
     }
 
     /**
      * Get card code by card name
      *
-     * @param string $cardName
+     * @param string|null $cardName
      *
-     * @throws \InvalidArgumentException
-     *
-     * @return string
+     * @return string|null
      */
-    public function getCardCode($cardName)
+    public function getCardCode($cardName): ?string
     {
+        if (empty($cardName)) {
+            return null;
+        }
+
         foreach ($this->getIssuers() as $card) {
-            if ($card['name'] == $cardName) {
+            if (strtolower((string)$card['name']) === strtolower((string)$cardName)) {
                 return $card['code'];
             }
         }
 
-        throw new \InvalidArgumentException("No card found for card name: {$cardName}");
+        return null;
     }
 
     /**

--- a/Test/Unit/Model/ConfigProvider/Method/CreditcardTest.php
+++ b/Test/Unit/Model/ConfigProvider/Method/CreditcardTest.php
@@ -26,6 +26,7 @@ use Magento\Framework\App\Config\ScopeConfigInterface;
 use Magento\Store\Model\ScopeInterface;
 use Buckaroo\Magento2\Test\BaseTest;
 use Buckaroo\Magento2\Model\ConfigProvider\Method\Creditcard;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class CreditcardTest extends BaseTest
 {
@@ -94,5 +95,83 @@ class CreditcardTest extends BaseTest
         $result = $instance->getActive();
 
         $this->assertEquals(1, $result);
+    }
+
+    /**
+     * A known card code resolves to its display name.
+     */
+    public function testGetCardNameReturnsTheNameForAKnownCode()
+    {
+        // Arrange
+        $instance = $this->getInstance();
+
+        // Act
+        $result = $instance->getCardName('visa');
+
+        // Assert
+        $this->assertEquals('VISA', $result);
+    }
+
+    /**
+     * An order that never went through Magento's card form has no card type at all. Returning null
+     * keeps the order view, the success page and the invoice PDF rendering; throwing broke all three
+     * for PayLink orders paid by card.
+     *
+     * @param string|null $cardType
+     */
+    #[DataProvider('unresolvableCardTypeProvider')]
+    public function testGetCardNameReturnsNullWhenTheCodeCannotBeResolved($cardType)
+    {
+        // Arrange
+        $instance = $this->getInstance();
+
+        // Act
+        $result = $instance->getCardName($cardType);
+
+        // Assert
+        $this->assertNull($result);
+    }
+
+    /**
+     * @return array
+     */
+    public static function unresolvableCardTypeProvider()
+    {
+        return [
+            'empty string' => [''],
+            'null' => [null],
+            'unknown brand' => ['notacard'],
+        ];
+    }
+
+    /**
+     * A known card name resolves back to its service code.
+     */
+    public function testGetCardCodeReturnsTheCodeForAKnownName()
+    {
+        // Arrange
+        $instance = $this->getInstance();
+
+        // Act
+        $result = $instance->getCardCode('VISA');
+
+        // Assert
+        $this->assertEquals('visa', $result);
+    }
+
+    /**
+     * The admin template reads getCardCode() straight into a CSS class, outside any guard, so it
+     * must not throw either.
+     */
+    public function testGetCardCodeReturnsNullWhenTheNameCannotBeResolved()
+    {
+        // Arrange
+        $instance = $this->getInstance();
+
+        // Act
+        $result = $instance->getCardCode('Not A Card');
+
+        // Assert
+        $this->assertNull($result);
     }
 }


### PR DESCRIPTION
enhance credit card handling to support null values for unknown card types and names