### PR TITLE
BTI-1516 Add extra validation for QuoteService::getQuote()

### DIFF
--- a/Controller/Applepay/GetShippingMethods.php
+++ b/Controller/Applepay/GetShippingMethods.php
@@ -80,8 +80,7 @@ class GetShippingMethods extends AbstractApplepay
             try {
                 // Get Cart
                 $this->logger->addDebug(__METHOD__ . '|1.1|');
-                $cartHash = $postValues['id'] ?? null;
-                $this->quoteService->getQuote($cartHash);
+                $this->quoteService->getQuote();
 
                 // Process shipping address from Apple Pay wallet data.
                 $shippingAddressRequest = $this->applePayFormatData->getShippingAddressObject($postValues['wallet']);

--- a/Controller/Googlepay/GetShippingMethods.php
+++ b/Controller/Googlepay/GetShippingMethods.php
@@ -136,14 +136,11 @@ class GetShippingMethods extends AbstractGooglepay
      */
     private function initializeQuote(array $postValues, array $addressData)
     {
-        $cartHash = $postValues['id'] ?? null;
-
-        if (!$cartHash && isset($postValues['product'])) {
+        if (isset($postValues['product'])) {
             $this->createQuoteWithProduct($postValues['product'], $addressData);
-            $this->quoteService->getQuote();
-        } else {
-            $this->quoteService->getQuote($cartHash);
         }
+
+        $this->quoteService->getQuote();
     }
 
     /**

--- a/Model/PaypalExpress/OrderCreate.php
+++ b/Model/PaypalExpress/OrderCreate.php
@@ -26,6 +26,7 @@ use Magento\Quote\Model\Quote\Address;
 use Magento\Sales\Api\Data\OrderInterface;
 use Magento\Quote\Api\CartManagementInterface;
 use Magento\Quote\Api\CartRepositoryInterface;
+use Magento\Quote\Api\ChangeQuoteControlInterface;
 use Magento\Quote\Model\MaskedQuoteIdToQuoteId;
 use Magento\Sales\Api\OrderRepositoryInterface;
 use Magento\Checkout\Model\Session as CheckoutSession;
@@ -48,6 +49,11 @@ class OrderCreate implements PaypalExpressOrderCreateInterface
      * @var \Magento\Quote\Model\MaskedQuoteIdToQuoteId
      */
     protected $maskedQuoteIdToQuoteId;
+
+    /**
+     * @var ChangeQuoteControlInterface
+     */
+    private $changeQuoteControl;
 
     /**
      * @var \Magento\Quote\Api\CartManagementInterface
@@ -95,6 +101,8 @@ class OrderCreate implements PaypalExpressOrderCreateInterface
      * @param OrderRepositoryInterface $orderRepository
      * @param OrderUpdateFactory $orderUpdateFactory
      * @param Log $logger
+     * @param ChangeQuoteControlInterface $changeQuoteControl
+     * @SuppressWarnings(PHPMD.ExcessiveParameterList)
      */
     public function __construct(
         OrderCreateResponseInterfaceFactory $responseFactory,
@@ -105,7 +113,8 @@ class OrderCreate implements PaypalExpressOrderCreateInterface
         CartRepositoryInterface $quoteRepository,
         OrderRepositoryInterface $orderRepository,
         OrderUpdateFactory $orderUpdateFactory,
-        Log $logger
+        Log $logger,
+        ChangeQuoteControlInterface $changeQuoteControl
     ) {
         $this->responseFactory = $responseFactory;
         $this->quoteManagement = $quoteManagement;
@@ -116,6 +125,7 @@ class OrderCreate implements PaypalExpressOrderCreateInterface
         $this->orderRepository = $orderRepository;
         $this->orderUpdateFactory = $orderUpdateFactory;
         $this->logger = $logger;
+        $this->changeQuoteControl = $changeQuoteControl;
     }
 
     /**
@@ -363,6 +373,13 @@ class OrderCreate implements PaypalExpressOrderCreateInterface
         $quote = $this->quoteRepository->get(
             $this->maskedQuoteIdToQuoteId->execute($cart_id)
         );
+
+        if (!$this->changeQuoteControl->isAllowed($quote)) {
+            throw new NoSuchEntityException(
+                __('No such entity with cartId = %1', $cart_id)
+            );
+        }
+
         return $quote;
     }
 }

--- a/Model/Service/QuoteService.php
+++ b/Model/Service/QuoteService.php
@@ -46,6 +46,8 @@ class QuoteService
      */
     protected $quoteBuilderInterfaceFactory;
     /**
+     * Retained for constructor backward-compatibility.
+     *
      * @var MaskedQuoteIdToQuoteIdInterface
      */
     private $maskedQuoteIdToQuoteId;
@@ -109,54 +111,41 @@ class QuoteService
     }
 
     /**
-     * Get checkout quote instance by cart Hash
+     * Get the checkout quote instance for the current session
      *
-     * @param int|string|null $cartHash
+     * The quote is resolved from the checkout session.
      *
      * @throws NoSuchEntityException
      *
      * @return CartInterface
      */
-    public function getQuote($cartHash = null)
+    public function getQuote()
     {
         if ($this->quote instanceof Quote) {
             return $this->quote;
         }
 
-        if ($cartHash) {
-            try {
-                $cartId = $this->maskedQuoteIdToQuoteId->execute($cartHash);
-                $this->quote = $this->cartRepository->get($cartId);
-            } catch (NoSuchEntityException $exception) {
-                throw new NoSuchEntityException(
-                    __('Could not find a cart with ID "%masked_cart_id"', ['masked_cart_id' => $cartHash])
-                );
-            }
-        } else {
-            try {
-                $this->quote = $this->checkoutSession->getQuote();
-            } catch (\Exception $exception) {
-                throw new NoSuchEntityException(
-                    __('Could not get checkout quote instance by current session')
-                );
-            }
+        try {
+            $this->quote = $this->checkoutSession->getQuote();
+        } catch (\Exception $exception) {
+            throw new NoSuchEntityException(
+                __('Could not get checkout quote instance by current session')
+            );
         }
 
         return $this->quote;
     }
 
     /**
-     * Get empty checkout quote instance by cart Hash
-     *
-     * @param int|string|null $cartHash
+     * Get the current session's checkout quote, emptied of its items
      *
      * @throws NoSuchEntityException
      *
      * @return CartInterface
      */
-    public function getEmptyQuote($cartHash)
+    public function getEmptyQuote()
     {
-        $this->quote = $this->getQuote($cartHash);
+        $this->quote = $this->getQuote();
         $this->quote->removeAllItems();
         return $this->quote;
     }

--- a/Service/Applepay/Add.php
+++ b/Service/Applepay/Add.php
@@ -102,8 +102,7 @@ class Add
             }
 
             // Get Cart (empty it first)
-            $cartHash = $request['id'] ?? null;
-            $this->quoteService->getEmptyQuote($cartHash);
+            $this->quoteService->getEmptyQuote();
 
             // Add product to cart
             $product = $this->applePayFormatData->getProductObject($request['product']);

--- a/Service/Googlepay/Add.php
+++ b/Service/Googlepay/Add.php
@@ -102,8 +102,7 @@ class Add
             }
 
             // Get Cart (empty it first)
