### PR TITLE
Bti 1316 magento 2 pay link order paid with bancontact gets an invalid payment method code blocking online refunds

### DIFF
--- a/Model/Push/PayPerEmailProcessor.php
+++ b/Model/Push/PayPerEmailProcessor.php
@@ -265,9 +265,39 @@ class PayPerEmailProcessor extends DefaultProcessor
                 || !empty($this->pushRequest->getAdditionalInformation('frompaylink')))
             && $this->pushTransactionType->getStatusKey() == 'BUCKAROO_MAGENTO2_STATUSCODE_SUCCESS'
         ) {
+            // Every push for a PayLink carries the PayLink marker, the group transaction that closes
+            // it included. Once an earlier push has told us what the consumer actually paid with,
+            // stamping PayLink back over that costs the order its online refund, so the resolved
+            // method wins.
+            if ($this->hasResolvedActualPaymentMethod()) {
+                $this->logger->addDebug(sprintf(
+                    '[PUSH - PayPerEmail] | [Webapi] | [%s:%s] - Keeping already resolved payment'
+                    . ' method %s instead of overwriting it with PayLink | order: %s',
+                    __METHOD__,
+                    __LINE__,
+                    (string)$this->payment->getMethod(),
+                    $this->order->getIncrementId()
+                ));
+
+                return;
+            }
+
             $this->payment->setMethod('buckaroo_magento2_payperemail');
             $this->orderRepository->save($this->order);
         }
+    }
+
+    /**
+     * Whether an earlier push already recorded a payment method that Magento can resolve.
+     *
+     * @return bool
+     */
+    private function hasResolvedActualPaymentMethod(): bool
+    {
+        $storedMethod = $this->payment->getAdditionalInformation(BuckarooAdapter::BUCKAROO_ACTUAL_PAYMENT_METHOD);
+
+        return !empty($storedMethod)
+            && $this->paymentMethodCodeResolver->resolve((string)$storedMethod) !== null;
     }
 
     /**
@@ -335,16 +365,13 @@ class PayPerEmailProcessor extends DefaultProcessor
 
         $transactionMethod = $this->pushRequest->getTransactionMethod();
         if (!empty($transactionMethod) && strtolower($transactionMethod) !== 'payperemail') {
-            $transactionMethod = strtolower($transactionMethod);
-            $this->saveActualPaymentMethodAndKeyForRefund($transactionKey, $transactionMethod);
-            return true;
+            return $this->saveActualPaymentMethodAndKeyForRefund($transactionKey, strtolower($transactionMethod));
         }
 
         if ($isPayPerEmailOrder && !empty($transactionKey) && $transactionKey !== $payPerEmailKey) {
             $transactionMethod = $this->deriveActualPaymentMethodFromPush();
             if ($transactionMethod !== null) {
-                $this->saveActualPaymentMethodAndKeyForRefund($transactionKey, $transactionMethod);
-                return true;
+                return $this->saveActualPaymentMethodAndKeyForRefund($transactionKey, $transactionMethod);
             }
         }
 
@@ -357,24 +384,14 @@ class PayPerEmailProcessor extends DefaultProcessor
      * @param string $transactionKey
      * @param string $transactionMethod
      *
-     * @return void
+     * @return bool
      * @throws LocalizedException
      */
