### PR TITLE
BTI-1523 Escape rendered values in admin log and giftcard grids

### DIFF
--- a/Block/Adminhtml/Grid/Renderer/Image.php
+++ b/Block/Adminhtml/Grid/Renderer/Image.php
@@ -68,7 +68,7 @@ class Image extends AbstractRenderer
             }
 
             $mediaDirectory = $store->getBaseUrl(UrlInterface::URL_TYPE_MEDIA);
-            return '<img src="' . $mediaDirectory . $img . '" width="50" >';
+            return '<img src="' . $this->escapeHtmlAttr($mediaDirectory . $img) . '" width="50" >';
         }
 
         return '';

--- a/Ui/Component/Listing/Columns/Nicelog.php
+++ b/Ui/Component/Listing/Columns/Nicelog.php
@@ -21,10 +21,36 @@ declare(strict_types=1);
 
 namespace Buckaroo\Magento2\Ui\Component\Listing\Columns;
 
+use Magento\Framework\Escaper;
+use Magento\Framework\View\Element\UiComponent\ContextInterface;
+use Magento\Framework\View\Element\UiComponentFactory;
 use Magento\Ui\Component\Listing\Columns\Column;
 
 class Nicelog extends Column
 {
+    /**
+     * @var Escaper
+     */
+    private $escaper;
+
+    /**
+     * @param ContextInterface    $context
+     * @param UiComponentFactory  $uiComponentFactory
+     * @param Escaper             $escaper
+     * @param array               $components
+     * @param array               $data
+     */
+    public function __construct(
+        ContextInterface $context,
+        UiComponentFactory $uiComponentFactory,
+        Escaper $escaper,
+        array $components = [],
+        array $data = []
+    ) {
+        parent::__construct($context, $uiComponentFactory, $components, $data);
+        $this->escaper = $escaper;
+    }
+
     /**
      * @inheritdoc
      */
@@ -35,9 +61,11 @@ class Nicelog extends Column
         if (empty($dataSource['data']['items'])) {
             return $dataSource;
         }
+        // The column is rendered with the raw-HTML cell template (ui/grid/cells/html) and the log
+        // message can contain request-derived content, so the message must be escaped here.
         foreach ($dataSource['data']['items'] as & $item) {
             if (isset($item['message'])) {
-                $item['message'] = "<pre>" . $item['message'] . "</pre>";
+                $item['message'] = "<pre>" . $this->escaper->escapeHtml($item['message']) . "</pre>";
             }
         }
         return $dataSource;

--- a/etc/adminhtml/menu.xml
+++ b/etc/adminhtml/menu.xml
@@ -34,7 +34,7 @@
              title="Buckaroo Log"
              module="Buckaroo_Magento2"
              sortOrder="9999"
-             resource="Magento_Backend::content"
+             resource="Buckaroo_Magento2::Log_view"
              parent="Magento_Backend::other_settings"
              action="buckaroo_magento2/log/index"
         />


### PR DESCRIPTION
The log listing renders its message column with the raw-HTML cell template (ui/grid/cells/html), and the message can contain request-derived content, so the value has to be escaped before it reaches that cell.

- Ui/Component/Listing/Columns/Nicelog escapes the message before wrapping it, keeping the existing <pre> formatting.
- Block/Adminhtml/Grid/Renderer/Image escapes the media path it writes into the img src attribute.
- etc/adminhtml/menu.xml declares the ACL resource the Log controller actually enforces (Buckaroo_Magento2::Log_view) instead of an unrelated one, so the menu entry matches who can open the page.