### PR TITLE
BTI-1517 Restore quote on payment return without modifying the customer session

### DIFF
--- a/Controller/Redirect/Process.php
+++ b/Controller/Redirect/Process.php
@@ -116,6 +116,8 @@ class Process extends Action implements HttpPostActionInterface, HttpGetActionIn
     protected $customerSession;
 
     /**
+     * Retained for constructor backward-compatibility.
+     *
      * @var CustomerRepositoryInterface
      */
     protected $customerRepository;
@@ -1062,56 +1064,40 @@ class Process extends Action implements HttpPostActionInterface, HttpGetActionIn
     }
 
     /**
-     * Set customer if it is set on order and not on session and restore quote
+     * Restore the quote for the returning shopper
+     *
+     * Quote restoration runs against the current checkout session and does not modify the
+     * customer session.
      *
      * @param string $status
      */
     protected function setCustomerAndRestoreQuote(string $status): void
     {
-        // Handle customer login if needed (only for registered customers who aren't logged in)
-        if (!$this->customerSession->isLoggedIn() && $this->order->getCustomerId() > 0) {
+        // Subclasses (e.g. IdinProcess) can reach this without an order set.
+        if ($this->order === null || !$this->order->getIncrementId()) {
+            return;
+        }
+
+        if ($this->checkoutSession->getLastRealOrderId()) {
+            return;
+        }
+
+        $this->checkoutSession->setLastRealOrderId($this->order->getIncrementId());
+
+        // For success or when we want to restore failed quotes
+        if ($status == 'success' || !$this->getSkipHandleFailedRecreate()) {
+            $this->checkoutSession->restoreQuote();
             $this->logger->addDebug(sprintf(
-                '[REDIRECT - %s] | [Controller] | [%s:%s] - Redirect %s To Checkout - Customer is not logged in',
-                $this->payment->getMethod(),
+                '[REDIRECT - %s] | [Controller] | [%s:%s] - Redirect %s To Checkout - Restore Quote',
+                $this->payment?->getMethod(),
                 __METHOD__,
                 __LINE__,
                 $status
             ));
-            try {
-                $customer = $this->customerRepository->getById($this->order->getCustomerId());
-                $this->customerSession->setCustomerDataAsLoggedIn($customer);
-            } catch (Exception $e) {
-                $this->logger->addError(sprintf(
-                    '[REDIRECT - %s] | [Controller] | [%s:%s] - Redirect %s To Checkout ' .
-                    '- Could not load customer | [ERROR]: %s',
-                    $this->payment->getMethod(),
-                    __METHOD__,
-                    __LINE__,
-                    $status,
-                    $e->getMessage()
-                ));
-            }
         }
 
-        // Handle session setup and quote restoration for all scenarios
-        if (!$this->checkoutSession->getLastRealOrderId() && $this->order->getIncrementId()) {
-            $this->checkoutSession->setLastRealOrderId($this->order->getIncrementId());
-
-            // For success or when we want to restore failed quotes
-            if ($status == 'success' || !$this->getSkipHandleFailedRecreate()) {
-                $this->checkoutSession->restoreQuote();
-                $this->logger->addDebug(sprintf(
-                    '[REDIRECT - %s] | [Controller] | [%s:%s] - Redirect %s To Checkout - Restore Quote',
-                    $this->payment->getMethod(),
-                    __METHOD__,
-                    __LINE__,
-                    $status
-                ));
-            }
-
-            if ($status == 'failed') {
-                $this->setSkipHandleFailedRecreate();
-            }
+        if ($status == 'failed') {
+            $this->setSkipHandleFailedRecreate();
         }
     }
 

--- a/Test/Unit/Controller/Redirect/SetCustomerAndRestoreQuoteTest.php
+++ b/Test/Unit/Controller/Redirect/SetCustomerAndRestoreQuoteTest.php
@@ -1,0 +1,95 @@
+<?php
+
+/**
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the MIT License
+ * It is available through the world-wide-web at this URL:
+ * https://tldrlegal.com/license/mit-license
+ * If you are unable to obtain it through the world-wide-web, please send an email
+ * to support@buckaroo.nl so we can send you a copy immediately.
+ *
+ * DISCLAIMER
+ *
+ * Do not edit or add to this file if you wish to upgrade this module to newer
+ * versions in the future. If you wish to customize this module for your
+ * needs please contact support@buckaroo.nl for more information.
+ *
+ * @copyright Copyright (c) Buckaroo B.V.
+ * @license   https://tldrlegal.com/license/mit-license
+ */
+
+namespace Buckaroo\Magento2\Test\Unit\Controller\Redirect;
+
+use Buckaroo\Magento2\Controller\Redirect\Process;
+use Buckaroo\Magento2\Test\BaseTest;
+use Magento\Checkout\Model\Session as CheckoutSession;
+use Magento\Customer\Model\Session as CustomerSession;
+use Magento\Sales\Model\Order;
+
+/**
+ * Covers Process::setCustomerAndRestoreQuote(): the quote is restored against the checkout
+ * session and the customer session is left untouched.
+ */
+class SetCustomerAndRestoreQuoteTest extends BaseTest
+{
+    protected $instanceClass = Process::class;
+
+    /**
+     * The quote is restored while the customer session is left as-is.
+     */
+    public function testRestoresQuoteWithoutModifyingCustomerSession(): void
+    {
+        $order = $this->getFakeMock(Order::class)
+            ->onlyMethods(['getIncrementId', 'getCustomerId'])
+            ->getMock();
+        $order->method('getIncrementId')->willReturn('000000001');
+        $order->method('getCustomerId')->willReturn(1);
+
+        $customerSession = $this->getFakeMock(CustomerSession::class)
+            ->onlyMethods(['isLoggedIn', 'setCustomerDataAsLoggedIn'])
+            ->getMock();
+        $customerSession->method('isLoggedIn')->willReturn(false);
+        $customerSession->expects($this->never())->method('setCustomerDataAsLoggedIn');
+
+        $checkoutSession = $this->getFakeMock(CheckoutSession::class)
+            ->addMethods(['getLastRealOrderId', 'setLastRealOrderId'])
+            ->onlyMethods(['restoreQuote'])
+            ->getMock();
+        $checkoutSession->method('getLastRealOrderId')->willReturn(null);
+        $checkoutSession->expects($this->once())->method('setLastRealOrderId')->with('000000001');
+
+        $instance = $this->getInstance([
+            'customerSession' => $customerSession,
+            'checkoutSession' => $checkoutSession,
+        ]);
+        $this->setProperty('order', $order, $instance);
+
+        $this->invokeArgs('setCustomerAndRestoreQuote', ['failed'], $instance);
+    }
+
+    /**
+     * Subclasses (e.g. IdinProcess) can reach this without an order set; it is a no-op then.
+     */
+    public function testIsANoopWhenNoOrderIsSet(): void
+    {
+        $customerSession = $this->getFakeMock(CustomerSession::class)
+            ->onlyMethods(['setCustomerDataAsLoggedIn'])
+            ->getMock();
+        $customerSession->expects($this->never())->method('setCustomerDataAsLoggedIn');
+
+        $checkoutSession = $this->getFakeMock(CheckoutSession::class)
+            ->addMethods(['setLastRealOrderId'])
+            ->getMock();
+        $checkoutSession->expects($this->never())->method('setLastRealOrderId');
+
+        $instance = $this->getInstance([
+            'customerSession' => $customerSession,
+            'checkoutSession' => $checkoutSession,
+        ]);
+        $this->setProperty('order', null, $instance);
+
+        $this->invokeArgs('setCustomerAndRestoreQuote', ['success'], $instance);
+        $this->addToAssertionCount(1);
+    }
+}


### PR DESCRIPTION
The redirect return flow restores the checkout quote against the current session and no longer changes customer authentication state.