-    private function saveActualPaymentMethodAndKeyForRefund(string $transactionKey, string $transactionMethod): void
+    private function saveActualPaymentMethodAndKeyForRefund(string $transactionKey, string $transactionMethod): bool
     {
-        $this->payment->setAdditionalInformation(
-            BuckarooAdapter::BUCKAROO_ACTUAL_PAYMENT_METHOD,
-            $transactionMethod
-        );
-        $this->payment->setAdditionalInformation(
-            BuckarooAdapter::BUCKAROO_ACTUAL_PAYMENT_TRANSACTION_KEY,
-            $transactionKey
-        );
         $methodCode = $this->paymentMethodCodeResolver->resolve($transactionMethod);
 
-        if ($methodCode !== null) {
-            $this->payment->setMethod($methodCode);
-        } else {
+        if ($methodCode === null) {
             $this->logger->addWarning(sprintf(
                 '[PUSH - PayPerEmail] | [Webapi] | [%s:%s] - No payment method registered for service'
                 . ' %s; leaving the order method unchanged | order: %s',
@@ -383,9 +400,23 @@ class PayPerEmailProcessor extends DefaultProcessor
                 $transactionMethod,
                 $this->order->getIncrementId()
             ));
+
+            return false;
         }
 
+        $this->payment->setAdditionalInformation(
+            BuckarooAdapter::BUCKAROO_ACTUAL_PAYMENT_METHOD,
+            $transactionMethod
+        );
+        $this->payment->setAdditionalInformation(
+            BuckarooAdapter::BUCKAROO_ACTUAL_PAYMENT_TRANSACTION_KEY,
+            $transactionKey
+        );
+        $this->payment->setMethod($methodCode);
+
         $this->orderRepository->save($this->order);
+
+        return true;
     }
 
     /**
@@ -395,14 +426,19 @@ class PayPerEmailProcessor extends DefaultProcessor
      */
     private function deriveActualPaymentMethodFromPush(): ?string
     {
-        if (method_exists($this->pushRequest, 'getPrimaryService')) {
-            $primary = $this->pushRequest->getPrimaryService();
-            if (!empty($primary) && strtolower((string) $primary) !== 'payperemail') {
-                return strtolower((string) $primary);
-            }
+        $service = $this->findServiceInPushData();
+
+        if ($service !== null) {
+            return $service;
         }
 
-        return $this->findServiceInPushData();
+        $storedMethod = $this->payment->getAdditionalInformation(BuckarooAdapter::BUCKAROO_ACTUAL_PAYMENT_METHOD);
+
+        if (!empty($storedMethod) && $this->paymentMethodCodeResolver->resolve((string)$storedMethod) !== null) {
+            return strtolower((string)$storedMethod);
+        }
+
+        return null;
     }
 
     /**
@@ -423,12 +459,21 @@ class PayPerEmailProcessor extends DefaultProcessor
         }
 
         foreach (array_keys($data) as $key) {
-            if (preg_match('/^brq_service_([a-z0-9]+)_/i', (string) $key, $m)) {
-                $service = strtolower($m[1]);
-                if ($service !== 'payperemail' && $service !== 'paylink') {
-                    return $service;
-                }
+            if (!preg_match('/^brq_service_([a-z0-9]+)_/i', (string)$key, $matches)) {
+                continue;
             }
+
+            $service = strtolower($matches[1]);
+
+            if ($service === 'payperemail' || $service === 'paylink') {
+                continue;
+            }
+
+            if ($this->paymentMethodCodeResolver->resolve($service) === null) {
+                continue;
+            }
+
+            return $service;
         }
 
         return null;

--- a/Test/Unit/Model/Push/PayPerEmailProcessorTest.php
+++ b/Test/Unit/Model/Push/PayPerEmailProcessorTest.php
@@ -26,6 +26,7 @@ class PayPerEmailProcessorTest extends \Buckaroo\Magento2\Test\BaseTest
     private $configPayPerEmailMock;
     private $currencyFactoryMock;
     private $orderRepositoryMock;
+    private $paymentMethodCodeResolverMock;
 
     public function setUp(): void
     {
@@ -47,6 +48,9 @@ class PayPerEmailProcessorTest extends \Buckaroo\Magento2\Test\BaseTest
         $this->configPayPerEmailMock = $this->getFakeMock('Buckaroo\Magento2\Model\ConfigProvider\Method\PayPerEmail')->getMock();
         $this->currencyFactoryMock = $this->getFakeMock('Magento\Directory\Model\CurrencyFactory')->getMock();
         $this->orderRepositoryMock = $this->createMock(\Magento\Sales\Api\OrderRepositoryInterface::class);
+        $this->paymentMethodCodeResolverMock = $this->createMock(
+            \Buckaroo\Magento2\Model\PaymentMethodCodeResolver::class
+        );
     }
 
     public function getInstance(array $args = [])
@@ -73,6 +77,7 @@ class PayPerEmailProcessorTest extends \Buckaroo\Magento2\Test\BaseTest
             'groupTransactionResource' => $this->createMock(\Buckaroo\Magento2\Model\ResourceModel\GroupTransaction::class),
             'transactionRepository' => $this->createMock(\Magento\Sales\Api\TransactionRepositoryInterface::class),
             'searchCriteriaBuilder' => $this->createMock(\Magento\Framework\Api\SearchCriteriaBuilder::class),
+            'paymentMethodCodeResolver' => $this->paymentMethodCodeResolverMock,
         ] + $args);
     }
 
@@ -179,5 +184,118 @@ class PayPerEmailProcessorTest extends \Buckaroo\Magento2\Test\BaseTest
 
         $paymentDetails = ['description' => 'Payment status : success'];
         $this->assertFalse($this->invokeArgs('invoiceShouldBeSaved', [&$paymentDetails], $instance));
+    }
+
+    /**
+     * BTI-1316: a PayLink paid in full with one giftcard is closed by a push that names no payment
+     * service of its own, only the PayLink. Overwriting the giftcard method with PayLink at that
+     * point left the order on a method that cannot be refunded online.
+     */
+    public function testPayLinkPushKeepsAnAlreadyResolvedPaymentMethod(): void
+    {
+        $instance = $this->getInstance();
+
+        $pushRequestMock = $this->getFakeMock(\Buckaroo\Magento2\Test\Unit\Stubs\PushRequestInterfaceStub::class)
+            ->getMock();
+        $pushRequestMock->method('getAdditionalInformation')->willReturnMap([
+            ['service_action_from_magento', 'frompaylink'],
+        ]);
+        $this->pushTransactionTypeMock->method('getStatusKey')
+            ->willReturn('BUCKAROO_MAGENTO2_STATUSCODE_SUCCESS');
+
+        $paymentMock = $this->getFakeMock('Magento\Sales\Model\Order\Payment')->getMock();
+        $paymentMock->method('getAdditionalInformation')
+            ->with('buckaroo_actual_payment_method')
+            ->willReturn('vvvgiftcard');
+        $paymentMock->method('getMethod')->willReturn('buckaroo_magento2_giftcards');
+        $paymentMock->expects($this->never())->method('setMethod');
+
+        $this->paymentMethodCodeResolverMock->method('resolve')
+            ->with('vvvgiftcard')
+            ->willReturn('buckaroo_magento2_giftcards');
+
+        $this->orderRepositoryMock->expects($this->never())->method('save');
+
+        $this->setProperty('order', $this->getFakeMock('Magento\Sales\Model\Order')->getMock(), $instance);
+        $this->setProperty('payment', $paymentMock, $instance);
+        $this->setProperty('pushRequest', $pushRequestMock, $instance);
+
+        $this->invoke('receivePushCheckPayLink', $instance);
+    }
+
+    public function testPayLinkPushStampsPayPerEmailWhenNoMethodResolvedYet(): void
+    {
+        $instance = $this->getInstance();
+
+        $pushRequestMock = $this->getFakeMock(\Buckaroo\Magento2\Test\Unit\Stubs\PushRequestInterfaceStub::class)
+            ->getMock();
+        $pushRequestMock->method('getAdditionalInformation')->willReturnMap([
+            ['service_action_from_magento', 'frompaylink'],
+        ]);
+        $this->pushTransactionTypeMock->method('getStatusKey')
+            ->willReturn('BUCKAROO_MAGENTO2_STATUSCODE_SUCCESS');
+
+        $paymentMock = $this->getFakeMock('Magento\Sales\Model\Order\Payment')->getMock();
+        $paymentMock->method('getAdditionalInformation')->willReturn(null);
+        $paymentMock->expects($this->once())->method('setMethod')->with('buckaroo_magento2_payperemail');
+
+        $this->orderRepositoryMock->expects($this->once())->method('save');
+
+        $this->setProperty('order', $this->getFakeMock('Magento\Sales\Model\Order')->getMock(), $instance);
+        $this->setProperty('payment', $paymentMock, $instance);
+        $this->setProperty('pushRequest', $pushRequestMock, $instance);
+
+        $this->invoke('receivePushCheckPayLink', $instance);
+    }
+
+    /**
+     * A PayLink push carries brq_SERVICE_general_paylink alongside the service actually paid with.
+     * Matching on the key shape alone picked "general" and wrote that onto the order.
+     */
+    public function testFindServiceInPushDataSkipsServiceKeysThatAreNotPaymentMethods(): void
+    {
+        $instance = $this->getInstance();
+
+        $pushRequestMock = $this->getFakeMock(\Buckaroo\Magento2\Test\Unit\Stubs\PushRequestInterfaceStub::class)
+            ->getMock();
+        $pushRequestMock->method('getData')->willReturn([
+            'brq_amount'                                  => '30.25',
+            'brq_service_general_paylink'                 => 'https://testcheckout.buckaroo.nl/html/',
+            'brq_service_payperemail_expirationdate'      => '2027-09-02',
+            'brq_service_vvvgiftcard_maskedgiftcardnumber' => '00000000*******0001',
+        ]);
+
+        $this->paymentMethodCodeResolverMock->method('resolve')->willReturnMap([
+            ['general', null],
+            ['vvvgiftcard', 'buckaroo_magento2_giftcards'],
+        ]);
+
+        $this->setProperty('pushRequest', $pushRequestMock, $instance);
+
+        $this->assertSame('vvvgiftcard', $this->invoke('findServiceInPushData', $instance));
+    }
+
+    public function testUnresolvableServiceCodeIsNotWrittenOntoThePayment(): void
+    {
+        $instance = $this->getInstance();
+
+        $paymentMock = $this->getFakeMock('Magento\Sales\Model\Order\Payment')->getMock();
+        $paymentMock->expects($this->never())->method('setAdditionalInformation');
+        $paymentMock->expects($this->never())->method('setMethod');
+
+        $orderMock = $this->getFakeMock('Magento\Sales\Model\Order')->getMock();
+        $orderMock->method('getIncrementId')->willReturn('300000013');
+
+        $this->paymentMethodCodeResolverMock->method('resolve')->with('general')->willReturn(null);
+        $this->orderRepositoryMock->expects($this->never())->method('save');
+
+        $this->setProperty('order', $orderMock, $instance);
+        $this->setProperty('payment', $paymentMock, $instance);
+
+        $this->assertFalse($this->invokeArgs(
+            'saveActualPaymentMethodAndKeyForRefund',
+            ['SOME_GROUP_TRANSACTION_KEY', 'general'],
+            $instance
+        ));
     }
 }


### PR DESCRIPTION
enhance PayPerEmailProcessor to preserve resolved payment methods during PayLink pushes