### PR TITLE
BTI-1526 Fix express wallet shipping address change failing after first call

### DIFF
--- a/Controller/Applepay/GetShippingMethods.php
+++ b/Controller/Applepay/GetShippingMethods.php
@@ -84,7 +84,7 @@ class GetShippingMethods extends AbstractApplepay
 
                 // Process shipping address from Apple Pay wallet data.
                 $shippingAddressRequest = $this->applePayFormatData->getShippingAddressObject($postValues['wallet']);
-                $this->quoteService->addAddressToQuote($shippingAddressRequest);
+                $this->quoteService->addAddressToQuote($shippingAddressRequest, true);
                 $this->logger->addDebug(__METHOD__ . '|1.1.3|');
                 //Set Payment Method
                 $this->quoteService->setPaymentMethod(Applepay::CODE);

--- a/Controller/Googlepay/GetShippingMethods.php
+++ b/Controller/Googlepay/GetShippingMethods.php
@@ -92,7 +92,7 @@ class GetShippingMethods extends AbstractGooglepay
             $this->initializeQuote($postValues, $addressData);
 
             $shippingAddressRequest = $this->googlepayFormatData->getShippingAddressObject($addressData);
-            $this->quoteService->addAddressToQuote($shippingAddressRequest);
+            $this->quoteService->addAddressToQuote($shippingAddressRequest, true);
             $this->quoteService->setPaymentMethod(Googlepay::CODE);
 
             $shippingMethodsResult = $this->getShippingMethodsForQuote();

--- a/Model/Service/QuoteAddressService.php
+++ b/Model/Service/QuoteAddressService.php
@@ -105,8 +105,9 @@ class QuoteAddressService
         $address->setCity($shippingAddress->getCity());
         $address->setRegion($shippingAddress->getState());
 
-        // Fill any missing fields on both shipping and billing addresses.
-        // Skip for Google Pay as it always provides complete address data.
+        // Fill any missing fields on both shipping and billing addresses. Express wallets
+        // (Apple Pay and Google Pay) only supply locality/postcode/country while the shopper is
+        // still choosing a shipping option, so callers in those flows pass true.
         if ($fillMissingFields) {
             $this->maybeFillAnyMissingAddressFields($shippingAddress, $cart);
         }
@@ -138,12 +139,41 @@ class QuoteAddressService
     protected function maybeFillShippingAddressFields(Quote $quote): void
     {
         $address = $quote->getShippingAddress();
-        if ($address->getId() === null) {
+
+        // Express wallets only supply locality/postcode/country, so the remaining required
+        // fields are filled with placeholders. Each field is filled only when it is empty, so
+        // this stays correct when the wallet sends a new address for an already saved quote
+        // address (the shopper changing address in the payment sheet).
+        $this->fillPlaceholderAddressFields($address);
+
+        $quote->setShippingAddress($address);
+    }
+
+    /**
+     * Fill the fields Magento requires for quote validation, without overwriting real data.
+     *
+     * @param \Magento\Quote\Model\Quote\Address $address
+     */
+    private function fillPlaceholderAddressFields($address): void
+    {
+        if (!$address->getFirstname()) {
             $address->setFirstname('unknown');
+        }
+
+        if (!$address->getLastname()) {
             $address->setLastname('unknown');
+        }
+
+        if (!$address->getEmail()) {
             $address->setEmail('no-reply@example.com');
+        }
+
+        if (!array_filter((array)$address->getStreet())) {
             $address->setStreet('unknown');
-            $quote->setShippingAddress($address);
+        }
+
+        if (!$address->getTelephone()) {
+            $address->setTelephone('0000000000');
         }
     }
 
@@ -236,17 +266,26 @@ class QuoteAddressService
         Quote $quote
     ): void {
         $address = $quote->getBillingAddress();
-        if ($address->getId() === null) {
-            $address->setFirstname('unknown');
-            $address->setLastname('unknown');
-            $address->setEmail('no-reply@example.com');
-            $address->setStreet('unknown');
+
+        $this->fillPlaceholderAddressFields($address);
+
+        if (!$address->getCountryId()) {
             $address->setCountryId($shippingAddress->getCountryCode());
-            $address->setPostcode($shippingAddress->getPostalCode());
-            $address->setCity($shippingAddress->getCity());
-            $address->setRegion($shippingAddress->getState());
-            $quote->setBillingAddress($address);
         }
+
+        if (!$address->getPostcode()) {
+            $address->setPostcode($shippingAddress->getPostalCode());
+        }
+
+        if (!$address->getCity()) {
+            $address->setCity($shippingAddress->getCity());
+        }
+
+        if (!$address->getRegion()) {
+            $address->setRegion($shippingAddress->getState());
+        }
+
+        $quote->setBillingAddress($address);
     }
 
     /**

--- a/Service/Applepay/Add.php
+++ b/Service/Applepay/Add.php
@@ -122,8 +122,10 @@ class Add
                 // Get Shipping Address From Request using wallet data
                 $shippingAddressRequest = $this->applePayFormatData->getShippingAddressObject($request['wallet']);
 
-                // Add Shipping Address on Quote (only once)
-                $this->quoteService->addAddressToQuote($shippingAddressRequest);
+                // Add the shipping address to the quote. The Apple Pay sheet only supplies
+                // locality/postcode/country while the shopper is still choosing, so the remaining
+                // fields Magento requires have to be filled in.
+                $this->quoteService->addAddressToQuote($shippingAddressRequest, true);
 
                 // Get Shipping Methods from the updated quote
                 $shippingMethods = $this->quoteService->getAvailableShippingMethods();

--- a/Service/Googlepay/Add.php
+++ b/Service/Googlepay/Add.php
@@ -122,8 +122,10 @@ class Add
                 // Get Shipping Address From Request using wallet data
                 $shippingAddressRequest = $this->googlepayFormatData->getShippingAddressObject($request['wallet']);
 
-                // Add Shipping Address on Quote (only once)
-                $this->quoteService->addAddressToQuote($shippingAddressRequest);
+                // Add the shipping address to the quote. The wallet only supplies
+                // locality/postcode/country while the shopper is still
+                // choosing, so the remaining fields Magento requires have to be filled in.
+                $this->quoteService->addAddressToQuote($shippingAddressRequest, true);
 
                 // Get Shipping Methods from the updated quote
                 $shippingMethods = $this->quoteService->getAvailableShippingMethods();


### PR DESCRIPTION
Changing the shipping address in the Apple Pay or Google Pay sheet failed after the first call, so the sheet could not refresh its shipping methods and the payment was abandoned. The first call succeeded; every later one failed with "The shipping address contains invalid data: First Name is a required value, Last Name ..., Street Address ..., Phone Number ...".

Both sheets supply only locality, postcode and country while the shopper is still choosing a shipping option - the name and street are withheld until the payment is authorised - so the remaining fields Magento requires have to be filled in. Three defects prevented that, and all three had to be fixed:

- QuoteAddressService::addAddressToQuote() takes $fillMissingFields, but no caller ever passed true, so the filler was unreachable. Both Apple Pay and both Google Pay entry points now pass it.
- The fillers were gated on $address->getId() === null, so they ran only for a brand new address. Each required field is now filled only when it is empty, which keeps real wallet data intact and works on repeat calls.
- telephone was never filled, although the validator requires it.

The comment claiming Google Pay always provides complete address data was wrong; it fails identically, and has been corrected.

Verified with real orders on both wallets. The placed order carries the real wallet address, not the placeholders, confirming they cover only the intermediate selection phase and are replaced at authorisation.