### PR TITLE
BTI-1489 security hardening (unauth controllers, ACL, rate-limit)

### DIFF
--- a/Block/Adminhtml/System/Config/CredentialsChecker.php
+++ b/Block/Adminhtml/System/Config/CredentialsChecker.php
@@ -66,6 +66,16 @@ class CredentialsChecker extends Field
     }
 
     /**
+     * Get the ACL-protected admin URL used to validate the credentials
+     *
+     * @return string
+     */
+    public function getAjaxUrl(): string
+    {
+        return $this->getUrl('buckaroo/credentialschecker/index');
+    }
+
+    /**
      * Return element html
      *
      * @param AbstractElement $element

--- a/Controller/Adminhtml/CredentialsChecker/Index.php
+++ b/Controller/Adminhtml/CredentialsChecker/Index.php
@@ -17,31 +17,41 @@
  * @copyright Copyright (c) Buckaroo B.V.
  * @license   https://tldrlegal.com/license/mit-license
  */
+declare(strict_types=1);
 
-namespace Buckaroo\Magento2\Controller\CredentialsChecker;
+namespace Buckaroo\Magento2\Controller\Adminhtml\CredentialsChecker;
 
-use Buckaroo\Magento2\Exception as BuckarooException;
 use Buckaroo\Magento2\Model\Adapter\BuckarooAdapter;
 use Buckaroo\Magento2\Model\ConfigProvider\Account;
-use Buckaroo\Magento2\Model\ConfigProvider\Factory;
 use Exception;
-use Magento\Checkout\Model\ConfigProviderInterface;
-use Magento\Framework\App\Action\Action;
-use Magento\Framework\App\Action\Context;
+use Magento\Backend\App\Action;
+use Magento\Backend\App\Action\Context;
 use Magento\Framework\App\Action\HttpPostActionInterface;
 use Magento\Framework\Controller\Result\Json;
 use Magento\Framework\Controller\ResultFactory;
-use Magento\Framework\Encryption\Encryptor;
+use Magento\Framework\Encryption\EncryptorInterface;
 