-            $cartHash = $request['id'] ?? null;
-            $this->quoteService->getEmptyQuote($cartHash);
+            $this->quoteService->getEmptyQuote();
 
             // Add product to cart
             $product = $this->googlepayFormatData->getProductObject($request['product']);

--- a/Test/Unit/Controller/Adminhtml/CredentialsChecker/IndexTest.php
+++ b/Test/Unit/Controller/Adminhtml/CredentialsChecker/IndexTest.php
@@ -94,7 +94,7 @@ class IndexTest extends TestCase
         $this->clientMock->expects($this->never())->method('confirmCredential');
         $this->jsonResultMock->expects($this->once())
             ->method('setData')
-            ->with($this->callback(static fn ($data): bool => $data['success'] === false));
+            ->with($this->callback(static fn ($data) => $data['success'] === false));
 
         // Act
         $this->assertSame($this->jsonResultMock, $this->controller->execute());

--- a/Test/Unit/Model/PaypalExpress/OrderCreateTest.php
+++ b/Test/Unit/Model/PaypalExpress/OrderCreateTest.php
@@ -28,10 +28,12 @@ use Buckaroo\Magento2\Model\PaypalExpress\OrderUpdateFactory;
 use Buckaroo\Magento2\Model\PaypalExpress\PaypalExpressException;
 use Buckaroo\Magento2\Test\BaseTest;
 use Magento\Checkout\Model\Session as CheckoutSession;
