### PR TITLE
BTI-1522 Add extra validation for giftcard, POS and checkout entry points

### DIFF
--- a/Controller/Checkout/Giftcard.php
+++ b/Controller/Checkout/Giftcard.php
@@ -29,7 +29,6 @@ use Buckaroo\Transaction\Response\TransactionResponse;
 use Magento\Checkout\Model\Session;
 use Magento\Framework\App\Action\Action;
 use Magento\Framework\App\Action\Context;
-use Magento\Framework\App\Action\HttpGetActionInterface;
 use Magento\Framework\App\Action\HttpPostActionInterface;
 use Magento\Framework\Controller\Result\Json;
 use Magento\Framework\Controller\ResultFactory;
@@ -38,7 +37,7 @@ use Magento\Quote\Model\Quote;
 /**
  * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
-class Giftcard extends Action implements HttpPostActionInterface, HttpGetActionInterface
+class Giftcard extends Action implements HttpPostActionInterface
 {
     /**
      * @var BuckarooLoggerInterface

--- a/Controller/Pos/SetTerminal.php
+++ b/Controller/Pos/SetTerminal.php
@@ -109,7 +109,7 @@ class SetTerminal extends Action implements HttpGetActionInterface
             var_export($params, true)
         ));
 
-        if (!empty($params['id'])) {
+        if (!empty($params['id']) && $this->isValidTerminalId($params['id'])) {
             $metadata = $this->cookieMetadataFactory
                 ->createPublicCookieMetadata()
                 ->setPath('/')
@@ -124,5 +124,17 @@ class SetTerminal extends Action implements HttpGetActionInterface
         /** @var Redirect $resultRedirect */
         $resultRedirect = $this->resultFactory->create(ResultFactory::TYPE_REDIRECT);
         return $resultRedirect->setPath('');
+    }
+
+    /**
+     * Is the supplied value shaped like a POS terminal identifier
+     *
+     * @param mixed $terminalId
+     *
+     * @return bool
+     */
+    private function isValidTerminalId($terminalId): bool
+    {
+        return is_string($terminalId) && preg_match('/^[A-Za-z0-9_-]{1,64}$/', $terminalId) === 1;
     }
 }

--- a/Model/Giftcard/Api/GetTransactionsResponse.php
+++ b/Model/Giftcard/Api/GetTransactionsResponse.php
@@ -27,6 +27,7 @@ use Buckaroo\Magento2\Api\Data\Giftcard\TransactionResponseInterfaceFactory;
 use Buckaroo\Magento2\Helper\PaymentGroupTransaction;
 use Magento\Framework\DataObject;
 use Magento\Quote\Api\CartRepositoryInterface;
+use Magento\Quote\Api\ChangeQuoteControlInterface;
 use Magento\Quote\Model\Quote;
 use Magento\Quote\Model\QuoteIdMaskFactory;
 
@@ -53,6 +54,11 @@ class GetTransactionsResponse extends DataObject implements GetTransactionsRespo
     protected $trResponseFactory;
 
     /**
+     * @var ChangeQuoteControlInterface
+     */
+    private $changeQuoteControl;
+
+    /**
      * @var Quote
      */
     protected $quote;
@@ -62,6 +68,7 @@ class GetTransactionsResponse extends DataObject implements GetTransactionsRespo
      * @param CartRepositoryInterface             $cartRepository
      * @param PaymentGroupTransaction             $groupTransaction
      * @param TransactionResponseInterfaceFactory $trResponseFactory
+     * @param ChangeQuoteControlInterface         $changeQuoteControl
      * @param string|null                         $cartId
      *
      * @throws NoQuoteException
@@ -71,12 +78,14 @@ class GetTransactionsResponse extends DataObject implements GetTransactionsRespo
         CartRepositoryInterface $cartRepository,
         PaymentGroupTransaction $groupTransaction,
         TransactionResponseInterfaceFactory $trResponseFactory,
+        ChangeQuoteControlInterface $changeQuoteControl,
         ?string $cartId = null
     ) {
         $this->quoteIdMaskFactory = $quoteIdMaskFactory;
         $this->cartRepository = $cartRepository;
         $this->groupTransaction = $groupTransaction;
         $this->trResponseFactory = $trResponseFactory;
+        $this->changeQuoteControl = $changeQuoteControl;
         $this->quote = $this->getQuote($cartId);
     }
 
@@ -94,10 +103,16 @@ class GetTransactionsResponse extends DataObject implements GetTransactionsRespo
         try {
             $quoteIdMask = $this->quoteIdMaskFactory->create()->load($cartId, 'masked_id');
             /** @var Quote $quote */
-            return $this->cartRepository->getActive($quoteIdMask->getQuoteId());
+            $quote = $this->cartRepository->getActive($quoteIdMask->getQuoteId());
         } catch (\Throwable $th) {
-            throw new NoQuoteException(__("The cart isn't active."), 0, $th);
+            throw new NoQuoteException((string)__("The cart isn't active."), 0, $th);
         }