+/**
+ * Validates the configured Buckaroo credentials from the admin configuration screen.
+ *
+ * This action relays merchant credentials to the Buckaroo API and must therefore never be
+ * reachable from the storefront: it lives in the adminhtml area and is guarded by the
+ * Buckaroo configuration ACL resource.
+ */
 class Index extends Action implements HttpPostActionInterface
 {
     /**
-     * @var ConfigProviderInterface
+     * ACL resource required to validate credentials.
      */
-    protected $accountConfig;
+    public const ADMIN_RESOURCE = 'Buckaroo_Magento2::configuration';
 
     /**
-     * @var Encryptor
+     * Credential type for the secret key.
+     */
+    private const CREDENTIAL_SECRET_KEY = 'secretKey';
+
+    /**
+     * @var EncryptorInterface
      */
     private $encryptor;
 
@@ -56,32 +66,25 @@ class Index extends Action implements HttpPostActionInterface
     private $client;
 
     /**
-     * Check Credentials in Admin
-     *
-     * @param Context          $context
-     * @param Factory          $configProviderFactory
-     * @param Encryptor        $encryptor
-     * @param Account          $configProviderAccount
-     * @param BuckarooAdapter  $client
-     *
-     * @throws BuckarooException
+     * @param Context            $context
+     * @param EncryptorInterface $encryptor
+     * @param Account            $configProviderAccount
+     * @param BuckarooAdapter    $client
      */
     public function __construct(
         Context $context,
-        Factory $configProviderFactory,
-        Encryptor $encryptor,
+        EncryptorInterface $encryptor,
         Account $configProviderAccount,
         BuckarooAdapter $client
     ) {
         parent::__construct($context);
-        $this->accountConfig = $configProviderFactory->get('account');
         $this->encryptor = $encryptor;
         $this->configProviderAccount = $configProviderAccount;
         $this->client = $client;
     }
 
     /**
-     * Check Buckaroo Credentials Secret Key and Merchant Key
+     * Check the Buckaroo secret key and merchant key
      *
      * @throws Exception
      *
@@ -89,25 +92,27 @@ class Index extends Action implements HttpPostActionInterface
      */
     public function execute(): Json
     {
+        $secretKey = (string)$this->getRequest()->getParam('secretKey', '');
+        $merchantKey = (string)$this->getRequest()->getParam('merchantKey', '');
 
-        $params = $this->getRequest()->getParams();
-        if (empty($params) || empty($params['secretKey']) || empty($params['merchantKey'])) {
+        if ($secretKey === '' || $merchantKey === '') {
             return $this->doResponse([
                 'success' => false,
                 'error_message' => __('Failed to start validation process due to lack of data')
             ]);
         }
 
-        $secretKey = $this->resolveCredential($params['secretKey'], 'secretKey');
-        $merchantKey = $this->resolveCredential($params['merchantKey'], 'merchantKey');
-
-        return $this->validateCredentials($merchantKey, $secretKey);
+        return $this->validateCredentials(
+            $this->resolveCredential($merchantKey, 'merchantKey'),
+            $this->resolveCredential($secretKey, self::CREDENTIAL_SECRET_KEY)
+        );
     }
 
     /**
      * Resolves the provided credential by checking if it contains any non-asterisk characters.
-     * If it contains any real characters, the raw credential is returned.
-     * Otherwise, the credential is decrypted from the stored configuration.
+     *
+     * The configuration form renders stored encrypted values as asterisks, so an all-asterisk
+     * input means "use the value already stored for this scope".
      *
      * @param string $credential The raw credential input.
      * @param string $type       The type of the credential ('secretKey' or 'merchantKey').
@@ -118,14 +123,19 @@ class Index extends Action implements HttpPostActionInterface
      */
     private function resolveCredential(string $credential, string $type): string
     {
-        return preg_match('/[^\*]/', $credential) ? $credential :
-            $this->encryptor->decrypt($this->configProviderAccount->{"get{$type}"}());
+        if (preg_match('/[^\*]/', $credential)) {
+            return $credential;
+        }
+
+        $storedCredential = $type === self::CREDENTIAL_SECRET_KEY
+            ? $this->configProviderAccount->getSecretKey()
+            : $this->configProviderAccount->getMerchantKey();
+
+        return (string)$this->encryptor->decrypt((string)$storedCredential);
     }
 
     /**
      * Validates the credentials by sending them to the Buckaroo client for confirmation.
-     * If the credentials are valid, a success response is generated.
-     * Otherwise, an error message is returned stating the credentials are invalid.
      *
      * @param string $merchantKey The merchant key to validate.
      * @param string $secretKey   The secret key to validate.
@@ -137,19 +147,17 @@ class Index extends Action implements HttpPostActionInterface
     private function validateCredentials(string $merchantKey, string $secretKey): Json
     {
         if ($this->client->confirmCredential($merchantKey, $secretKey)) {
-            return $this->doResponse([
-                'success' => true
-            ]);
-        } else {
-            return $this->doResponse([
-                'success' => false,
-                'error_message' => 'The credentials are not valid!'
-            ]);
+            return $this->doResponse(['success' => true]);
         }
+
+        return $this->doResponse([
+            'success' => false,
+            'error_message' => __('The credentials are not valid!')
+        ]);
     }
 
     /**
-     * Set Response on resultJson
+     * Set response on resultJson
      *
      * @param array $response
      *
@@ -157,7 +165,6 @@ class Index extends Action implements HttpPostActionInterface
      */
     private function doResponse(array $response): Json
     {
-        $this->_actionFlag->set('', self::FLAG_NO_POST_DISPATCH, '1');
         /** @var Json $result */
         $result = $this->resultFactory->create(ResultFactory::TYPE_JSON);
         return $result->setData($response);

--- a/Controller/Adminhtml/Giftcard/Edit.php
+++ b/Controller/Adminhtml/Giftcard/Edit.php
@@ -34,6 +34,11 @@ use Magento\Framework\View\Result\PageFactory;
 class Edit extends Action implements HttpGetActionInterface
 {
     /**
+     * ACL resource required to manage Buckaroo giftcards.
+     */
+    public const ADMIN_RESOURCE = 'Buckaroo_Magento2::buckaroo_giftcards';
+
+    /**
      * @var PageFactory
      */
     protected $resultPageFactory;
@@ -76,9 +81,17 @@ class Edit extends Action implements HttpGetActionInterface
     }
 
     /**
-     * Edit Giftcard
+     * Restrict giftcard management to users granted the giftcard ACL resource.
      *
-     * @throws LocalizedException
+     * @return bool
+     */
+    protected function _isAllowed()
+    {
+        return $this->_authorization->isAllowed(self::ADMIN_RESOURCE);
+    }
+
+    /**
+     * Render the giftcard edit form
      *
      * @return ResponseInterface|Page
      */

--- a/Controller/Adminhtml/Giftcard/NewAction.php
+++ b/Controller/Adminhtml/Giftcard/NewAction.php
@@ -30,6 +30,21 @@ use Magento\Framework\Controller\ResultInterface;
 class NewAction extends Action implements HttpGetActionInterface
 {
     /**
+     * ACL resource required to manage Buckaroo giftcards.
+     */
+    public const ADMIN_RESOURCE = 'Buckaroo_Magento2::buckaroo_giftcards';
+
+    /**
+     * Restrict giftcard creation to users granted the giftcard ACL resource.
+     *
+     * @return bool
+     */
+    protected function _isAllowed()
+    {
+        return $this->_authorization->isAllowed(self::ADMIN_RESOURCE);
+    }
+
+    /**
      * New action
      *
      * @return ResultInterface

--- a/Controller/Checkout/Giftcard.php
+++ b/Controller/Checkout/Giftcard.php
@@ -24,6 +24,7 @@ use Buckaroo\Magento2\Logging\BuckarooLoggerInterface;
 use Buckaroo\Magento2\Model\Giftcard\Api\ApiException;
 use Buckaroo\Magento2\Model\Giftcard\Request\GiftcardInterface;
 use Buckaroo\Magento2\Model\Giftcard\Response\Giftcard as GiftcardResponse;
+use Buckaroo\Magento2\Service\Giftcard\AttemptLimit;
 use Buckaroo\Transaction\Response\TransactionResponse;
 use Magento\Checkout\Model\Session;
 use Magento\Framework\App\Action\Action;
@@ -32,10 +33,11 @@ use Magento\Framework\App\Action\HttpGetActionInterface;
 use Magento\Framework\App\Action\HttpPostActionInterface;
 use Magento\Framework\Controller\Result\Json;
 use Magento\Framework\Controller\ResultFactory;
-use Magento\Framework\Exception\LocalizedException;
-use Magento\Framework\Phrase;
 use Magento\Quote\Model\Quote;
 
+/**
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
 class Giftcard extends Action implements HttpPostActionInterface, HttpGetActionInterface
 {
     /**
@@ -59,24 +61,32 @@ class Giftcard extends Action implements HttpPostActionInterface, HttpGetActionI
     protected $checkoutSession;
 
     /**
+     * @var AttemptLimit
+     */
+    private $attemptLimit;
+
+    /**
      * @param Context                 $context
      * @param Session                 $checkoutSession
      * @param GiftcardInterface       $giftcardRequest
      * @param GiftcardResponse        $giftcardResponse
      * @param BuckarooLoggerInterface $logger
+     * @param AttemptLimit            $attemptLimit
      */
     public function __construct(
         Context $context,
         Session $checkoutSession,
         GiftcardInterface $giftcardRequest,
         GiftcardResponse $giftcardResponse,
-        BuckarooLoggerInterface $logger
+        BuckarooLoggerInterface $logger,
+        AttemptLimit $attemptLimit
     ) {
         parent::__construct($context);
         $this->checkoutSession = $checkoutSession;
         $this->giftcardRequest = $giftcardRequest;
         $this->giftcardResponse = $giftcardResponse;
         $this->logger = $logger;
+        $this->attemptLimit = $attemptLimit;
     }
 
     /**
@@ -106,11 +116,17 @@ class Giftcard extends Action implements HttpPostActionInterface, HttpGetActionI
 
         try {
             $quote = $this->checkoutSession->getQuote();
+            $this->attemptLimit->assertWithinLimit($quote);
 
-            return $this->getGiftcardResponse(
-                $quote,
-                $this->build($quote)->send()
-            );
+            try {
+                return $this->getGiftcardResponse(
+                    $quote,
+                    $this->build($quote)->send()
+                );
+            } catch (ApiException $inner) {
+                $this->attemptLimit->registerFailedAttempt($quote);
+                throw $inner;
+            }
         } catch (ApiException $th) {
             $this->logger->addError(sprintf(
                 '[Giftcard] | [Controller] | [%s:%s] - Apply Inline Giftcard | [ERROR]: %s',
@@ -133,7 +149,7 @@ class Giftcard extends Action implements HttpPostActionInterface, HttpGetActionI
     /**
      * Return response with error message
      *
-     * @param Phrase|string $message
+     * @param \Magento\Framework\Phrase|string $message
      *
      * @return Json
      */
@@ -152,7 +168,7 @@ class Giftcard extends Action implements HttpPostActionInterface, HttpGetActionI
      * @param Quote               $quote
      * @param TransactionResponse $response
      *
-     * @throws ApiException|LocalizedException
+     * @throws ApiException|\Magento\Framework\Exception\LocalizedException
      *
      * @return Json
      */

--- a/Controller/Clicktopay/Token.php
+++ b/Controller/Clicktopay/Token.php
@@ -25,7 +25,9 @@ namespace Buckaroo\Magento2\Controller\Clicktopay;
 use Buckaroo\Magento2\Logging\BuckarooLoggerInterface;
 use Buckaroo\Magento2\Model\ConfigProvider\Method\Clicktopay as ClicktopayConfig;
 use Buckaroo\Magento2\Service\OauthTokenService;
+use Magento\Checkout\Model\Session as CheckoutSession;
 use Magento\Framework\App\Action\HttpPostActionInterface;
+use Magento\Framework\App\Request\Http;
 use Magento\Framework\Controller\Result\Json;
 use Magento\Framework\Controller\Result\JsonFactory;
 use Magento\Framework\Encryption\EncryptorInterface;
@@ -33,6 +35,16 @@ use Magento\Framework\Encryption\EncryptorInterface;
 class Token implements HttpPostActionInterface
 {
     private const SCOPE = 'clicktopay:save';
+
+    /**
+     * Header the storefront sends so this proxy only serves genuine checkout AJAX requests.
+     */
+    private const FRONTEND_ORIGIN_HEADER = 'X-Requested-From';
+
+    /**
+     * Expected value of the frontend-origin header.
+     */
+    private const FRONTEND_ORIGIN_VALUE = 'MagentoFrontend';
 
     /**
      * @var JsonFactory
@@ -60,24 +72,40 @@ class Token implements HttpPostActionInterface
     private EncryptorInterface $encryptor;
 
     /**
+     * @var Http
+     */
+    private Http $request;
+
+    /**
+     * @var CheckoutSession
+     */
+    private CheckoutSession $checkoutSession;
+
+    /**
      * @param JsonFactory             $resultJsonFactory
      * @param ClicktopayConfig        $config
      * @param OauthTokenService       $tokenService
      * @param BuckarooLoggerInterface $logger
      * @param EncryptorInterface      $encryptor
+     * @param Http                    $request
+     * @param CheckoutSession         $checkoutSession
      */
     public function __construct(
         JsonFactory $resultJsonFactory,
         ClicktopayConfig $config,
         OauthTokenService $tokenService,
         BuckarooLoggerInterface $logger,
-        EncryptorInterface $encryptor
+        EncryptorInterface $encryptor,
+        Http $request,
+        CheckoutSession $checkoutSession
     ) {
         $this->resultJsonFactory = $resultJsonFactory;
         $this->config            = $config;
         $this->tokenService      = $tokenService;
         $this->logger            = $logger;
         $this->encryptor         = $encryptor;
+        $this->request           = $request;
+        $this->checkoutSession   = $checkoutSession;
     }
 
     /**
@@ -90,6 +118,16 @@ class Token implements HttpPostActionInterface
      */
     public function execute(): Json
     {
+        // This endpoint spends the merchant's Click to Pay credentials, so it must only serve a
+        // genuine storefront checkout request: reject anything without an active quote or a valid
+        // form key. Without this an anonymous caller can mint OAuth tokens on the merchant's behalf.
+        if (!$this->isTrustedCheckoutRequest()) {
+            $this->logger->addError('[ClicktoPay] Token proxy: rejected untrusted request');
+            $result = $this->resultJsonFactory->create();
+            $result->setHttpResponseCode(403);
+            return $result->setData(['error' => 'Unauthorized request']);
+        }
+
         // Both credentials are stored encrypted (obscure fields with the Encrypted backend
         // model), so scopeConfig returns ciphertext. Decrypt them before authenticating.
         $clientId     = $this->decryptCredential((string) $this->config->getClientId());
@@ -107,6 +145,22 @@ class Token implements HttpPostActionInterface
 
         $result = $this->resultJsonFactory->create();
         return $result->setData($token);
+    }
+
+    /**
+     * Only serve genuine storefront checkout AJAX requests.
+     *
+     * Mirrors the hosted-fields token proxy (CredentialsChecker\GetToken): the caller must send
+     * the storefront origin header and hold an active checkout quote. This keeps an anonymous,
+     * session-less request from minting OAuth tokens on the merchant's credentials without relying
+     * on a form key, which is unreliable for cached checkout AJAX.
+     *
+     * @return bool
+     */
+    private function isTrustedCheckoutRequest(): bool
+    {
+        return $this->request->getHeader(self::FRONTEND_ORIGIN_HEADER) === self::FRONTEND_ORIGIN_VALUE
+            && (bool) $this->checkoutSession->getQuoteId();
     }
 
     /**

--- a/Controller/Mrcash/Process.php
+++ b/Controller/Mrcash/Process.php
@@ -38,7 +38,9 @@ use Magento\Customer\Model\Session as CustomerSession;
 use Magento\Framework\Api\SearchCriteriaBuilder;
 use Magento\Framework\App\Action\Context;
 use Magento\Framework\App\ResponseInterface;
+use Magento\Framework\Data\Form\FormKey\Validator as FormKeyValidator;
 use Magento\Framework\Event\ManagerInterface;
+use Magento\Framework\Exception\NotFoundException;
 use Magento\Quote\Api\CartRepositoryInterface;
 use Magento\Quote\Model\Quote;
 use Magento\Sales\Api\OrderPaymentRepositoryInterface;
@@ -79,6 +81,11 @@ class Process extends \Buckaroo\Magento2\Controller\Redirect\Process
     protected $lockManager;
 
     /**
+     * @var FormKeyValidator
+     */
+    private $formKeyValidator;
+
+    /**
      * @param Context $context
      * @param BuckarooLoggerInterface $logger
      * @param Quote $quote
@@ -99,6 +106,7 @@ class Process extends \Buckaroo\Magento2\Controller\Redirect\Process
      * @param SpamLimitService $spamLimitService
      * @param CartRepositoryInterface $cartRepository
      * @param OrderPaymentRepositoryInterface $paymentRepository
+     * @param FormKeyValidator $formKeyValidator
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
      */
     public function __construct(
@@ -121,7 +129,8 @@ class Process extends \Buckaroo\Magento2\Controller\Redirect\Process
         LockManagerWrapper $lockManagerWrapper,
         SpamLimitService $spamLimitService,
         CartRepositoryInterface $cartRepository,
-        OrderPaymentRepositoryInterface $paymentRepository
+        OrderPaymentRepositoryInterface $paymentRepository,
+        FormKeyValidator $formKeyValidator
     ) {
         parent::__construct(
             $context,
@@ -147,17 +156,33 @@ class Process extends \Buckaroo\Magento2\Controller\Redirect\Process
         $this->searchCriteriaBuilder = $searchCriteriaBuilder;
         $this->orderRepository = $orderRepository;
         $this->transactionRepository = $transactionRepository;
+        $this->formKeyValidator = $formKeyValidator;
     }
 
     /**
      * Redirect Process Mrcash
      *
+     * This action is only ever called by the storefront cancel button on the Bancontact QR page,
+     * so it requires a POST with a valid form key and it only acts on the order that the current
+     * session actually placed. The inherited Buckaroo signature bypass does not apply here.
+     *
      * @throws Exception
+     * @throws NotFoundException
      *
      * @return ResponseInterface
      */
     public function execute()
     {
+        if (!$this->isRequestTrusted()) {
+            $this->logger->addError(sprintf(
+                '[REDIRECT - Mrcash] | [Controller] | [%s:%s] - Rejected cancel request: '
+                . 'not a POST or invalid form key',
+                __METHOD__,
+                __LINE__
+            ));
+            throw new NotFoundException(__('Page not found.'));
+        }
+
         if (!$this->getTransactionKey()) {
             return $this->_redirect('defaultNoRoute');
         }
@@ -176,15 +201,18 @@ class Process extends \Buckaroo\Magento2\Controller\Redirect\Process
         $this->order = $order;
         $this->payment = $this->order->getPayment();
 
-        if ($this->customerSession->getCustomerId() != $this->order->getCustomerId()) {
+        if (!$this->isOrderOwnedByCurrentSession()) {
             $errorMessage = 'Customer is different then the customer that start Mrcash process request.';
             $this->logger->addError(sprintf(
-                '[REDIRECT - Mrcash] | [Controller] | [%s:%s] - %s - customerSessionid: %s != customerOrderId: %s',
+                '[REDIRECT - Mrcash] | [Controller] | [%s:%s] - %s - customerSessionid: %s'
+                . ' != customerOrderId: %s | sessionLastRealOrderId: %s != orderIncrementId: %s',
                 __METHOD__,
                 __LINE__,
                 $errorMessage,
                 var_export($this->customerSession->getCustomerId(), true),
-                var_export($this->order->getCustomerId(), true)
+                var_export($this->order->getCustomerId(), true),
+                var_export($this->checkoutSession->getLastRealOrderId(), true),
+                var_export($this->order->getIncrementId(), true)
             ));
             $this->messageManager->addErrorMessage($errorMessage);
             return $this->handleProcessedResponse(
@@ -211,6 +239,40 @@ class Process extends \Buckaroo\Magento2\Controller\Redirect\Process
             );
             return $this->handleProcessedResponse('checkout/cart');
         }
+    }
+
+    /**
+     * Only a storefront POST carrying a valid form key may cancel a payment
+     *
+     * @return bool
+     */
+    private function isRequestTrusted(): bool
+    {
+        /** @var \Magento\Framework\App\Request\Http $request */
+        $request = $this->getRequest();
+
+        return $request->isPost() && $this->formKeyValidator->validate($request);
+    }
+
+    /**
+     * Verify the resolved order belongs to the session issuing the cancel request
+     *
+     * A guest order carries no customer id, so comparing customer ids alone lets any anonymous
+     * session cancel any guest order. The order the current session placed is therefore the
+     * authoritative check; the customer id comparison is kept for logged in customers.
+     *
+     * @return bool
+     */
+    private function isOrderOwnedByCurrentSession(): bool
+    {
+        if ((int)$this->customerSession->getCustomerId() !== (int)$this->order->getCustomerId()) {
+            return false;
+        }
+
+        $lastRealOrderId = $this->checkoutSession->getLastRealOrderId();
+
+        return !empty($lastRealOrderId)
+            && (string)$lastRealOrderId === (string)$this->order->getIncrementId();
     }
 
     /**

--- a/Controller/Redirect/IdinProcess.php
+++ b/Controller/Redirect/IdinProcess.php
@@ -35,6 +35,7 @@ use Buckaroo\Magento2\Service\Sales\Quote\Recreate;
 use Magento\Checkout\Model\Session as CheckoutSession;
 use Magento\Customer\Api\CustomerRepositoryInterface;
 use Magento\Customer\Model\Customer;
+use Magento\Customer\Model\CustomerRegistry;
 use Magento\Customer\Model\ResourceModel\CustomerFactory;
 use Magento\Customer\Model\Session as CustomerSession;
 use Magento\Framework\App\Action\Context;
@@ -62,6 +63,11 @@ class IdinProcess extends Process implements HttpPostActionInterface
     protected $spamLimitService;
 
     /**
+     * @var CustomerRegistry
+     */
+    private $customerRegistry;
+
+    /**
      * @param Context $context
      * @param BuckarooLoggerInterface $logger
      * @param Quote $quote
@@ -81,6 +87,7 @@ class IdinProcess extends Process implements HttpPostActionInterface
      * @param OrderRepositoryInterface $orderRepository
      * @param CartRepositoryInterface $cartRepository
      * @param OrderPaymentRepositoryInterface $paymentRepository
+     * @param CustomerRegistry $customerRegistry
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
      */
     public function __construct(
@@ -102,7 +109,8 @@ class IdinProcess extends Process implements HttpPostActionInterface
         CustomerFactory $customerFactory,
         OrderRepositoryInterface $orderRepository,
         CartRepositoryInterface $cartRepository,
-        OrderPaymentRepositoryInterface $paymentRepository
+        OrderPaymentRepositoryInterface $paymentRepository,
+        CustomerRegistry $customerRegistry
     ) {
         parent::__construct(
             $context,
@@ -126,16 +134,29 @@ class IdinProcess extends Process implements HttpPostActionInterface
         );
 
         $this->customerResourceFactory = $customerFactory;
+        $this->customerRegistry = $customerRegistry;
     }
 
     /**
      * Process the iDIN redirect request and verify the customer.
+     *
+     * The iDIN outcome decides whether an age restricted checkout may continue, so the request
+     * must be proven to come from Buckaroo (signature) and to belong to the iDIN verification
+     * this session started. Without both checks any anonymous POST can mark itself as verified.
      *
      * @return ResponseInterface
      * @throws \Exception
      */
     public function execute(): ResponseInterface
     {
+        if (!$this->isRequestAuthentic()) {
+            $this->addErrorMessage(
+                __(self::GENERAL_ERROR_MESSAGE) // phpcs:ignore Magento2.Translation.ConstantUsage
+            );
+
+            return $this->handleProcessedResponse('checkout');
+        }
+
         // Initialize the order, quote, payment
         if ($this->redirectRequest->hasPostData('primary_service', 'IDIN')) {
             if ($this->setCustomerIDIN()) {
@@ -155,6 +176,39 @@ class IdinProcess extends Process implements HttpPostActionInterface
     }
 
     /**
+     * Verify the redirect request was issued by Buckaroo for this session
+     *
+     * @throws \Exception
+     *
+     * @return bool
+     */
+    private function isRequestAuthentic(): bool
+    {
+        if (count($this->redirectRequest->getData()) === 0) {
+            $this->logger->addError(sprintf(
+                '[REDIRECT - iDIN] | [Controller] | [%s:%s] - Empty iDIN redirect request',
+                __METHOD__,
+                __LINE__
+            ));
+
+            return false;
+        }
+
+        if (!$this->redirectRequest->validate()) {
+            $this->logger->addError(sprintf(
+                '[REDIRECT - iDIN] | [Controller] | [%s:%s] - Signature validation failed',
+                __METHOD__,
+                __LINE__
+            ));
+
+            return false;
+        }
+
+        return true;
+    }
+
+
+    /**
      * Set consumer bin IDIN on customer
      *
      * @throws \Exception
@@ -163,39 +217,95 @@ class IdinProcess extends Process implements HttpPostActionInterface
      */
     private function setCustomerIDIN(): bool
     {
-        if (!empty($this->redirectRequest->getServiceIdinConsumerbin())
-            && !empty($this->redirectRequest->getServiceIdinIseighteenorolder())
-            && $this->redirectRequest->getServiceIdinIseighteenorolder() == 'True'
-        ) {
-            $this->checkoutSession->setCustomerIDIN($this->redirectRequest->getServiceIdinConsumerbin());
-            $this->checkoutSession->setCustomerIDINIsEighteenOrOlder(true);
-            $idinCid = $this->redirectRequest->getAdditionalInformation('idin_cid');
-            if (!empty($idinCid)) {
-                try {
-                    /** @var Customer $customerNew */
-                    $customerNew = $this->customerRepository->getById((int)$idinCid);
-                } catch (\Exception $e) {
-                    $this->addErrorMessage(__('Unfortunately customer was not find by IDIN id: "%1"!', $idinCid));
-                    $this->logger->addError(sprintf(
-                        '[REDIRECT - iDIN] | [Controller] | [%s:%s] - Customer was not find by IDIN id | [ERROR]: %s',
-                        __METHOD__,
-                        __LINE__,
-                        $e->getMessage()
-                    ));
-                    return false;
-                }
-                $customerData = $customerNew->getDataModel();
-                $customerData->setCustomAttribute('buckaroo_idin', $this->redirectRequest->getServiceIdinConsumerbin());
-                $customerData->setCustomAttribute('buckaroo_idin_iseighteenorolder', 1);
-                $customerNew->updateData($customerData);
+        $consumerBin = $this->redirectRequest->getServiceIdinConsumerbin();
 
-                $customerResource = $this->customerResourceFactory->create();
-                $customerResource->saveAttribute($customerNew, 'buckaroo_idin');
-                $customerResource->saveAttribute($customerNew, 'buckaroo_idin_iseighteenorolder');
-            }
+        if (empty($consumerBin)
+            || empty($this->redirectRequest->getServiceIdinIseighteenorolder())
+            || $this->redirectRequest->getServiceIdinIseighteenorolder() != 'True'
+        ) {
+            return false;
+        }
+
+        $customerId = $this->getVerifiedCustomerId();
+
+        if ($customerId === false) {
+            return false;
+        }
+
+        $this->checkoutSession->setCustomerIDIN($consumerBin);
+        $this->checkoutSession->setCustomerIDINIsEighteenOrOlder(true);
+
+        if ($customerId === null) {
             return true;
         }
-        return false;
+
+        return $this->persistIdinOnCustomer($customerId, (string)$consumerBin);
+    }
+
+    /**
+     * Resolve the customer the verification belongs to
+     *
+     * Returns null for a guest verification (session only) and false when the signed customer id
+     * contradicts the logged in customer.
+     *
+     * @return int|null|false
+     */
+    private function getVerifiedCustomerId()
+    {
+        $sessionCustomerId = (int)$this->customerSession->getCustomerId();
+        $requestCustomerId = (int)$this->redirectRequest->getAdditionalInformation('idin_cid');
+
+        if ($requestCustomerId > 0 && $sessionCustomerId > 0 && $requestCustomerId !== $sessionCustomerId) {
+            $this->logger->addError(sprintf(
+                '[REDIRECT - iDIN] | [Controller] | [%s:%s] - iDIN customer id %s does not match session customer %s',
+                __METHOD__,
+                __LINE__,
+                $requestCustomerId,
+                $sessionCustomerId
+            ));
+
+            return false;
+        }
+
+        if ($sessionCustomerId > 0) {
+            return $sessionCustomerId;
+        }
+
+        return $requestCustomerId > 0 ? $requestCustomerId : null;
+    }
+
+    /**
+     * Store the iDIN result on the customer account
+     *
+     * @param int    $customerId
+     * @param string $consumerBin
+     *
+     * @return bool
+     */
+    private function persistIdinOnCustomer(int $customerId, string $consumerBin): bool
+    {
+        try {
+            /** @var Customer $customer */
+            $customer = $this->customerRegistry->retrieve((string)$customerId);
+            $customer->setData('buckaroo_idin', $consumerBin);
+            $customer->setData('buckaroo_idin_iseighteenorolder', 1);
+
+            $customerResource = $this->customerResourceFactory->create();
+            $customerResource->saveAttribute($customer, 'buckaroo_idin');
+            $customerResource->saveAttribute($customer, 'buckaroo_idin_iseighteenorolder');
+        } catch (\Exception $e) {
+            $this->addErrorMessage(__('Unfortunately customer was not find by IDIN id: "%1"!', $customerId));
+            $this->logger->addError(sprintf(
+                '[REDIRECT - iDIN] | [Controller] | [%s:%s] - Customer was not find by IDIN id | [ERROR]: %s',
+                __METHOD__,
+                __LINE__,
+                $e->getMessage()
+            ));
+
+            return false;
+        }
+
+        return true;
     }
 
     /**

--- a/Model/Giftcard/Api/Pay.php
+++ b/Model/Giftcard/Api/Pay.php
@@ -25,6 +25,7 @@ use Buckaroo\Magento2\Api\Data\Giftcard\PayResponseSetInterfaceFactory;
 use Buckaroo\Magento2\Api\PayWithGiftcardInterface;
 use Buckaroo\Magento2\Model\Giftcard\Request\GiftcardInterface as GiftcardRequest;
 use Buckaroo\Magento2\Model\Giftcard\Response\Giftcard as GiftcardResponse;
+use Buckaroo\Magento2\Service\Giftcard\AttemptLimit;
 use Magento\Quote\Api\CartRepositoryInterface;
 use Magento\Quote\Model\Quote;
 use Magento\Quote\Model\QuoteIdMaskFactory;
@@ -57,24 +58,32 @@ class Pay implements PayWithGiftcardInterface
     protected $payResponseFactory;
 
     /**
+     * @var AttemptLimit
+     */
+    private $attemptLimit;
+
+    /**
      * @param GiftcardRequest                $giftcardRequest
      * @param GiftcardResponse               $giftcardResponse
      * @param QuoteIdMaskFactory             $quoteIdMaskFactory
      * @param CartRepositoryInterface        $cartRepository
      * @param PayResponseSetInterfaceFactory $payResponseFactory
+     * @param AttemptLimit                   $attemptLimit
      */
     public function __construct(
         GiftcardRequest $giftcardRequest,
         GiftcardResponse $giftcardResponse,
         QuoteIdMaskFactory $quoteIdMaskFactory,
         CartRepositoryInterface $cartRepository,
-        PayResponseSetInterfaceFactory $payResponseFactory
+        PayResponseSetInterfaceFactory $payResponseFactory,
+        AttemptLimit $attemptLimit
     ) {
         $this->giftcardRequest = $giftcardRequest;
         $this->giftcardResponse = $giftcardResponse;
         $this->quoteIdMaskFactory = $quoteIdMaskFactory;
         $this->cartRepository = $cartRepository;
         $this->payResponseFactory = $payResponseFactory;
+        $this->attemptLimit = $attemptLimit;
     }
 
     /**
@@ -92,11 +101,17 @@ class Pay implements PayWithGiftcardInterface
 
         try {
             $quote = $this->getQuote($cartId);
+            $this->attemptLimit->assertWithinLimit($quote);
 
-            return $this->getResponse(
-                $quote,
-                $this->build($quote, $giftcardId, $payment)->send()
-            );
+            try {
+                return $this->getResponse(
+                    $quote,
+                    $this->build($quote, $giftcardId, $payment)->send()
+                );
+            } catch (ApiException $th) {
+                $this->attemptLimit->registerFailedAttempt($quote);
+                throw $th;
+            }
         } catch (ApiException $th) {
             throw $th;
         } catch (NoQuoteException $th) {

--- a/Plugin/MyParcelNLBuckarooPlugin.php
+++ b/Plugin/MyParcelNLBuckarooPlugin.php
@@ -22,7 +22,7 @@ namespace Buckaroo\Magento2\Plugin;
 
 use Buckaroo\Magento2\Logging\BuckarooLoggerInterface;
 use Magento\Checkout\Model\Session;
-use Magento\Framework\App\RequestInterface;
+use Magento\Framework\App\Request\Http;
 use Magento\Framework\Serialize\Serializer\Json;
 
 class MyParcelNLBuckarooPlugin
@@ -33,7 +33,7 @@ class MyParcelNLBuckarooPlugin
     protected $checkoutSession;
 
     /**
-     * @var RequestInterface
+     * @var Http
      */
     protected $request;
 
@@ -49,13 +49,13 @@ class MyParcelNLBuckarooPlugin
 
     /**
      * @param Session                 $checkoutSession
-     * @param RequestInterface        $request
+     * @param Http                    $request
      * @param Json                    $json
      * @param BuckarooLoggerInterface $logger
      */
     public function __construct(
         Session $checkoutSession,
-        RequestInterface $request,
+        Http $request,
         Json $json,
         BuckarooLoggerInterface $logger
     ) {
@@ -70,25 +70,36 @@ class MyParcelNLBuckarooPlugin
      */
     public function beforeGetFromDeliveryOptions()
     {
-        // @codingStandardsIgnoreLine
-        if ($result = file_get_contents('php://input')) {
-            if ($jsonDecoded = $this->json->unserialize($result)) {
-                $this->logger->addDebug(sprintf(
-                    '[MyParcelNL] | [Plugin] | [%s:%s] - Set Pickup Location | deliveryOptions: %s',
-                    __METHOD__,
-                    __LINE__,
-                    var_export($jsonDecoded, true)
-                ));
-                if (!empty($jsonDecoded['deliveryOptions']) &&
-                    !empty($jsonDecoded['deliveryOptions'][0]['deliveryType']) &&
-                    ($jsonDecoded['deliveryOptions'][0]['deliveryType'] == 'pickup') &&
-                    !empty($jsonDecoded['deliveryOptions'][0]['pickupLocation'])
-                ) {
-                    $this->checkoutSession->setMyParcelNLBuckarooData(
-                        $this->json->serialize($jsonDecoded['deliveryOptions'][0]['pickupLocation'])
-                    );
-                }
-            }
+        $body = $this->request->getContent();
+        if (empty($body)) {
+            return;
+        }
+
+        try {
+            $jsonDecoded = $this->json->unserialize($body);
+        } catch (\InvalidArgumentException $e) {
+            return;
+        }
+
+        if (!is_array($jsonDecoded) || empty($jsonDecoded['deliveryOptions'][0])) {
+            return;
+        }
+
+        $this->logger->addDebug(sprintf(
+            '[MyParcelNL] | [Plugin] | [%s:%s] - Set Pickup Location | deliveryOptions: %s',
+            __METHOD__,
+            __LINE__,
+            var_export($jsonDecoded, true)
+        ));
+
+        $deliveryOption = $jsonDecoded['deliveryOptions'][0];
+        if (!empty($deliveryOption['deliveryType'])
+            && $deliveryOption['deliveryType'] === 'pickup'
+            && !empty($deliveryOption['pickupLocation'])
+        ) {
+            $this->checkoutSession->setMyParcelNLBuckarooData(
+                $this->json->serialize($deliveryOption['pickupLocation'])
+            );
         }
     }
 }

--- a/Service/Giftcard/AttemptLimit.php
+++ b/Service/Giftcard/AttemptLimit.php
@@ -1,0 +1,106 @@
+<?php
+/**
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the MIT License
+ * It is available through the world-wide-web at this URL:
+ * https://tldrlegal.com/license/mit-license
+ * If you are unable to obtain it through the world-wide-web, please email
+ * to support@buckaroo.nl, so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade this module to newer
+ * versions in the future. If you wish to customize this module for your
+ * needs please contact support@buckaroo.nl for more information.
+ *
+ * @copyright Copyright (c) Buckaroo B.V.
+ * @license   https://tldrlegal.com/license/mit-license
+ */
+declare(strict_types=1);
+
+namespace Buckaroo\Magento2\Service\Giftcard;
+
+use Buckaroo\Magento2\Model\Giftcard\Api\ApiException;
+use Magento\Quote\Api\CartRepositoryInterface;
+use Magento\Quote\Model\Quote;
+
+/**
+ * Caps the number of failed giftcard (card number + pin) attempts per quote.
+ *
+ * The counter lives on the quote payment so it survives across requests and works for both the
+ * storefront ajax controller and the guest webapi, neither of which shares a stable browser
+ * session for the API path. It is defense-in-depth against giftcard PIN brute forcing; it does
+ * not replace gateway-side controls and can be reset by starting a brand new cart.
+ */
+class AttemptLimit
+{
+    /**
+     * Maximum number of failed giftcard attempts allowed per quote.
+     */
+    public const MAX_ATTEMPTS = 10;
+
+    /**
+     * Payment additional_information key holding the failed-attempt counter.
+     */
+    private const ATTEMPTS_KEY = 'buckaroo_giftcard_failed_attempts';
+
+    /**
+     * @var CartRepositoryInterface
+     */
+    private $cartRepository;
+
+    /**
+     * @param CartRepositoryInterface $cartRepository
+     */
+    public function __construct(CartRepositoryInterface $cartRepository)
+    {
+        $this->cartRepository = $cartRepository;
+    }
+
+    /**
+     * Reject the request when the failed-attempt limit for this quote has been reached.
+     *
+     * @param Quote $quote
+     *
+     * @throws ApiException
+     *
+     * @return void
+     */
+    public function assertWithinLimit(Quote $quote): void
+    {
+        if ($this->getFailedAttempts($quote) >= self::MAX_ATTEMPTS) {
+            throw new ApiException(
+                (string)__('Too many giftcard attempts. Please try again later.')
+            );
+        }
+    }
+
+    /**
+     * Record a failed giftcard attempt against the quote.
+     *
+     * @param Quote $quote
+     *
+     * @return void
+     */
+    public function registerFailedAttempt(Quote $quote): void
+    {
+        $quote->getPayment()->setAdditionalInformation(
+            self::ATTEMPTS_KEY,
+            $this->getFailedAttempts($quote) + 1
+        );
+        $this->cartRepository->save($quote);
+    }
+
+    /**
+     * Current failed-attempt count stored on the quote payment.
+     *
+     * @param Quote $quote
+     *
+     * @return int
+     */
+    private function getFailedAttempts(Quote $quote): int
+    {
+        return (int)$quote->getPayment()->getAdditionalInformation(self::ATTEMPTS_KEY);
+    }
+}

--- a/Test/Unit/Controller/Adminhtml/CredentialsChecker/IndexTest.php
+++ b/Test/Unit/Controller/Adminhtml/CredentialsChecker/IndexTest.php
@@ -1,0 +1,123 @@
+<?php
+/**
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the MIT License
+ * It is available through the world-wide-web at this URL:
+ * https://tldrlegal.com/license/mit-license
+ * If you are unable to obtain it through the world-wide-web, please email
+ * to support@buckaroo.nl, so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade this module to newer
+ * versions in the future. If you wish to customize this module for your
+ * needs please contact support@buckaroo.nl for more information.
+ *
+ * @copyright Copyright (c) Buckaroo B.V.
+ * @license   https://tldrlegal.com/license/mit-license
+ */
+declare(strict_types=1);
+
+namespace Buckaroo\Magento2\Test\Unit\Controller\Adminhtml\CredentialsChecker;
+
+use Buckaroo\Magento2\Controller\Adminhtml\CredentialsChecker\Index;
+use Buckaroo\Magento2\Model\Adapter\BuckarooAdapter;
+use Buckaroo\Magento2\Model\ConfigProvider\Account;
+use Magento\Backend\App\Action\Context;
+use Magento\Framework\App\Request\Http;
+use Magento\Framework\Controller\Result\Json;
+use Magento\Framework\Controller\ResultFactory;
+use Magento\Framework\Encryption\EncryptorInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class IndexTest extends TestCase
+{
+    /**
+     * @var Http|MockObject
+     */
+    private $requestMock;
+
+    /**
+     * @var BuckarooAdapter|MockObject
+     */
+    private $clientMock;
+
+    /**
+     * @var Json|MockObject
+     */
+    private $jsonResultMock;
+
+    /**
+     * @var Index
+     */
+    private Index $controller;
+
+    protected function setUp(): void
+    {
+        $this->requestMock = $this->createMock(Http::class);
+        $this->clientMock = $this->createMock(BuckarooAdapter::class);
+
+        $this->jsonResultMock = $this->createMock(Json::class);
+        $this->jsonResultMock->method('setData')->willReturnSelf();
+
+        $resultFactoryMock = $this->createMock(ResultFactory::class);
+        $resultFactoryMock->method('create')->with(ResultFactory::TYPE_JSON)->willReturn($this->jsonResultMock);
+
+        $contextMock = $this->createMock(Context::class);
+        $contextMock->method('getRequest')->willReturn($this->requestMock);
+        $contextMock->method('getResultFactory')->willReturn($resultFactoryMock);
+
+        $this->controller = new Index(
+            $contextMock,
+            $this->createMock(EncryptorInterface::class),
+            $this->createMock(Account::class),
+            $this->clientMock
+        );
+    }
+
+    public function testIsGuardedByTheBuckarooConfigurationAclResource(): void
+    {
+        $this->assertSame('Buckaroo_Magento2::configuration', Index::ADMIN_RESOURCE);
+    }
+
+    public function testDoesNotCallTheGatewayWhenCredentialsAreMissing(): void
+    {
+        // Arrange
+        $this->requestMock->method('getParam')->willReturnMap([
+            ['secretKey', '', ''],
+            ['merchantKey', '', ''],
+        ]);
+
+        // Assert: no live credential round-trip is attempted
+        $this->clientMock->expects($this->never())->method('confirmCredential');
+        $this->jsonResultMock->expects($this->once())
+            ->method('setData')
+            ->with($this->callback(static fn ($data): bool => $data['success'] === false));
+
+        // Act
+        $this->assertSame($this->jsonResultMock, $this->controller->execute());
+    }
+
+    public function testValidatesSuppliedCredentialsAgainstTheGateway(): void
+    {
+        // Arrange
+        $this->requestMock->method('getParam')->willReturnMap([
+            ['secretKey', '', 'plain-secret'],
+            ['merchantKey', '', 'plain-merchant'],
+        ]);
+        $this->clientMock->expects($this->once())
+            ->method('confirmCredential')
+            ->with('plain-merchant', 'plain-secret')
+            ->willReturn(true);
+
+        // Assert
+        $this->jsonResultMock->expects($this->once())
+            ->method('setData')
+            ->with(['success' => true]);
+
+        // Act
+        $this->assertSame($this->jsonResultMock, $this->controller->execute());
+    }
+}

--- a/Test/Unit/Controller/Clicktopay/TokenTest.php
+++ b/Test/Unit/Controller/Clicktopay/TokenTest.php
@@ -27,6 +27,8 @@ use Buckaroo\Magento2\Logging\BuckarooLoggerInterface;
 use Buckaroo\Magento2\Model\ConfigProvider\Method\Clicktopay as ClicktopayConfig;
 use Buckaroo\Magento2\Service\OauthTokenService;
 use Buckaroo\Magento2\Test\BaseTest;
+use Magento\Checkout\Model\Session as CheckoutSession;
+use Magento\Framework\App\Request\Http;
 use Magento\Framework\Controller\Result\Json;
 use Magento\Framework\Controller\Result\JsonFactory;
 use Magento\Framework\Encryption\EncryptorInterface;
@@ -52,6 +54,8 @@ class TokenTest extends BaseTest
 
         $instance = $this->getInstance([
             'resultJsonFactory' => $resultJsonFactory,
+            'request'           => $this->createRequestMock('MagentoFrontend'),
+            'checkoutSession'   => $this->createCheckoutSessionMock(42),
             'config'            => $this->createConfigMock(),
             'tokenService'      => $tokenService,
             'logger'            => $this->createMock(BuckarooLoggerInterface::class),
@@ -77,6 +81,8 @@ class TokenTest extends BaseTest
 
         $instance = $this->getInstance([
             'resultJsonFactory' => $resultJsonFactory,
+            'request'           => $this->createRequestMock('MagentoFrontend'),
+            'checkoutSession'   => $this->createCheckoutSessionMock(42),
             'config'            => $this->createConfigMock(),
             'tokenService'      => $tokenService,
             'logger'            => $this->createMock(BuckarooLoggerInterface::class),
@@ -105,6 +111,8 @@ class TokenTest extends BaseTest
 
         $instance = $this->getInstance([
             'resultJsonFactory' => $resultJsonFactory,
+            'request'           => $this->createRequestMock('MagentoFrontend'),
+            'checkoutSession'   => $this->createCheckoutSessionMock(42),
             'config'            => $config,
             'tokenService'      => $tokenService,
             'logger'            => $this->createMock(BuckarooLoggerInterface::class),
@@ -132,6 +140,8 @@ class TokenTest extends BaseTest
 
         $instance = $this->getInstance([
             'resultJsonFactory' => $resultJsonFactory,
+            'request'           => $this->createRequestMock('MagentoFrontend'),
+            'checkoutSession'   => $this->createCheckoutSessionMock(42),
             'config'            => $this->createConfigMock(),
             'tokenService'      => $tokenService,
             'logger'            => $this->createMock(BuckarooLoggerInterface::class),
@@ -141,6 +151,70 @@ class TokenTest extends BaseTest
         $instance->execute();
 
         $this->assertArrayHasKey('error', $capturedData);
+    }
+
+    /**
+     * An unauthenticated request (no active quote, no valid form key) must be rejected
+     * with a 403 before the merchant credentials are ever used.
+     */
+    public function testExecuteRejectsUntrustedRequest(): void
+    {
+        $tokenService = $this->createMock(OauthTokenService::class);
+        $tokenService->expects($this->never())->method('getToken');
+
+        $capturedData = null;
+        $resultJsonFactory = $this->createJsonFactoryMock($capturedData);
+
+        $instance = $this->getInstance([
+            'resultJsonFactory' => $resultJsonFactory,
+            'request'           => $this->createRequestMock('evil.example.com'),
+            'checkoutSession'   => $this->createCheckoutSessionMock(null),
+            'config'            => $this->createConfigMock(),
+            'tokenService'      => $tokenService,
+            'logger'            => $this->createMock(BuckarooLoggerInterface::class),
+            'encryptor'         => $this->createEncryptorMock(),
+        ]);
+
+        $instance->execute();
+
+        $this->assertArrayHasKey('error', $capturedData);
+        $this->assertSame('Unauthorized request', $capturedData['error']);
+    }
+
+    /**
+     * Storefront request mock returning the given origin header.
+     *
+     * @param string $origin
+     *
+     * @return Http|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private function createRequestMock(string $origin)
+    {
+        $request = $this->getMockBuilder(Http::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getHeader'])
+            ->getMock();
+        $request->method('getHeader')->with('X-Requested-From')->willReturn($origin);
+
+        return $request;
+    }
+
+    /**
+     * Checkout session mock exposing a quote id.
+     *
+     * @param int|null $quoteId
+     *
+     * @return CheckoutSession|\PHPUnit\Framework\MockObject\MockObject
+     */
+    private function createCheckoutSessionMock($quoteId)
+    {
+        $session = $this->getMockBuilder(CheckoutSession::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['getQuoteId'])
+            ->getMock();
+        $session->method('getQuoteId')->willReturn($quoteId);
+
+        return $session;
     }
 
     /**

--- a/Test/Unit/Controller/Mrcash/ProcessTest.php
+++ b/Test/Unit/Controller/Mrcash/ProcessTest.php
@@ -1,0 +1,143 @@
+<?php
+/**
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the MIT License
+ * It is available through the world-wide-web at this URL:
+ * https://tldrlegal.com/license/mit-license
+ * If you are unable to obtain it through the world-wide-web, please email
+ * to support@buckaroo.nl, so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade this module to newer
+ * versions in the future. If you wish to customize this module for your
+ * needs please contact support@buckaroo.nl for more information.
+ *
+ * @copyright Copyright (c) Buckaroo B.V.
+ * @license   https://tldrlegal.com/license/mit-license
+ */
+declare(strict_types=1);
+
+namespace Buckaroo\Magento2\Test\Unit\Controller\Mrcash;
+
+use Buckaroo\Magento2\Api\Data\PushRequestInterface;
+use Buckaroo\Magento2\Controller\Mrcash\Process;
+use Buckaroo\Magento2\Logging\BuckarooLoggerInterface;
+use Buckaroo\Magento2\Model\ConfigProvider\Account as AccountConfig;
+use Buckaroo\Magento2\Model\LockManagerWrapper;
+use Buckaroo\Magento2\Model\OrderStatusFactory;
+use Buckaroo\Magento2\Model\RequestPush\RequestPushFactory;
+use Buckaroo\Magento2\Model\Service\Order as OrderService;
+use Buckaroo\Magento2\Service\Push\OrderRequestService;
+use Buckaroo\Magento2\Service\Sales\Quote\Recreate;
+use Buckaroo\Magento2\Service\SpamLimitService;
+use Magento\Checkout\Model\Session as CheckoutSession;
+use Magento\Customer\Api\CustomerRepositoryInterface;
+use Magento\Customer\Model\Session as CustomerSession;
+use Magento\Framework\Api\SearchCriteriaBuilder;
+use Magento\Framework\App\Action\Context;
+use Magento\Framework\App\Request\Http;
+use Magento\Framework\Data\Form\FormKey\Validator as FormKeyValidator;
+use Magento\Framework\Event\ManagerInterface;
+use Magento\Framework\Exception\NotFoundException;
+use Magento\Framework\Message\ManagerInterface as MessageManagerInterface;
+use Magento\Quote\Api\CartRepositoryInterface;
+use Magento\Quote\Model\Quote;
+use Magento\Sales\Api\OrderPaymentRepositoryInterface;
+use Magento\Sales\Api\OrderRepositoryInterface;
+use Magento\Sales\Api\TransactionRepositoryInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
+class ProcessTest extends TestCase
+{
+    /**
+     * @var Http|MockObject
+     */
+    private $requestMock;
+
+    /**
+     * @var FormKeyValidator|MockObject
+     */
+    private $formKeyValidatorMock;
+
+    /**
+     * @var TransactionRepositoryInterface|MockObject
+     */
+    private $transactionRepositoryMock;
+
+    /**
+     * @var Process
+     */
+    private Process $controller;
+
+    protected function setUp(): void
+    {
+        $this->requestMock = $this->createMock(Http::class);
+        $this->formKeyValidatorMock = $this->createMock(FormKeyValidator::class);
+        $this->transactionRepositoryMock = $this->createMock(TransactionRepositoryInterface::class);
+
+        $contextMock = $this->createMock(Context::class);
+        $contextMock->method('getRequest')->willReturn($this->requestMock);
+        $contextMock->method('getMessageManager')->willReturn($this->createMock(MessageManagerInterface::class));
+
+        $requestPushFactoryMock = $this->createMock(RequestPushFactory::class);
+        $requestPushFactoryMock->method('create')->willReturn($this->createMock(PushRequestInterface::class));
+
+        $this->controller = new Process(
+            $contextMock,
+            $this->createMock(BuckarooLoggerInterface::class),
+            $this->createMock(Quote::class),
+            $this->createMock(AccountConfig::class),
+            $this->createMock(OrderRequestService::class),
+            $this->createMock(OrderStatusFactory::class),
+            $this->createMock(CheckoutSession::class),
+            $this->createMock(CustomerSession::class),
+            $this->createMock(CustomerRepositoryInterface::class),
+            $this->createMock(OrderService::class),
+            $this->createMock(ManagerInterface::class),
+            $this->createMock(Recreate::class),
+            $requestPushFactoryMock,
+            $this->createMock(SearchCriteriaBuilder::class),
+            $this->createMock(OrderRepositoryInterface::class),
+            $this->transactionRepositoryMock,
+            $this->createMock(LockManagerWrapper::class),
+            $this->createMock(SpamLimitService::class),
+            $this->createMock(CartRepositoryInterface::class),
+            $this->createMock(OrderPaymentRepositoryInterface::class),
+            $this->formKeyValidatorMock
+        );
+    }
+
+    public function testRejectsNonPostRequestBeforeTouchingAnyTransaction(): void
+    {
+        // Arrange: a GET request (the reported unauthenticated cancel vector)
+        $this->requestMock->method('isPost')->willReturn(false);
+        $this->formKeyValidatorMock->method('validate')->willReturn(true);
+
+        // Assert: it never looks up a transaction/order
+        $this->transactionRepositoryMock->expects($this->never())->method('getList');
+
+        // Act
+        $this->expectException(NotFoundException::class);
+        $this->controller->execute();
+    }
+
+    public function testRejectsPostWithInvalidFormKey(): void
+    {
+        // Arrange: a POST that does not carry a valid form key
+        $this->requestMock->method('isPost')->willReturn(true);
+        $this->formKeyValidatorMock->method('validate')->willReturn(false);
+
+        // Assert
+        $this->transactionRepositoryMock->expects($this->never())->method('getList');
+
+        // Act
+        $this->expectException(NotFoundException::class);
+        $this->controller->execute();
+    }
+}

--- a/Test/Unit/Controller/Redirect/CsrfBypassGuardTest.php
+++ b/Test/Unit/Controller/Redirect/CsrfBypassGuardTest.php
@@ -1,0 +1,135 @@
+<?php
+/**
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the MIT License
+ * It is available through the world-wide-web at this URL:
+ * https://tldrlegal.com/license/mit-license
+ * If you are unable to obtain it through the world-wide-web, please email
+ * to support@buckaroo.nl, so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade this module to newer
+ * versions in the future. If you wish to customize this module for your
+ * needs please contact support@buckaroo.nl for more information.
+ *
+ * @copyright Copyright (c) Buckaroo B.V.
+ * @license   https://tldrlegal.com/license/mit-license
+ */
+declare(strict_types=1);
+
+namespace Buckaroo\Magento2\Test\Unit\Controller\Redirect;
+
+use Buckaroo\Magento2\Controller\Redirect\Process;
+use PHPUnit\Framework\TestCase;
+use ReflectionClass;
+
+/**
+ * Recurrence guard for the CSRF-bypass class of vulnerabilities (BTI-1489).
+ *
+ * Buckaroo\Magento2\Controller\Redirect\Process disables Magento's form-key CSRF
+ * (validateForCsrf() => true) for the whole controller; the compensating control is the
+ * Buckaroo signature check in Process::execute(). Any subclass that OVERRIDES execute()
+ * silently keeps the CSRF bypass while potentially dropping that signature check - which is
+ * exactly how the Mrcash and iDIN vulnerabilities happened.
+ *
+ * This test fails when a NEW subclass overrides execute() without being consciously added to
+ * the reviewed allow-list below. Adding a class here is a signal to verify it validates either
+ * the Buckaroo signature or the form key before acting.
+ */
+class CsrfBypassGuardTest extends TestCase
+{
+    /**
+     * Subclasses of Process that override execute() and have been security-reviewed to enforce
+     * signature-or-form-key before performing any state change.
+     *
+     * @var string[]
+     */
+    private const REVIEWED_EXECUTE_OVERRIDES = [
+        \Buckaroo\Magento2\Controller\Mrcash\Process::class,      // POST + form key + own-order check
+        \Buckaroo\Magento2\Controller\Redirect\IdinProcess::class, // signature + session-owned transaction
+    ];
+
+    public function testEveryProcessSubclassOverridingExecuteHasBeenReviewed(): void
+    {
+        $offenders = [];
+
+        foreach ($this->processSubclasses() as $class) {
+            $reflection = new ReflectionClass($class);
+            if ($reflection->isAbstract()) {
+                continue;
+            }
+
+            $declaringClass = $reflection->getMethod('execute')->getDeclaringClass()->getName();
+            if ($declaringClass !== $class) {
+                // Inherits Process::execute() (the fully signature-validated flow) - safe.
+                continue;
+            }
+
+            if (!in_array($class, self::REVIEWED_EXECUTE_OVERRIDES, true)) {
+                $offenders[] = $class;
+            }
+        }
+
+        $this->assertSame(
+            [],
+            $offenders,
+            "These controllers extend Redirect\\Process and override execute(), so they inherit the "
+            . "CSRF bypass. Confirm each validates the Buckaroo signature or the form key before "
+            . "acting, then add it to REVIEWED_EXECUTE_OVERRIDES: " . implode(', ', $offenders)
+        );
+    }
+
+    /**
+     * Discover all concrete controller classes that extend Redirect\Process.
+     *
+     * @return string[]
+     */
+    private function processSubclasses(): array
+    {
+        $controllerDir = dirname(__DIR__, 4) . '/Controller';
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($controllerDir, \FilesystemIterator::SKIP_DOTS)
+        );
+
+        $classes = [];
+        foreach ($iterator as $file) {
+            if ($file->getExtension() !== 'php') {
+                continue;
+            }
+
+            $class = $this->classFromFile((string)$file);
+            if ($class === null || !class_exists($class)) {
+                continue;
+            }
+
+            if (is_subclass_of($class, Process::class)) {
+                $classes[] = $class;
+            }
+        }
+
+        return $classes;
+    }
+
+    /**
+     * Derive the fully-qualified class name from a controller file path.
+     *
+     * @param string $path
+     *
+     * @return string|null
+     */
+    private function classFromFile(string $path): ?string
+    {
+        $marker = '/Controller/';
+        $position = strpos($path, $marker);
+        if ($position === false) {
+            return null;
+        }
+
+        $relative = substr($path, $position + strlen($marker));
+        $relative = substr($relative, 0, -strlen('.php'));
+
+        return 'Buckaroo\\Magento2\\Controller\\' . str_replace('/', '\\', $relative);
+    }
+}

--- a/Test/Unit/Controller/Redirect/IdinProcessTest.php
+++ b/Test/Unit/Controller/Redirect/IdinProcessTest.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the MIT License
+ * It is available through the world-wide-web at this URL:
+ * https://tldrlegal.com/license/mit-license
+ * If you are unable to obtain it through the world-wide-web, please email
+ * to support@buckaroo.nl, so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade this module to newer
+ * versions in the future. If you wish to customize this module for your
+ * needs please contact support@buckaroo.nl for more information.
+ *
+ * @copyright Copyright (c) Buckaroo B.V.
+ * @license   https://tldrlegal.com/license/mit-license
+ */
+
+namespace Buckaroo\Magento2\Test\Unit\Controller\Redirect;
+
+use Buckaroo\Magento2\Controller\Redirect\IdinProcess;
+use Buckaroo\Magento2\Model\RequestPush\RequestPushFactory;
+use Buckaroo\Magento2\Test\BaseTest;
+use Buckaroo\Magento2\Test\Unit\Stubs\PushRequestInterfaceStub;
+use Magento\Checkout\Model\Session as CheckoutSession;
+use Magento\Framework\App\Action\Context;
+use Magento\Framework\App\RequestInterface;
+use Magento\Framework\App\Response\RedirectInterface;
+use Magento\Framework\App\ResponseInterface;
+use Magento\Framework\Controller\Result\Redirect;
+use Magento\Framework\Controller\Result\RedirectFactory;
+use Magento\Framework\Message\ManagerInterface;
+
+/**
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
+ */
+class IdinProcessTest extends BaseTest
+{
+    protected $instanceClass = IdinProcess::class;
+
+    /**
+     * An unsigned (forged) iDIN return must be rejected before any verification state is written
+     * to the checkout session.
+     */
+    public function testForgedRequestWithInvalidSignatureDoesNotVerifyTheCustomer(): void
+    {
+        // Arrange: a push that carries data but fails signature validation
+        $pushRequestMock = $this->getMockBuilder(PushRequestInterfaceStub::class)->getMock();
+        $pushRequestMock->method('getData')->willReturn(['brq_primary_service' => 'IDIN']);
+        $pushRequestMock->method('getOriginalRequest')->willReturn([]);
+        $pushRequestMock->method('validate')->willReturn(false);
+
+        $requestPushFactoryMock = $this->createMock(RequestPushFactory::class);
+        $requestPushFactoryMock->method('create')->willReturn($pushRequestMock);
+
+        // The checkout session must never receive an iDIN verification write on this path.
+        $checkoutSessionMock = $this->getMockBuilder(CheckoutSession::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['__call'])
+            ->getMock();
+        $checkoutSessionMock->expects($this->never())->method('__call');
+
+        $instance = $this->getInstance([
+            'context' => $this->buildContextMock(),
+            'redirectFactory' => $this->buildRedirectFactoryMock(),
+            'requestPushFactory' => $requestPushFactoryMock,
+            'checkoutSession' => $checkoutSessionMock,
+        ]);
+
+        // Act
+        $result = $instance->execute();
+
+        // Assert
+        $this->assertInstanceOf(ResponseInterface::class, $result);
+    }
+
+    /**
+     * @return Context
+     */
+    private function buildContextMock(): Context
+    {
+        $response = $this->getFakeMock(ResponseInterface::class)->getMock();
+
+        $request = $this->getFakeMock(RequestInterface::class)->getMock();
+        $request->method('getParams')->willReturn([]);
+
+        $redirect = $this->getFakeMock(RedirectInterface::class)->getMock();
+        $redirect->method('redirect');
+
+        $messageManagerMock = $this->getFakeMock(ManagerInterface::class)->getMock();
+        $messageManagerMock->method('addErrorMessage');
+
+        $contextMock = $this->getFakeMock(Context::class)
+            ->onlyMethods(['getRequest', 'getRedirect', 'getResponse', 'getMessageManager'])
+            ->getMock();
+        $contextMock->method('getRequest')->willReturn($request);
+        $contextMock->method('getRedirect')->willReturn($redirect);
+        $contextMock->method('getResponse')->willReturn($response);
+        $contextMock->method('getMessageManager')->willReturn($messageManagerMock);
+
+        return $contextMock;
+    }
+
+    /**
+     * @return RedirectFactory
+     */
+    private function buildRedirectFactoryMock(): RedirectFactory
+    {
+        $redirectMock = $this->createMock(Redirect::class);
+        $redirectFactoryMock = $this->createMock(RedirectFactory::class);
+        $redirectFactoryMock->method('create')->willReturn($redirectMock);
+
+        return $redirectFactoryMock;
+    }
+}

--- a/Test/Unit/Plugin/MyParcelNLBuckarooPluginTest.php
+++ b/Test/Unit/Plugin/MyParcelNLBuckarooPluginTest.php
@@ -1,0 +1,124 @@
+<?php
+/**
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the MIT License
+ * It is available through the world-wide-web at this URL:
+ * https://tldrlegal.com/license/mit-license
+ * If you are unable to obtain it through the world-wide-web, please email
+ * to support@buckaroo.nl, so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade this module to newer
+ * versions in the future. If you wish to customize this module for your
+ * needs please contact support@buckaroo.nl for more information.
+ *
+ * @copyright Copyright (c) Buckaroo B.V.
+ * @license   https://tldrlegal.com/license/mit-license
+ */
+declare(strict_types=1);
+
+namespace Buckaroo\Magento2\Test\Unit\Plugin;
+
+use Buckaroo\Magento2\Logging\BuckarooLoggerInterface;
+use Buckaroo\Magento2\Plugin\MyParcelNLBuckarooPlugin;
+use Magento\Checkout\Model\Session;
+use Magento\Framework\App\Request\Http;
+use Magento\Framework\Serialize\Serializer\Json;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class MyParcelNLBuckarooPluginTest extends TestCase
+{
+    /**
+     * @var Http|MockObject
+     */
+    private $requestMock;
+
+    /**
+     * @var Session|MockObject
+     */
+    private $checkoutSessionMock;
+
+    /**
+     * @var MyParcelNLBuckarooPlugin
+     */
+    private MyParcelNLBuckarooPlugin $plugin;
+
+    protected function setUp(): void
+    {
+        $this->requestMock = $this->createMock(Http::class);
+        // setMyParcelNLBuckarooData() is a SessionManager magic setter, so it is exercised
+        // through __call; asserting on __call keeps the test valid across PHPUnit versions.
+        $this->checkoutSessionMock = $this->getMockBuilder(Session::class)
+            ->disableOriginalConstructor()
+            ->onlyMethods(['__call'])
+            ->getMock();
+
+        $json = new Json();
+
+        $this->plugin = new MyParcelNLBuckarooPlugin(
+            $this->checkoutSessionMock,
+            $this->requestMock,
+            $json,
+            $this->createMock(BuckarooLoggerInterface::class)
+        );
+    }
+
+    public function testStoresPickupLocationFromDeliveryOptions(): void
+    {
+        // Arrange
+        $body = json_encode([
+            'deliveryOptions' => [
+                ['deliveryType' => 'pickup', 'pickupLocation' => ['location_code' => 'NL-123']],
+            ],
+        ]);
+        $this->requestMock->method('getContent')->willReturn($body);
+
+        // Assert
+        $this->checkoutSessionMock->expects($this->once())
+            ->method('__call')
+            ->with('setMyParcelNLBuckarooData', [json_encode(['location_code' => 'NL-123'])]);
+
+        // Act
+        $this->plugin->beforeGetFromDeliveryOptions();
+    }
+
+    public function testIgnoresEmptyBody(): void
+    {
+        $this->requestMock->method('getContent')->willReturn('');
+        $this->checkoutSessionMock->expects($this->never())->method('__call');
+
+        $this->plugin->beforeGetFromDeliveryOptions();
+    }
+
+    public function testIgnoresMalformedJson(): void
+    {
+        $this->requestMock->method('getContent')->willReturn('not-json{');
+        $this->checkoutSessionMock->expects($this->never())->method('__call');
+
+        $this->plugin->beforeGetFromDeliveryOptions();
+    }
+
+    public function testIgnoresNonPickupDeliveryType(): void
+    {
+        $body = json_encode([
+            'deliveryOptions' => [
+                ['deliveryType' => 'delivery', 'pickupLocation' => ['x' => 1]],
+            ],
+        ]);
+        $this->requestMock->method('getContent')->willReturn($body);
+        $this->checkoutSessionMock->expects($this->never())->method('__call');
+
+        $this->plugin->beforeGetFromDeliveryOptions();
+    }
+
+    public function testIgnoresScalarJson(): void
+    {
+        $this->requestMock->method('getContent')->willReturn('"just-a-string"');
+        $this->checkoutSessionMock->expects($this->never())->method('__call');
+
+        $this->plugin->beforeGetFromDeliveryOptions();
+    }
+}

--- a/Test/Unit/Service/Giftcard/AttemptLimitTest.php
+++ b/Test/Unit/Service/Giftcard/AttemptLimitTest.php
@@ -1,0 +1,120 @@
+<?php
+/**
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the MIT License
+ * It is available through the world-wide-web at this URL:
+ * https://tldrlegal.com/license/mit-license
+ * If you are unable to obtain it through the world-wide-web, please email
+ * to support@buckaroo.nl, so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade this module to newer
+ * versions in the future. If you wish to customize this module for your
+ * needs please contact support@buckaroo.nl for more information.
+ *
+ * @copyright Copyright (c) Buckaroo B.V.
+ * @license   https://tldrlegal.com/license/mit-license
+ */
+declare(strict_types=1);
+
+namespace Buckaroo\Magento2\Test\Unit\Service\Giftcard;
+
+use Buckaroo\Magento2\Model\Giftcard\Api\ApiException;
+use Buckaroo\Magento2\Service\Giftcard\AttemptLimit;
+use Magento\Quote\Api\CartRepositoryInterface;
+use Magento\Quote\Model\Quote;
+use Magento\Quote\Model\Quote\Payment;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+
+class AttemptLimitTest extends TestCase
+{
+    /**
+     * @var CartRepositoryInterface|MockObject
+     */
+    private $cartRepositoryMock;
+
+    /**
+     * @var Payment|MockObject
+     */
+    private $paymentMock;
+
+    /**
+     * @var Quote|MockObject
+     */
+    private $quoteMock;
+
+    /**
+     * @var AttemptLimit
+     */
+    private AttemptLimit $service;
+
+    protected function setUp(): void
+    {
+        $this->cartRepositoryMock = $this->createMock(CartRepositoryInterface::class);
+        $this->paymentMock = $this->createMock(Payment::class);
+        $this->quoteMock = $this->createMock(Quote::class);
+        $this->quoteMock->method('getPayment')->willReturn($this->paymentMock);
+
+        $this->service = new AttemptLimit($this->cartRepositoryMock);
+    }
+
+    public function testAllowsRequestBelowTheLimit(): void
+    {
+        // Arrange
+        $this->paymentMock->method('getAdditionalInformation')
+            ->with('buckaroo_giftcard_failed_attempts')
+            ->willReturn(AttemptLimit::MAX_ATTEMPTS - 1);
+
+        // Act + Assert (no exception)
+        $this->service->assertWithinLimit($this->quoteMock);
+        $this->addToAssertionCount(1);
+    }
+
+    public function testRejectsRequestAtTheLimit(): void
+    {
+        // Arrange
+        $this->paymentMock->method('getAdditionalInformation')
+            ->with('buckaroo_giftcard_failed_attempts')
+            ->willReturn(AttemptLimit::MAX_ATTEMPTS);
+
+        // Assert
+        $this->expectException(ApiException::class);
+
+        // Act
+        $this->service->assertWithinLimit($this->quoteMock);
+    }
+
+    public function testRegisterFailedAttemptIncrementsCounterAndPersistsQuote(): void
+    {
+        // Arrange
+        $this->paymentMock->method('getAdditionalInformation')
+            ->with('buckaroo_giftcard_failed_attempts')
+            ->willReturn(4);
+
+        // Assert
+        $this->paymentMock->expects($this->once())
+            ->method('setAdditionalInformation')
+            ->with('buckaroo_giftcard_failed_attempts', 5);
+        $this->cartRepositoryMock->expects($this->once())
+            ->method('save')
+            ->with($this->quoteMock);
+
+        // Act
+        $this->service->registerFailedAttempt($this->quoteMock);
+    }
+
+    public function testTreatsMissingCounterAsZero(): void
+    {
+        // Arrange
+        $this->paymentMock->method('getAdditionalInformation')
+            ->with('buckaroo_giftcard_failed_attempts')
+            ->willReturn(null);
+
+        // Act + Assert (no exception on a fresh quote)
+        $this->service->assertWithinLimit($this->quoteMock);
+        $this->addToAssertionCount(1);
+    }
+}

--- a/etc/acl.xml
+++ b/etc/acl.xml
@@ -31,6 +31,7 @@
                     </resource>
                 </resource>
                 <resource id="Buckaroo_Magento2::paylink" title="PayLink" sortOrder="5" />
+                <resource id="Buckaroo_Magento2::buckaroo_giftcards" title="Buckaroo Giftcards" sortOrder="7" />
                 <resource id="Buckaroo_Magento2::extend_reservation" title="Extend Klarna Reservation" sortOrder="6" />
                 <resource id="Buckaroo_Magento2::Log" title="Log" sortOrder="10">
                     <resource id="Buckaroo_Magento2::Log_save" title="Save Log" sortOrder="10"/>

--- a/etc/adminhtml/menu.xml
+++ b/etc/adminhtml/menu.xml
@@ -26,7 +26,7 @@
              title="Buckaroo Giftcards"
              module="Buckaroo_Magento2"
              sortOrder="100"
-             resource="Magento_Backend::content"
+             resource="Buckaroo_Magento2::buckaroo_giftcards"
              parent="Magento_Backend::other_settings"
              action="buckaroo/giftcard"
         />

--- a/view/adminhtml/templates/credentials_checker.phtml
+++ b/view/adminhtml/templates/credentials_checker.phtml
@@ -22,7 +22,8 @@
 {
     "#buckaroo_magento2_credentials_checker_button": {
         "Buckaroo_Magento2/js/view/adminhtml/credentials-checker": {
-            "element": "#buckaroo_magento2_credentials_checker_button"
+            "element": "#buckaroo_magento2_credentials_checker_button",
+            "url": "<?= $escaper->escapeJs($block->getAjaxUrl()); ?>"
         }
     }
 }

--- a/view/adminhtml/web/js/view/adminhtml/credentials-checker.js
+++ b/view/adminhtml/web/js/view/adminhtml/credentials-checker.js
@@ -19,9 +19,8 @@
 
 define([
     'uiComponent',
-    'jquery',
-    'mage/url'
-], function (Component, $, urlBuilder) {
+    'jquery'
+], function (Component, $) {
     'use strict';
 
     return Component.extend({
@@ -36,6 +35,9 @@ define([
             if (config && config.element) {
                 this.element = $(config.element)[0];
             }
+
+            // Admin (ACL protected) endpoint, provided by the block
+            this.ajaxUrl = config && config.url ? config.url : null;
 
             this.bindEvents();
             return this;
@@ -84,11 +86,16 @@ define([
                 return;
             }
 
+            if (!this.ajaxUrl) {
+                self.showMessage('Unable to validate credentials: endpoint is not configured.', true);
+                return;
+            }
+
             // Show loading message
             self.showMessage('Checking credentials...', false);
 
             $.ajax({
-                url: urlBuilder.build('/buckaroo/credentialschecker/index'),
+                url: this.ajaxUrl,
                 type: 'POST',
                 dataType: 'json',
                 showLoader: true,

--- a/view/frontend/web/js/view/payment/method-renderer/clicktopay.js
+++ b/view/frontend/web/js/view/payment/method-renderer/clicktopay.js
@@ -207,6 +207,7 @@ define(
                     return $.ajax({
                         url: window.BASE_URL + 'buckaroo/clicktopay/token',
                         method: 'POST',
+                        headers: { 'X-Requested-From': 'MagentoFrontend' },
                         data: { form_key: window.FORM_KEY }
                     }).then(function (response) {
                         var expiresIn = parseInt(response.expires_in, 10) || 0;


### PR DESCRIPTION
Hardening and validation improvements across several controllers and admin actions.

- Tighter request validation and session/ownership checks on a few payment endpoints
- More consistent ACL handling on the giftcard admin actions
- Input-handling cleanups to use the framework request API

Unit tests added for each change. phpcs / phpmd / phpstan clean; di:compile passes.