### PR TITLE
BTI-1503-Magento-2-Bancontact-client-side-QR-code-not-rendering-blank-white-checkout-page

### DIFF
--- a/Block/Checkout/Mrcash/Pay.php
+++ b/Block/Checkout/Mrcash/Pay.php
@@ -49,7 +49,8 @@ class Pay extends Template
         if ($transactionKey === null) {
             $transactionKey = '';
         }
-        $transactionKey = preg_replace('/[^0-9]/', '', $transactionKey);
+
+        $transactionKey = preg_replace('/[^\w]/', '', $transactionKey);
         return $transactionKey;
     }
 }

--- a/Test/Unit/Block/Checkout/Mrcash/PayTest.php
+++ b/Test/Unit/Block/Checkout/Mrcash/PayTest.php
@@ -1,0 +1,57 @@
+<?php
+/**
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the MIT License
+ * It is available through the world-wide-web at this URL:
+ * https://tldrlegal.com/license/mit-license
+ * If you are unable to obtain it through the world-wide-web, please email
+ * to support@buckaroo.nl, so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade this module to newer
+ * versions in the future. If you wish to customize this module for your
+ * needs please contact support@buckaroo.nl for more information.
+ *
+ * @copyright Copyright (c) Buckaroo B.V.
+ * @license   https://tldrlegal.com/license/mit-license
+ */
+
+namespace Buckaroo\Magento2\Test\Unit\Block\Checkout\Mrcash;
+
+use Buckaroo\Magento2\Block\Checkout\Mrcash\Pay;
+use Buckaroo\Magento2\Test\BaseTest;
+
+class PayTest extends BaseTest
+{
+    protected $instanceClass = Pay::class;
+
+    /**
+     * The full alphanumeric (hex) Buckaroo transaction key must be preserved so the Bancontact
+     * QR SDK receives a valid key. Regression guard for the digit-only strip that corrupted it.
+     */
+    public function testPreservesFullAlphanumericTransactionKey(): void
+    {
+        $instance = $this->getInstance();
+        $this->setProperty('response', ['Key' => '2ECCAAB0B23D44B5BAA7DF8DE62F8AAB'], $instance);
+
+        $this->assertSame('2ECCAAB0B23D44B5BAA7DF8DE62F8AAB', $instance->getTransactionKey());
+    }
+
+    public function testStripsNonWordCharacters(): void
+    {
+        $instance = $this->getInstance();
+        $this->setProperty('response', ['Key' => 'ABC-123 xyz!@#'], $instance);
+
+        $this->assertSame('ABC123xyz', $instance->getTransactionKey());
+    }
+
+    public function testReturnsEmptyStringWhenKeyMissing(): void
+    {
+        $instance = $this->getInstance();
+        $this->setProperty('response', [], $instance);
+
+        $this->assertSame('', $instance->getTransactionKey());
+    }
+}

--- a/view/frontend/web/js/view/checkout/mrcash/pay.js
+++ b/view/frontend/web/js/view/checkout/mrcash/pay.js
@@ -54,6 +54,9 @@ define(
                         return true;
                     }
                 );
+
+                // The QR has been requested; remove the loading overlay so it no longer covers the code.
+                $('#buckaroo_magento2_mrcash_loader').hide();
             },
 
             cancelPayment: function () {


### PR DESCRIPTION
update transaction key handling to preserve alphanumeric characters and add unit tests