+
+        if (!$this->changeQuoteControl->isAllowed($quote)) {
+            throw new NoQuoteException((string)__("The cart isn't active."));
+        }
+
+        return $quote;
     }
 
     /**

--- a/Model/Giftcard/Api/Pay.php
+++ b/Model/Giftcard/Api/Pay.php
@@ -27,6 +27,7 @@ use Buckaroo\Magento2\Model\Giftcard\Request\GiftcardInterface as GiftcardReques
 use Buckaroo\Magento2\Model\Giftcard\Response\Giftcard as GiftcardResponse;
 use Buckaroo\Magento2\Service\Giftcard\AttemptLimit;
 use Magento\Quote\Api\CartRepositoryInterface;
+use Magento\Quote\Api\ChangeQuoteControlInterface;
 use Magento\Quote\Model\Quote;
 use Magento\Quote\Model\QuoteIdMaskFactory;
 
@@ -63,12 +64,18 @@ class Pay implements PayWithGiftcardInterface
     private $attemptLimit;
 
     /**
+     * @var ChangeQuoteControlInterface
+     */
+    private $changeQuoteControl;
+
+    /**
      * @param GiftcardRequest                $giftcardRequest
      * @param GiftcardResponse               $giftcardResponse
      * @param QuoteIdMaskFactory             $quoteIdMaskFactory
      * @param CartRepositoryInterface        $cartRepository
      * @param PayResponseSetInterfaceFactory $payResponseFactory
      * @param AttemptLimit                   $attemptLimit
+     * @param ChangeQuoteControlInterface    $changeQuoteControl
      */
     public function __construct(
         GiftcardRequest $giftcardRequest,
@@ -76,7 +83,8 @@ class Pay implements PayWithGiftcardInterface
         QuoteIdMaskFactory $quoteIdMaskFactory,
         CartRepositoryInterface $cartRepository,
         PayResponseSetInterfaceFactory $payResponseFactory,
-        AttemptLimit $attemptLimit
+        AttemptLimit $attemptLimit,
+        ChangeQuoteControlInterface $changeQuoteControl
     ) {
         $this->giftcardRequest = $giftcardRequest;
         $this->giftcardResponse = $giftcardResponse;
@@ -84,6 +92,7 @@ class Pay implements PayWithGiftcardInterface
         $this->cartRepository = $cartRepository;
         $this->payResponseFactory = $payResponseFactory;
         $this->attemptLimit = $attemptLimit;
+        $this->changeQuoteControl = $changeQuoteControl;
     }
 
     /**
@@ -135,10 +144,16 @@ class Pay implements PayWithGiftcardInterface
         try {
             $quoteIdMask = $this->quoteIdMaskFactory->create()->load($cartId, 'masked_id');
             /** @var Quote $quote */
-            return $this->cartRepository->getActive($quoteIdMask->getQuoteId());
+            $quote = $this->cartRepository->getActive($quoteIdMask->getQuoteId());
         } catch (\Throwable $th) {
-            throw new NoQuoteException(__("The cart isn't active."), 0, $th);
+            throw new NoQuoteException((string)__("The cart isn't active."), 0, $th);
         }
+
+        if (!$this->changeQuoteControl->isAllowed($quote)) {
+            throw new NoQuoteException((string)__("The cart isn't active."));
+        }
+
+        return $quote;
     }
 
     /**

--- a/Model/GuestPaymentInformationManagement.php
+++ b/Model/GuestPaymentInformationManagement.php
@@ -133,6 +133,8 @@ class GuestPaymentInformationManagement implements GuestPaymentInformationManage
 
         $this->checkSpecificCountry($paymentMethod, $billingAddress);
 
+        // Guest checkout: the masked cart id is the credential by Magento convention.
+        // nosemgrep: buckaroo-cart-mask-resolved-without-access-check
         $quoteIdMask = $this->quoteIdMaskFactory->create()->load($cartId, 'masked_id');
         /** @var Quote $quote */
         $quote = $this->cartRepository->getActive($quoteIdMask->getQuoteId());

--- a/Plugin/GuestSaveManager.php
+++ b/Plugin/GuestSaveManager.php
@@ -119,6 +119,8 @@ if (class_exists('\Onestepcheckout\Iosc\Plugin\GuestSaveManager')) {
             ?AddressInterface $billingAddress = null
         ) {
             if ($billingAddress == null) {
+                // Guest checkout: the masked cart id is the credential by Magento convention.
+                // nosemgrep: buckaroo-cart-mask-resolved-without-access-check
                 $quoteId = $this->maskedQuoteIdToQuoteId->execute($cartId);
                 $billingAddress = $this->cartRepository->getActive($quoteId)->getBillingAddress();
             }
@@ -152,6 +154,8 @@ if (class_exists('\Onestepcheckout\Iosc\Plugin\GuestSaveManager')) {
             ?AddressInterface $billingAddress = null
         ) {
             if ($billingAddress == null) {
+                // Guest checkout: the masked cart id is the credential by Magento convention.
+                // nosemgrep: buckaroo-cart-mask-resolved-without-access-check
                 $quoteId = $this->maskedQuoteIdToQuoteId->execute($cartId);
                 $billingAddress = $this->cartRepository->getActive($quoteId)->getBillingAddress();
             }


### PR DESCRIPTION
Validate that the caller is entitled to the cart before the giftcard API reads or mutates it, and tighten two smaller input/method issues found in the same pass.

- Model/Giftcard/Api/Pay and Model/Giftcard/Api/GetTransactionsResponse resolve the cart from a masked id, which the frontend area does not validate on its own. Both now check ChangeQuoteControlInterface::isAllowed() before using the quote.
- Controller/Pos/SetTerminal validates the shape of the terminal identifier before persisting it in a year-long public cookie that selects the terminal for a POS payment.
- Controller/Checkout/Giftcard no longer implements HttpGetActionInterface. The form key is enforced on POST only and the action is not read-only.
- Guest checkout resolves the masked id deliberately, per Magento's own convention. Annotated at the call sites so the intent is explicit.
- NoQuoteException extends \Exception and requires a string message under strict_types; the four call sites now cast the Phrase.