+use Magento\Framework\Exception\NoSuchEntityException;
 use Magento\Customer\Api\Data\CustomerInterface;
 use Magento\Customer\Model\Session as CustomerSession;
 use Magento\Quote\Api\CartManagementInterface;
 use Magento\Quote\Api\CartRepositoryInterface;
+use Magento\Quote\Api\ChangeQuoteControlInterface;
 use Magento\Quote\Model\MaskedQuoteIdToQuoteId;
 use Magento\Quote\Model\Quote;
 use Magento\Quote\Model\Quote\Address as QuoteAddress;
@@ -73,9 +75,19 @@ class OrderCreateTest extends BaseTest
             'orderRepository'        => $this->getFakeMock(OrderRepositoryInterface::class)->getMock(),
             'orderUpdateFactory'     => $this->getFakeMock(OrderUpdateFactory::class)->getMock(),
             'logger'                 => $this->getFakeMock(Log::class)->getMock(),
+            'changeQuoteControl'     => $this->makeChangeQuoteControl(true),
         ];
 
         return $this->getObject(OrderCreate::class, array_merge($defaults, $overrides));
+    }
+
+    /** A ChangeQuoteControl that allows or denies every quote. */
+    private function makeChangeQuoteControl(bool $allowed): ChangeQuoteControlInterface
+    {
+        $mock = $this->getFakeMock(ChangeQuoteControlInterface::class)->getMock();
+        $mock->method('isAllowed')->willReturn($allowed);
+
+        return $mock;
     }
 
     /** Invoke a protected/private method via reflection. */
@@ -356,5 +368,48 @@ class OrderCreateTest extends BaseTest
         ]);
 
         $this->callMethod($instance, 'createOrder', ['paypal-order-id-123', 'masked-cart-id']);
+    }
+
+    // -------------------------------------------------------------------------
+    // getQuote() honours the ChangeQuoteControl decision for the resolved cart
+    // -------------------------------------------------------------------------
+
+    public function testGetQuoteReturnsQuoteWhenChangeQuoteControlAllows(): void
+    {
+        $quoteMock = $this->getFakeMock(Quote::class)->getMock();
+
+        $maskedMock = $this->getFakeMock(MaskedQuoteIdToQuoteId::class)->getMock();
+        $maskedMock->method('execute')->willReturn(42);
+
+        $repoMock = $this->getFakeMock(CartRepositoryInterface::class)->getMock();
+        $repoMock->method('get')->with(42)->willReturn($quoteMock);
+
+        $instance = $this->makeOrderCreate([
+            'maskedQuoteIdToQuoteId' => $maskedMock,
+            'quoteRepository'        => $repoMock,
+            'changeQuoteControl'     => $this->makeChangeQuoteControl(true),
+        ]);
+
+        $this->assertSame($quoteMock, $this->callMethod($instance, 'getQuote', ['masked-cart-id']));
+    }
+
+    public function testGetQuoteThrowsWhenChangeQuoteControlDenies(): void
+    {
+        $quoteMock = $this->getFakeMock(Quote::class)->getMock();
+
+        $maskedMock = $this->getFakeMock(MaskedQuoteIdToQuoteId::class)->getMock();
+        $maskedMock->method('execute')->willReturn(42);
+
+        $repoMock = $this->getFakeMock(CartRepositoryInterface::class)->getMock();
+        $repoMock->method('get')->with(42)->willReturn($quoteMock);
+
+        $instance = $this->makeOrderCreate([
+            'maskedQuoteIdToQuoteId' => $maskedMock,
+            'quoteRepository'        => $repoMock,
+            'changeQuoteControl'     => $this->makeChangeQuoteControl(false),
+        ]);
+
+        $this->expectException(NoSuchEntityException::class);
+        $this->callMethod($instance, 'getQuote', ['masked-cart-id']);
     }
 }


### PR DESCRIPTION
Resolve express checkout quotes from the checkout session instead of a request-supplied cart id, and validate cart access via ChangeQuoteControl on the PayPal Express order-create path.