### PR TITLE
BTI-1524 Limit logged payload data and escape Klarna MoR DataRequest lookup

### DIFF
--- a/Plugin/MyParcelNLBuckarooPlugin.php
+++ b/Plugin/MyParcelNLBuckarooPlugin.php
@@ -86,10 +86,10 @@ class MyParcelNLBuckarooPlugin
         }
 
         $this->logger->addDebug(sprintf(
-            '[MyParcelNL] | [Plugin] | [%s:%s] - Set Pickup Location | deliveryOptions: %s',
+            '[MyParcelNL] | [Plugin] | [%s:%s] - Set Pickup Location | fields: %s',
             __METHOD__,
             __LINE__,
-            var_export($jsonDecoded, true)
+            var_export(array_keys($jsonDecoded), true)
         ));
 
         $deliveryOption = $jsonDecoded['deliveryOptions'][0];

--- a/Service/Push/KlarnaMorOrderService.php
+++ b/Service/Push/KlarnaMorOrderService.php
@@ -119,7 +119,7 @@ class KlarnaMorOrderService
                 'sop.parent_id = so.entity_id',
                 ['entity_id']
             )
-            ->where('sop.additional_information LIKE ?', '%' . $pushKey . '%')
+            ->where('sop.additional_information LIKE ?', '%' . str_replace(['\\', '%', '_'], ['\\\\', '\\%', '\\_'], $pushKey) . '%')
             ->limit(1);
 
         $orderId = $connection->fetchOne($select);


### PR DESCRIPTION
- Plugin/MyParcelNLBuckarooPlugin now logs the field names only, which keeps the diagnostic value without the personal data.

- Service/Push/KlarnaMorOrderService resolves a pending DataRequest push by matching the key with LIKE. The value is bound, but % and _ keep their wildcard meaning inside the pattern, so a key containing either could match a different order than the one the push belongs to. Both are now escaped, along with the escape character itself.